### PR TITLE
Fix differentiation between highlighting and selecting, fix camera bug when double click in selection mode

### DIFF
--- a/app/src/app/page.tsx
+++ b/app/src/app/page.tsx
@@ -107,6 +107,11 @@ export default function ProtSpaceApp() {
 
   // Handle protein selection
   const handleProteinClick = (proteinId: string, event?: React.MouseEvent) => {
+    // When in non-selection mode, add the clicked protein to highlightedProteinIds immediately
+    if (!selectionMode) {
+      setHighlightedProteinIds([proteinId]);
+    }
+
     // Standard selection behavior regardless of split state
     setSelectedProteinIds((prevIds) => {
       // If the protein is already selected, deselect it
@@ -127,6 +132,8 @@ export default function ProtSpaceApp() {
         // Only show structure for the selected protein when not in selection mode
         if (!selectionMode) {
           setViewStructureId(proteinId);
+          // For single-click in non-selection mode, add to highlighted (red border)
+          setHighlightedProteinIds([proteinId]);
         }
         return [proteinId];
       }
@@ -135,6 +142,10 @@ export default function ProtSpaceApp() {
       // Only show structure for the newly clicked protein when not in selection mode
       if (!selectionMode) {
         setViewStructureId(proteinId);
+        // Add to highlighted list for the red border
+        setHighlightedProteinIds((prev) =>
+          prev.includes(proteinId) ? prev : [...prev, proteinId]
+        );
       }
       return [...prevIds, proteinId];
     });

--- a/app/src/components/Header/Header.tsx
+++ b/app/src/components/Header/Header.tsx
@@ -16,8 +16,6 @@ interface HeaderProps {
 
 export default function Header({
   onSearch,
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  highlightedProteins,
   selectedProteins = [],
   onRemoveHighlight,
   onSaveSession,

--- a/app/src/components/Header/Header.tsx
+++ b/app/src/components/Header/Header.tsx
@@ -5,6 +5,7 @@ import Logo from "@/components/Logo/Logo";
 
 interface HeaderProps {
   onSearch: (query: string) => void;
+  // highlightedProteins is kept for backwards compatibility
   highlightedProteins: string[];
   selectedProteins: string[];
   onRemoveHighlight: (proteinId: string) => void;
@@ -15,6 +16,7 @@ interface HeaderProps {
 
 export default function Header({
   onSearch,
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   highlightedProteins,
   selectedProteins = [],
   onRemoveHighlight,
@@ -224,19 +226,14 @@ export default function Header({
         <div className="relative">
           <button
             onClick={() => setShowHighlighted(!showHighlighted)}
-            disabled={
-              highlightedProteins.length === 0 && selectedProteins.length === 0
-            }
+            disabled={selectedProteins.length === 0}
             className={`px-3 py-1.5 border border-gray-700 rounded-lg flex items-center space-x-1 bg-[#0a2a4d] text-white ${
-              highlightedProteins.length === 0 && selectedProteins.length === 0
+              selectedProteins.length === 0
                 ? "opacity-50 cursor-not-allowed"
                 : "hover:bg-[#0d3159] transition-colors duration-200"
             }`}
           >
-            <span>
-              Selected (
-              {new Set([...highlightedProteins, ...selectedProteins]).size})
-            </span>
+            <span>Selected ({selectedProteins.length})</span>
             <svg
               xmlns="http://www.w3.org/2000/svg"
               className="h-4 w-4"
@@ -253,10 +250,10 @@ export default function Header({
             </svg>
           </button>
 
-          {showHighlighted && highlightedProteins.length > 0 && (
+          {showHighlighted && selectedProteins.length > 0 && (
             <div className="absolute z-10 right-0 mt-2 w-48 bg-[#0a2a4d] rounded-lg shadow-lg border border-gray-700">
               <ul className="py-1 max-h-48 overflow-y-auto">
-                {Array.from(new Set(highlightedProteins)).map((protein) => (
+                {Array.from(new Set(selectedProteins)).map((protein) => (
                   <li
                     key={protein}
                     className="px-4 py-2 cursor-pointer flex items-center justify-between text-gray-300 hover:bg-gray-700"

--- a/app/src/components/InteractiveLegend/InteractiveLegend.tsx
+++ b/app/src/components/InteractiveLegend/InteractiveLegend.tsx
@@ -801,7 +801,7 @@ const InteractiveLegend = forwardRef<
               draggedItem === item.value ? "bg-blue-50 dark:bg-blue-900/30" : ""
             }
 
-            ${isItemSelected ? "ring-2 ring-blue-500 dark:ring-blue-400" : ""}
+            ${isItemSelected ? "ring-2 ring-red-500 dark:ring-red-400" : ""}
             ${
               item.extractedFromOther
                 ? "border-l-4 border-green-500 dark:border-green-400"


### PR DESCRIPTION

# Description

This PR improves the differentiation between highlighting and selecting behaviors on the canvas:

- Highlighting is triggered by search or a single press and is visually indicated with a red border and no transparency.

- Selecting is triggered by pressing the select button and applies low transparency to unselected members, making selected elements stand out.

Additionally, this PR fixes a bug where double-clicking on the canvas would cause the mouse to become stuck, ensuring smoother interaction.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. 

- [ ] Test A
- [ ] Test B

**Test Configuration**: (Browser, etc.)

## Checklist

- [ ] I linted my code with ESLint and formatted it with Prettier
- [ ] I used an AI tool for a self-review
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I created a/multiple changeset(s) describing my changes succinctly
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
