### PR TITLE
fix(core): handle all ECO/GO evidence codes in annotation parsing

### DIFF
--- a/docs/guide/data-format.md
+++ b/docs/guide/data-format.md
@@ -75,7 +75,7 @@ Annotation values can include an [ECO evidence code](https://www.evidenceontolog
 - `Cytoplasm|EXP` (experimental evidence)
 - `apoptotic process|IDA` (inferred from direct assay)
 
-Recognized evidence codes: `EXP`, `HDA`, `IDA`, `TAS`, `NAS`, `IC`, `ISS`, `SAM`, `COMB`, `IMP`, `IEA`
+Evidence codes are recognized by pattern: any 2–5 uppercase letter code (e.g., `EXP`, `IDA`, `IPI`, `IGI`, `IEP`, `COMB`) or raw ECO identifiers (e.g., `ECO:0000269`). This covers all standard [GO evidence codes](http://geneontology.org/docs/guide-go-evidence-codes/) and ECO ontology IDs.
 
 Evidence codes are displayed in the protein tooltip alongside the annotation value.
 

--- a/packages/core/src/components/data-loader/utils/conversion.test.ts
+++ b/packages/core/src/components/data-loader/utils/conversion.test.ts
@@ -98,21 +98,65 @@ describe('parseAnnotationValue', () => {
     expect(result.evidence).toBe('IDA');
   });
 
-  it('does not treat unknown codes as evidence', () => {
-    const result = parseAnnotationValue('value|UNKNOWN');
-    expect(result.label).toBe('value|UNKNOWN');
+  it('does not treat long unknown codes as evidence', () => {
+    const result = parseAnnotationValue('value|TOOLONG123');
+    expect(result.label).toBe('value|TOOLONG123');
     expect(result.scores).toEqual([]);
     expect(result.evidence).toBeNull();
   });
 
-  it('parses all known evidence codes', () => {
-    const codes = ['EXP', 'HDA', 'IDA', 'TAS', 'NAS', 'IC', 'ISS', 'SAM', 'COMB', 'IMP', 'IEA'];
+  it('does not treat single uppercase letter as evidence', () => {
+    const result = parseAnnotationValue('value|A');
+    expect(result.label).toBe('value|A');
+    expect(result.scores).toEqual([]);
+    expect(result.evidence).toBeNull();
+  });
+
+  it('parses all standard GO evidence codes', () => {
+    const codes = [
+      // Original 11
+      'EXP',
+      'HDA',
+      'IDA',
+      'TAS',
+      'NAS',
+      'IC',
+      'ISS',
+      'SAM',
+      'COMB',
+      'IMP',
+      'IEA',
+      // Additional GO evidence codes
+      'IPI',
+      'IGI',
+      'IEP',
+      'HTP',
+      'HMP',
+      'HGI',
+      'HEP',
+      'IBA',
+      'IBD',
+      'IKR',
+      'IRD',
+      'ISA',
+      'ISO',
+      'ISM',
+      'RCA',
+      'ND',
+    ];
     for (const code of codes) {
       const result = parseAnnotationValue(`some label|${code}`);
       expect(result.label).toBe('some label');
       expect(result.scores).toEqual([]);
       expect(result.evidence).toBe(code);
     }
+  });
+
+  it('parses raw ECO ID format as evidence', () => {
+    const result = parseAnnotationValue('Cytoplasm|ECO:0000269');
+    expect(result.label).toBe('Cytoplasm');
+    expect(result.scores).toEqual([]);
+    expect(result.evidence).toBe('ECO:0000269');
   });
 
   it('prefers numeric score over evidence code for numeric suffixes', () => {

--- a/packages/core/src/components/data-loader/utils/conversion.ts
+++ b/packages/core/src/components/data-loader/utils/conversion.ts
@@ -25,31 +25,20 @@ function getIdColumnsSet(proteinIdCol: string): Set<string> {
 /** Keys to exclude when building metadata */
 const METADATA_EXCLUDED_KEYS = new Set(['projection_name', 'name', 'info_json']);
 
-/** Known ECO evidence codes, priority-ordered */
-const KNOWN_EVIDENCE_CODES = new Set([
-  'EXP',
-  'HDA',
-  'IDA',
-  'TAS',
-  'NAS',
-  'IC',
-  'ISS',
-  'SAM',
-  'COMB',
-  'IMP',
-  'IEA',
-]);
+/** Match GO/ECO evidence codes: 2–5 uppercase letters OR ECO:NNNNNNN */
+const EVIDENCE_CODE_RE = /^(?:[A-Z]{2,5}|ECO:\d+)$/;
 
 /**
  * Parse an annotation value that may contain a pipe-separated score or evidence code suffix.
  * Format: `label|score`, `label|score1,score2,...`, or `label|EVIDENCE_CODE`
  * If the part after the last `|` is numeric → scores.
- * If it matches a known evidence code → evidence.
+ * If it matches an evidence code pattern (2–5 uppercase letters or ECO:digits) → evidence.
  * Otherwise the full string is kept as the label.
  * Examples:
  *   "PF00001 (7tm_1)|1.5e-10"       → { label: "PF00001 (7tm_1)", scores: [1.5e-10], evidence: null }
  *   "PF00001|1.5e-10,2.3e-5"        → { label: "PF00001", scores: [1.5e-10, 2.3e-5], evidence: null }
  *   "Cytoplasm|EXP"                  → { label: "Cytoplasm", scores: [], evidence: "EXP" }
+ *   "Cytoplasm|ECO:0000269"          → { label: "Cytoplasm", scores: [], evidence: "ECO:0000269" }
  *   "GO:0005524|ATP binding"         → { label: "GO:0005524|ATP binding", scores: [], evidence: null }
  *   "taxonomy_value"                 → { label: "taxonomy_value", scores: [], evidence: null }
  */
@@ -66,8 +55,8 @@ export const parseAnnotationValue = (
 
   const suffix = trimmed.substring(lastPipe + 1).trim();
 
-  // Check for known evidence code
-  if (KNOWN_EVIDENCE_CODES.has(suffix)) {
+  // Check for evidence code pattern (2–5 uppercase letters or ECO:digits)
+  if (EVIDENCE_CODE_RE.test(suffix)) {
     const label = trimmed.substring(0, lastPipe).trim();
     return { label, scores: [], evidence: suffix };
   }


### PR DESCRIPTION
## Summary
- Replace hardcoded `KNOWN_EVIDENCE_CODES` set (11 codes) with regex pattern `/^(?:[A-Z]{2,5}|ECO:\d+)$/`
- Now recognizes all standard GO evidence codes (IPI, IGI, IEP, HTP, etc.) and raw ECO ontology IDs (e.g., `ECO:0000269`)
- Updated tests and docs to reflect pattern-based matching

Closes #172