### PR TITLE
fix(app): always reset legend state on dataset load

### DIFF
--- a/app/src/demo/main.ts
+++ b/app/src/demo/main.ts
@@ -14,7 +14,6 @@ import {
   exportParquetBundle,
   generateBundleFilename,
   generateDatasetHash,
-  hasStorageItemsForHash,
 } from '@protspace/utils';
 import { maybeRunWebglPerfSuite } from './webgl-perf-suite';
 import { startProductTour } from '../tour/product-tour';
@@ -46,8 +45,6 @@ export async function initializeDemo() {
     // Track state
     let hiddenValues: string[] = [];
     let selectedProteins: string[] = [];
-    let selectionMode = false;
-    let isolationMode = false;
 
     // Performance monitoring
     const performanceMetrics = {
@@ -150,8 +147,6 @@ export async function initializeDemo() {
         // Reset all state
         hiddenValues = [];
         selectedProteins = [];
-        selectionMode = false;
-        isolationMode = false;
 
         // Update progress
         if (isLargeDataset) {
@@ -512,11 +507,6 @@ export async function initializeDemo() {
       updateLegend();
     });
 
-    // Handle selection mode toggle for local state
-    controlBar.addEventListener('toggle-selection-mode', () => {
-      selectionMode = plotElement.selectionMode; // Sync with scatterplot state
-    });
-
     // Handle data-change from scatterplot to sync selections
     plotElement.addEventListener('data-change', () => {
       // When data changes (e.g. after a split), the selection is often cleared.
@@ -561,25 +551,21 @@ export async function initializeDemo() {
     // Handle successful data loading
     dataLoader.addEventListener('data-loaded', async (event: Event) => {
       const customEvent = event as CustomEvent<DataLoadedEventDetail>;
-      const { data, settings, source } = customEvent.detail;
+      const { data, settings } = customEvent.detail;
 
       // Compute dataset hash upfront for clearing and settings
       const datasetHash = generateDatasetHash(data.protein_ids);
 
-      // On auto-load (page reload), skip clearing/overwriting if localStorage already has settings.
-      // On first-ever auto-load (no localStorage entries), treat as fresh load so file settings apply.
-      const isReload = source === 'auto' && hasStorageItemsForHash(datasetHash);
-
-      // Clear all component state before loading new data (skip on reload to preserve settings)
-      if (!isReload && legendElement) {
+      // Clear all component state before loading new data
+      if (legendElement) {
         legendElement.clearForNewDataset(datasetHash);
       }
 
       // Load the new data into all components
       await loadNewData(data);
 
-      // Apply file-based settings to legend if present (skip on reload to preserve user changes)
-      if (!isReload && settings && legendElement) {
+      // Apply file-based settings to legend if present
+      if (settings && legendElement) {
         legendElement.setFileSettings(settings, datasetHash);
       }
 

--- a/app/tests/dataset-reload.spec.ts
+++ b/app/tests/dataset-reload.spec.ts
@@ -1,0 +1,143 @@
+import { test, expect, type Page } from '@playwright/test';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Wait for the scatterplot data to be loaded. */
+async function waitForDataLoad(page: Page, timeout = 30_000): Promise<void> {
+  await page.waitForSelector('#myPlot', { timeout });
+
+  await page.waitForFunction(
+    () => {
+      const plot = document.querySelector('#myPlot') as any;
+      return plot?.data?.protein_ids?.length > 0;
+    },
+    { timeout, polling: 1000 },
+  );
+
+  // Let rendering settle
+  await page.waitForTimeout(500);
+}
+
+/** Dismiss the product tour if it appears. */
+async function dismissTourIfPresent(page: Page): Promise<void> {
+  const skipBtn = page.locator('.driver-tour-skip-btn');
+  if ((await skipBtn.count()) > 0) {
+    await skipBtn.click();
+    await page.waitForSelector('.driver-popover', { state: 'detached', timeout: 5_000 });
+  }
+}
+
+/** Get the first non-Other legend item's data-value from shadow DOM. */
+async function getFirstLegendItemValue(page: Page): Promise<string> {
+  const value = await page.evaluate(() => {
+    const legend = document.querySelector('protspace-legend') as any;
+    if (!legend?.shadowRoot) return null;
+    const item = legend.shadowRoot.querySelector(
+      '.legend-item:not([data-value="Other"]):not([data-value="__NA__"])',
+    );
+    return item?.getAttribute('data-value') ?? null;
+  });
+  if (!value) throw new Error('No legend item found');
+  return value;
+}
+
+/** Check if a legend item is hidden (has the 'hidden' CSS class). */
+async function isLegendItemHidden(page: Page, value: string): Promise<boolean> {
+  return page.evaluate((v) => {
+    const legend = document.querySelector('protspace-legend') as any;
+    if (!legend?.shadowRoot) return false;
+    const item = legend.shadowRoot.querySelector(`[data-value="${v}"]`);
+    return item?.classList.contains('hidden') ?? false;
+  }, value);
+}
+
+/** Click a legend item by its data-value. */
+async function clickLegendItem(page: Page, value: string): Promise<void> {
+  await page.evaluate((v) => {
+    const legend = document.querySelector('protspace-legend') as any;
+    const item = legend?.shadowRoot?.querySelector(`[data-value="${v}"]`) as HTMLElement;
+    item?.click();
+  }, value);
+  // Wait for state update and re-render
+  await page.waitForTimeout(300);
+}
+
+/** Find a protspace legend localStorage key. */
+async function findLegendStorageKey(page: Page): Promise<string | null> {
+  return page.evaluate(() => {
+    for (let i = 0; i < localStorage.length; i++) {
+      const key = localStorage.key(i);
+      if (key?.startsWith('protspace:legend:')) return key;
+    }
+    return null;
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+test.describe('Dataset reload resets state (#178)', () => {
+  test.beforeEach(async ({ page }) => {
+    // Suppress the product tour so it doesn't interfere
+    await page.goto('/explore');
+    await page.evaluate(() => localStorage.setItem('driver.overviewTour', 'true'));
+    await page.goto('/explore');
+    await waitForDataLoad(page);
+    await dismissTourIfPresent(page);
+  });
+
+  test('page reload restores default legend state', async ({ page }) => {
+    const itemValue = await getFirstLegendItemValue(page);
+
+    // Item should start visible
+    expect(await isLegendItemHidden(page, itemValue)).toBe(false);
+
+    // Click to hide the item
+    await clickLegendItem(page, itemValue);
+    expect(await isLegendItemHidden(page, itemValue)).toBe(true);
+
+    // Verify localStorage was written
+    const storageKey = await findLegendStorageKey(page);
+    expect(storageKey).not.toBeNull();
+
+    // Reload the page
+    await page.reload();
+    await waitForDataLoad(page);
+    await dismissTourIfPresent(page);
+
+    // After reload, the item should be visible again (default state restored)
+    expect(await isLegendItemHidden(page, itemValue)).toBe(false);
+  });
+
+  test('legend localStorage is cleared on reload', async ({ page }) => {
+    const itemValue = await getFirstLegendItemValue(page);
+
+    // Modify legend state
+    await clickLegendItem(page, itemValue);
+
+    // Verify localStorage has legend entries
+    const storageKey = await findLegendStorageKey(page);
+    expect(storageKey).not.toBeNull();
+
+    const savedSettings = await page.evaluate((key) => {
+      return JSON.parse(localStorage.getItem(key!) || '{}');
+    }, storageKey);
+    expect(savedSettings.hiddenValues).toContain(itemValue);
+
+    // Reload the page
+    await page.reload();
+    await waitForDataLoad(page);
+
+    // After reload + file settings applied, hiddenValues should not contain our item
+    const reloadedKey = await findLegendStorageKey(page);
+    if (reloadedKey) {
+      const reloadedSettings = await page.evaluate((key) => {
+        return JSON.parse(localStorage.getItem(key!) || '{}');
+      }, reloadedKey);
+      expect(reloadedSettings.hiddenValues ?? []).not.toContain(itemValue);
+    }
+  });
+});

--- a/app/tests/playwright.config.ts
+++ b/app/tests/playwright.config.ts
@@ -36,6 +36,14 @@ export default defineConfig({
       },
       testMatch: /product-tour\.spec\.ts/,
     },
+    {
+      name: 'dataset-reload',
+      use: {
+        ...devices['Desktop Chrome'],
+        viewport: { width: 1280, height: 720 },
+      },
+      testMatch: /dataset-reload\.spec\.ts/,
+    },
   ],
 
   outputDir: '../test-results/',

--- a/packages/utils/src/storage/index.ts
+++ b/packages/utils/src/storage/index.ts
@@ -5,5 +5,4 @@ export {
   setStorageItem,
   removeStorageItem,
   removeAllStorageItemsByHash,
-  hasStorageItemsForHash,
 } from './storage-service';

--- a/packages/utils/src/storage/storage-service.test.ts
+++ b/packages/utils/src/storage/storage-service.test.ts
@@ -5,7 +5,6 @@ import {
   setStorageItem,
   removeStorageItem,
   removeAllStorageItemsByHash,
-  hasStorageItemsForHash,
 } from './storage-service';
 
 const localStorageMock = (() => {
@@ -314,59 +313,6 @@ describe('removeAllStorageItemsByHash', () => {
 
     const removedCount = removeAllStorageItemsByHash('anyHash');
     expect(removedCount).toBe(0);
-
-    localStorageMock.key = originalKey;
-  });
-});
-
-describe('hasStorageItemsForHash', () => {
-  beforeEach(() => {
-    localStorageMock.clear();
-    vi.clearAllMocks();
-  });
-
-  it('should return true when items exist for the hash', () => {
-    localStorageMock.setItem('protspace:legend:hash123:Taxonomy', '{"data": 1}');
-
-    expect(hasStorageItemsForHash('hash123')).toBe(true);
-  });
-
-  it('should return false when no items exist for the hash', () => {
-    localStorageMock.setItem('protspace:legend:otherHash:Taxonomy', '{"data": 1}');
-
-    expect(hasStorageItemsForHash('hash123')).toBe(false);
-  });
-
-  it('should return false when localStorage is empty', () => {
-    expect(hasStorageItemsForHash('anyHash')).toBe(false);
-  });
-
-  it('should return true on first match without scanning all keys', () => {
-    localStorageMock.setItem('protspace:legend:hash123:Taxonomy', '{"data": 1}');
-    localStorageMock.setItem('protspace:legend:hash123:Function', '{"data": 2}');
-
-    expect(hasStorageItemsForHash('hash123')).toBe(true);
-  });
-
-  it('should not match hash in context position', () => {
-    localStorageMock.setItem('protspace:legend:otherHash:hash123', '{"data": 1}');
-
-    expect(hasStorageItemsForHash('hash123')).toBe(false);
-  });
-
-  it('should ignore non-protspace keys', () => {
-    localStorageMock.setItem('other:legend:hash123:Taxonomy', '{"data": 1}');
-
-    expect(hasStorageItemsForHash('hash123')).toBe(false);
-  });
-
-  it('should return false when localStorage throws', () => {
-    const originalKey = localStorageMock.key;
-    localStorageMock.key = vi.fn(() => {
-      throw new Error('Storage error');
-    });
-
-    expect(hasStorageItemsForHash('anyHash')).toBe(false);
 
     localStorageMock.key = originalKey;
   });

--- a/packages/utils/src/storage/storage-service.ts
+++ b/packages/utils/src/storage/storage-service.ts
@@ -68,18 +68,6 @@ function findStorageKeysByHash(datasetHash: string): string[] {
 }
 
 /**
- * Check if localStorage has any entries for a specific dataset hash.
- * Used to distinguish first-ever loads from reloads where settings already exist.
- */
-export function hasStorageItemsForHash(datasetHash: string): boolean {
-  try {
-    return findStorageKeysByHash(datasetHash).length > 0;
-  } catch {
-    return false;
-  }
-}
-
-/**
  * Remove all localStorage entries for a specific dataset hash.
  * This is used when importing a parquetbundle with settings to ensure
  * the imported settings are the only source of truth.


### PR DESCRIPTION
- [x] fix #178
- Remove `isReload` guard so `clearForNewDataset()` and `setFileSettings()` always run on dataset load
- Remove dead code: `hasStorageItemsForHash`, `selectionMode`/`isolationMode`, unused event listener
- Add Playwright E2E test for reload-resets-state behavior