### PR TITLE
docs: Update the current issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -12,58 +12,10 @@ body:
     id: description
     attributes:
       label: Bug Description
-      description: A clear and concise description of what the bug is
+      description: A clear and concise description of what the bug is, how it can be reproduced, and what the expected behavior is.
       placeholder: When I try to...
     validations:
       required: true
-
-  - type: textarea
-    id: reproduction
-    attributes:
-      label: Steps to Reproduce
-      description: Steps to reproduce the behavior
-      placeholder: |
-        1. Go to '...' 2. Click on '....' 3. Scroll down to '....' 4. See error
-    validations:
-      required: true
-
-  - type: textarea
-    id: logs
-    attributes:
-      label: Relevant log output
-      description: Please copy and paste any relevant log output. This will be automatically formatted into code, so no need for backticks.
-      render: shell
-
-  - type: textarea
-    id: expected
-    attributes:
-      label: Expected Behavior
-      description: What did you expect to happen?
-      placeholder: I expected...
-    validations:
-      required: true
-
-  - type: textarea
-    id: system
-    attributes:
-      label: System Information
-      description: Please provide information about your system
-      placeholder: |
-        - OS: [e.g., Windows 10, macOS 12.0] - Browser: [e.g., Chrome 96, Firefox 95] - Device: [e.g., Desktop, iPhone 13]
-    validations:
-      required: true
-
-  - type: textarea
-    id: additional
-    attributes:
-      label: Additional Context
-      description: |
-        Add any other context or screenshots about the feature request here
-
-        Tip: You can attach images or log files by clicking this area to highlight it and then dragging files in.
-      placeholder: Any other relevant information...
-    validations:
-      required: false
 
   - type: checkboxes
     id: terms

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,7 +1,7 @@
 blank_issues_enabled: false
 contact_links:
   - name: 📖 Documentation
-    url: ../blob/main/README.md
+    url: https://protspace.app/docs/
     about: Please check our documentation before creating an issue
   - name: 💬 Discussion
     url: ../discussions

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -10,43 +10,13 @@ body:
         Thanks for taking the time to suggest a new feature!
 
   - type: textarea
-    id: problem
+    id: feature_request
     attributes:
-      label: Is your feature request related to a problem?
-      description: A clear and concise description of what the problem is
-      placeholder: I'm always frustrated when...
+      label: Feature Request
+      description: A clear and concise description of the feature you want to see, what it would allow you to do, and why it would be useful.
+      placeholder: I would like to see a feature that allows me to...
     validations:
       required: true
-
-  - type: textarea
-    id: solution
-    attributes:
-      label: Describe the solution you'd like
-      description: A clear and concise description of what you want to happen
-      placeholder: I would like...
-    validations:
-      required: true
-
-  - type: textarea
-    id: alternatives
-    attributes:
-      label: Describe alternatives you've considered
-      description: A clear and concise description of any alternative solutions or features you've considered
-      placeholder: I've thought about...
-    validations:
-      required: false
-
-  - type: textarea
-    id: additional
-    attributes:
-      label: Additional Context
-      description: |
-        Add any other context or screenshots about the feature request here
-
-        Tip: You can attach images or log files by clicking this area to highlight it and then dragging files in.
-      placeholder: Any other relevant information...
-    validations:
-      required: false
 
   - type: checkboxes
     id: terms

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,36 +1,3 @@
-# Description
+## TLDR
 
-Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change.
-
-Fixes # (issue)
-
-## Type of change
-
-Please delete options that are not relevant.
-
-- [ ] Bug fix (non-breaking change which fixes an issue)
-- [ ] New feature (non-breaking change which adds functionality)
-- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-- [ ] This change requires a documentation update
-- [ ] New core component
-
-## How Has This Been Tested?
-
-Please describe the tests that you ran to verify your changes.
-
-- [ ] Test A
-- [ ] Test B
-
-**Test Configuration**: (Browser, etc.)
-
-## Checklist
-
-- [ ] I linted my code with ESLint and formatted it with Prettier
-- [ ] I used an AI tool for a self-review
-- [ ] I have commented my code, particularly in hard-to-understand areas
-- [ ] I have made corresponding changes to the documentation
-- [ ] I created a/multiple changeset(s) describing my changes succinctly
-- [ ] My changes generate no new warnings
-- [ ] I updated core, so I added/extended a basic example
-- [ ] I updated core, so I added/extended a story showcasing my changes
-- [ ] I updated core and ensured the next.js page works on Safari and Chrome
+## Description


### PR DESCRIPTION

## TLDR
More minimal issue and PR template. 

## Description
Updated links in
Remove all fields from feature and bug; only one field remaining + CoC. 

PR only has TLDR and Description. 
Should be enough for the moment. 

Fixes #114

