### PR TITLE
feat(core): persist export options per annotation

### DIFF
--- a/app/src/demo/main.ts
+++ b/app/src/demo/main.ts
@@ -573,6 +573,7 @@ export async function initializeDemo() {
       // Clear all component state before loading new data (skip on reload to preserve settings)
       if (!isReload && legendElement) {
         legendElement.clearForNewDataset(datasetHash);
+        controlBar.clearForNewDataset(datasetHash);
       }
 
       // Load the new data into all components
@@ -580,12 +581,16 @@ export async function initializeDemo() {
 
       // Apply file-based settings to legend if present (skip on reload to preserve user changes)
       if (!isReload && settings && legendElement) {
-        legendElement.setFileSettings(settings, datasetHash);
+        legendElement.setFileSettings(settings.legendSettings, datasetHash, true);
+        controlBar.setFileSettings(settings.exportOptions, datasetHash, false);
       }
 
       // Update control bar to indicate file has custom settings
       if (controlBar) {
-        controlBar.hasFileSettings = settings !== null;
+        controlBar.hasFileSettings =
+          settings !== null &&
+          (Object.keys(settings.legendSettings).length > 0 ||
+            Object.keys(settings.exportOptions).length > 0);
       }
     });
 
@@ -618,7 +623,8 @@ export async function initializeDemo() {
         imageHeight,
         legendWidthPercent,
         legendFontSizePx,
-        includeSettings,
+        includeLegendSettings,
+        includeExportOptions,
       } = customEvent.detail;
 
       try {
@@ -629,10 +635,13 @@ export async function initializeDemo() {
             throw new Error('No data available for export');
           }
 
-          // Get settings from legend if includeSettings is true
+          const includeSettings = includeLegendSettings || includeExportOptions;
           let settings: BundleSettings | undefined;
-          if (includeSettings && legendElement) {
-            settings = legendElement.getAllPersistedSettings();
+          if (includeSettings) {
+            settings = {
+              legendSettings: includeLegendSettings ? legendElement.getAllPersistedSettings() : {},
+              exportOptions: includeExportOptions ? controlBar.getAllPersistedExportOptions() : {},
+            };
           }
 
           const filename = generateBundleFilename(includeSettings);

--- a/packages/core/src/components/control-bar/control-bar-helpers.test.ts
+++ b/packages/core/src/components/control-bar/control-bar-helpers.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import {
   EXPORT_DEFAULTS,
+  createDefaultExportOptions,
   calculateHeightFromWidth,
   calculateWidthFromHeight,
   isProjection3D,
@@ -55,6 +56,18 @@ describe('control-bar-helpers', () => {
 
       requiredKeys.forEach((key) => {
         expect(EXPORT_DEFAULTS).toHaveProperty(key);
+      });
+    });
+
+    it('creates default export options including parquet toggles', () => {
+      expect(createDefaultExportOptions()).toEqual({
+        imageWidth: EXPORT_DEFAULTS.IMAGE_WIDTH,
+        imageHeight: EXPORT_DEFAULTS.IMAGE_HEIGHT,
+        lockAspectRatio: EXPORT_DEFAULTS.LOCK_ASPECT_RATIO,
+        legendWidthPercent: EXPORT_DEFAULTS.LEGEND_WIDTH_PERCENT,
+        legendFontSizePx: EXPORT_DEFAULTS.LEGEND_FONT_SIZE_PX,
+        includeLegendSettings: true,
+        includeExportOptions: true,
       });
     });
 

--- a/packages/core/src/components/control-bar/control-bar-helpers.ts
+++ b/packages/core/src/components/control-bar/control-bar-helpers.ts
@@ -3,6 +3,7 @@
  * These functions contain the core logic extracted from the component for better testability
  */
 
+import type { PersistedExportOptions } from '@protspace/utils';
 import type { ProtspaceData } from './types';
 
 /**
@@ -19,6 +20,18 @@ export const EXPORT_DEFAULTS = {
   MAX_LEGEND_FONT_SIZE_PX: 120,
   LOCK_ASPECT_RATIO: true,
 };
+
+export function createDefaultExportOptions(): PersistedExportOptions {
+  return {
+    imageWidth: EXPORT_DEFAULTS.IMAGE_WIDTH,
+    imageHeight: EXPORT_DEFAULTS.IMAGE_HEIGHT,
+    lockAspectRatio: EXPORT_DEFAULTS.LOCK_ASPECT_RATIO,
+    legendWidthPercent: EXPORT_DEFAULTS.LEGEND_WIDTH_PERCENT,
+    legendFontSizePx: EXPORT_DEFAULTS.LEGEND_FONT_SIZE_PX,
+    includeLegendSettings: true,
+    includeExportOptions: true,
+  };
+}
 
 /**
  * Calculate new height when width changes with locked aspect ratio

--- a/packages/core/src/components/control-bar/control-bar.ts
+++ b/packages/core/src/components/control-bar/control-bar.ts
@@ -1,6 +1,7 @@
 import { LitElement, html } from 'lit';
 import { customElement, property, state } from 'lit/decorators.js';
 import { controlBarStyles } from './control-bar.styles';
+import type { ExportOptionsMap, PersistedExportOptions } from '@protspace/utils';
 import type {
   DataChangeDetail,
   ProtspaceData,
@@ -13,6 +14,7 @@ import { toInternalValue } from '../legend/config';
 import { handleDropdownEscape, isAnyDropdownOpen } from '../../utils/dropdown-helpers';
 import {
   EXPORT_DEFAULTS,
+  createDefaultExportOptions,
   calculateHeightFromWidth,
   calculateWidthFromHeight,
   isProjection3D,
@@ -20,6 +22,7 @@ import {
   toggleProteinSelection,
   mergeProteinSelections,
 } from './control-bar-helpers';
+import { ExportPersistenceController } from './export-persistence-controller';
 import './search';
 import './annotation-select';
 
@@ -77,8 +80,13 @@ export class ProtspaceControlBar extends LitElement {
   @state() private exportLegendWidthPercent: number = EXPORT_DEFAULTS.LEGEND_WIDTH_PERCENT;
   @state() private exportLegendFontSizePx: number = EXPORT_DEFAULTS.LEGEND_FONT_SIZE_PX;
   @state() private exportLockAspectRatio: boolean = EXPORT_DEFAULTS.LOCK_ASPECT_RATIO;
-  @state() private exportIncludeSettings: boolean = true;
+  @state() private exportIncludeLegendSettings: boolean = true;
+  @state() private exportIncludeExportOptions: boolean = true;
   private _scatterplotElement: ScatterplotElementLike | null = null;
+  private _exportPersistence = new ExportPersistenceController({
+    onSettingsLoaded: (settings) => this._applyPersistedExportSettings(settings),
+    getCurrentSettings: () => this._getCurrentExportSettings(),
+  });
 
   // Search state
   @state() private allProteinIds: string[] = [];
@@ -283,13 +291,20 @@ export class ProtspaceControlBar extends LitElement {
 
   private handleAnnotationSelected(event: CustomEvent<{ annotation: string }>) {
     const annotation = event.detail.annotation;
+    if (annotation !== this.selectedAnnotation) {
+      this.selectedAnnotation = annotation;
+      this._exportPersistence.updateSelectedAnnotation(annotation);
+      this._exportPersistence.loadSettings();
+    }
+
     // If auto-sync is enabled, directly update the scatterplot
     if (this.autoSync && this._scatterplotElement) {
       if ('selectedAnnotation' in this._scatterplotElement) {
         (this._scatterplotElement as ScatterplotElementLike).selectedAnnotation = annotation;
-        this.selectedAnnotation = annotation;
       }
     }
+
+    this.selectedAnnotation = annotation;
 
     const customEvent = new CustomEvent('annotation-change', {
       detail: { annotation },
@@ -388,7 +403,8 @@ export class ProtspaceControlBar extends LitElement {
         imageHeight: this.exportImageHeight,
         legendWidthPercent: this.exportLegendWidthPercent,
         legendFontSizePx: this.exportLegendFontSizePx,
-        includeSettings: this.exportIncludeSettings,
+        includeLegendSettings: this.exportIncludeLegendSettings,
+        includeExportOptions: this.exportIncludeExportOptions,
       },
       bubbles: true,
       composed: true,
@@ -430,31 +446,39 @@ export class ProtspaceControlBar extends LitElement {
   }
 
   private resetExportSettings() {
-    const defaults = EXPORT_DEFAULTS;
-    this.exportImageWidth = defaults.IMAGE_WIDTH;
-    this.exportImageHeight = defaults.IMAGE_HEIGHT;
-    this.exportLegendWidthPercent = defaults.LEGEND_WIDTH_PERCENT;
-    this.exportLegendFontSizePx = defaults.LEGEND_FONT_SIZE_PX;
-    this.exportLockAspectRatio = defaults.LOCK_ASPECT_RATIO;
-    this.exportIncludeSettings = true;
+    this._applyUserExportSettingsChange(() => {
+      this._applyPersistedExportSettings(createDefaultExportOptions());
+    });
   }
 
   private handleWidthChange(newWidth: number) {
-    const oldWidth = this.exportImageWidth;
-    this.exportImageWidth = newWidth;
+    this._applyUserExportSettingsChange(() => {
+      const oldWidth = this.exportImageWidth;
+      this.exportImageWidth = newWidth;
 
-    if (this.exportLockAspectRatio) {
-      this.exportImageHeight = calculateHeightFromWidth(newWidth, oldWidth, this.exportImageHeight);
-    }
+      if (this.exportLockAspectRatio) {
+        this.exportImageHeight = calculateHeightFromWidth(
+          newWidth,
+          oldWidth,
+          this.exportImageHeight,
+        );
+      }
+    });
   }
 
   private handleHeightChange(newHeight: number) {
-    const oldHeight = this.exportImageHeight;
-    this.exportImageHeight = newHeight;
+    this._applyUserExportSettingsChange(() => {
+      const oldHeight = this.exportImageHeight;
+      this.exportImageHeight = newHeight;
 
-    if (this.exportLockAspectRatio) {
-      this.exportImageWidth = calculateWidthFromHeight(newHeight, oldHeight, this.exportImageWidth);
-    }
+      if (this.exportLockAspectRatio) {
+        this.exportImageWidth = calculateWidthFromHeight(
+          newHeight,
+          oldHeight,
+          this.exportImageWidth,
+        );
+      }
+    });
   }
 
   /**
@@ -481,6 +505,70 @@ export class ProtspaceControlBar extends LitElement {
       setter(max);
     } else {
       setter(value);
+    }
+  }
+
+  public getAllPersistedExportOptions(): ExportOptionsMap {
+    return this._exportPersistence.getAllSettingsForExport(this.annotations);
+  }
+
+  public setFileSettings(
+    settings: ExportOptionsMap | null,
+    datasetHash?: string,
+    clearExistingStorage: boolean = true,
+  ): void {
+    this._exportPersistence.setFileSettings(settings, datasetHash, clearExistingStorage);
+
+    if (settings?.[this.selectedAnnotation]) {
+      this._exportPersistence.loadSettings();
+    }
+  }
+
+  public clearForNewDataset(datasetHash: string): void {
+    this._exportPersistence.clearForNewDataset(datasetHash);
+    this._applyPersistedExportSettings(createDefaultExportOptions());
+    this.exportFormat = EXPORT_DEFAULTS.FORMAT;
+  }
+
+  private _getCurrentExportSettings(): PersistedExportOptions {
+    return {
+      imageWidth: this.exportImageWidth,
+      imageHeight: this.exportImageHeight,
+      lockAspectRatio: this.exportLockAspectRatio,
+      legendWidthPercent: this.exportLegendWidthPercent,
+      legendFontSizePx: this.exportLegendFontSizePx,
+      includeLegendSettings: this.exportIncludeLegendSettings,
+      includeExportOptions: this.exportIncludeExportOptions,
+    };
+  }
+
+  private _applyPersistedExportSettings(settings: PersistedExportOptions): void {
+    this.exportImageWidth = settings.imageWidth;
+    this.exportImageHeight = settings.imageHeight;
+    this.exportLockAspectRatio = settings.lockAspectRatio;
+    this.exportLegendWidthPercent = settings.legendWidthPercent;
+    this.exportLegendFontSizePx = settings.legendFontSizePx;
+    this.exportIncludeLegendSettings = settings.includeLegendSettings;
+    this.exportIncludeExportOptions = settings.includeExportOptions;
+  }
+
+  private _applyUserExportSettingsChange(update: () => void): void {
+    update();
+    this._exportPersistence.saveSettings();
+  }
+
+  private _syncExportPersistenceFromData(data: ProtspaceData): void {
+    const proteinIds = Array.isArray(data.protein_ids) ? data.protein_ids : [];
+    const hashChanged = this._exportPersistence.updateDatasetHash(proteinIds);
+
+    const annotationChanged = this._exportPersistence.updateSelectedAnnotation(
+      this.selectedAnnotation,
+    );
+    if (
+      (hashChanged || annotationChanged || !this._exportPersistence.settingsLoaded) &&
+      this.selectedAnnotation
+    ) {
+      this._exportPersistence.loadSettings();
     }
   }
 
@@ -938,18 +1026,35 @@ export class ProtspaceControlBar extends LitElement {
                                   <input
                                     type="checkbox"
                                     class="export-checkbox"
-                                    .checked=${this.exportIncludeSettings}
+                                    .checked=${this.exportIncludeLegendSettings}
                                     @change=${(e: Event) => {
-                                      this.exportIncludeSettings = (
-                                        e.target as HTMLInputElement
-                                      ).checked;
+                                      this._applyUserExportSettingsChange(() => {
+                                        this.exportIncludeLegendSettings = (
+                                          e.target as HTMLInputElement
+                                        ).checked;
+                                      });
                                     }}
                                   />
                                   <span>Include legend settings</span>
                                 </label>
+                                <label class="export-checkbox-label">
+                                  <input
+                                    type="checkbox"
+                                    class="export-checkbox"
+                                    .checked=${this.exportIncludeExportOptions}
+                                    @change=${(e: Event) => {
+                                      this._applyUserExportSettingsChange(() => {
+                                        this.exportIncludeExportOptions = (
+                                          e.target as HTMLInputElement
+                                        ).checked;
+                                      });
+                                    }}
+                                  />
+                                  <span>Include export options settings</span>
+                                </label>
                                 <div class="export-parquet-help">
-                                  Legend customizations (colors, order, visibility) will be saved in
-                                  the file and restored when loading.
+                                  Legend customizations and remembered export dimensions can be
+                                  saved in the file and restored when loading.
                                 </div>
                               </div>
                             `
@@ -1059,9 +1164,11 @@ export class ProtspaceControlBar extends LitElement {
                                     class="export-checkbox"
                                     .checked=${this.exportLockAspectRatio}
                                     @change=${(e: Event) => {
-                                      this.exportLockAspectRatio = (
-                                        e.target as HTMLInputElement
-                                      ).checked;
+                                      this._applyUserExportSettingsChange(() => {
+                                        this.exportLockAspectRatio = (
+                                          e.target as HTMLInputElement
+                                        ).checked;
+                                      });
                                     }}
                                   />
                                   <span>Lock aspect ratio</span>
@@ -1084,15 +1191,20 @@ export class ProtspaceControlBar extends LitElement {
                                           (e.target as HTMLInputElement).value,
                                         );
                                         if (!isNaN(value)) {
-                                          this.exportLegendWidthPercent = this.clamp(value, 15, 50);
+                                          this._applyUserExportSettingsChange(() => {
+                                            this.exportLegendWidthPercent = this.clamp(
+                                              value,
+                                              15,
+                                              50,
+                                            );
+                                          });
                                         }
                                       }}
                                       @blur=${(e: Event) =>
-                                        this.handleNumberInputBlur(
-                                          e,
-                                          15,
-                                          50,
-                                          (v) => (this.exportLegendWidthPercent = v),
+                                        this.handleNumberInputBlur(e, 15, 50, (v) =>
+                                          this._applyUserExportSettingsChange(() => {
+                                            this.exportLegendWidthPercent = v;
+                                          }),
                                         )}
                                     />
                                     <span class="export-option-value-unit">%</span>
@@ -1107,9 +1219,11 @@ export class ProtspaceControlBar extends LitElement {
                                   step="1"
                                   .value=${String(this.exportLegendWidthPercent)}
                                   @input=${(e: Event) => {
-                                    this.exportLegendWidthPercent = parseInt(
-                                      (e.target as HTMLInputElement).value,
-                                    );
+                                    this._applyUserExportSettingsChange(() => {
+                                      this.exportLegendWidthPercent = parseInt(
+                                        (e.target as HTMLInputElement).value,
+                                      );
+                                    });
                                   }}
                                 />
                                 <div class="export-slider-labels">
@@ -1134,11 +1248,13 @@ export class ProtspaceControlBar extends LitElement {
                                           (e.target as HTMLInputElement).value,
                                         );
                                         if (!isNaN(value)) {
-                                          this.exportLegendFontSizePx = this.clamp(
-                                            value,
-                                            EXPORT_DEFAULTS.MIN_LEGEND_FONT_SIZE_PX,
-                                            EXPORT_DEFAULTS.MAX_LEGEND_FONT_SIZE_PX,
-                                          );
+                                          this._applyUserExportSettingsChange(() => {
+                                            this.exportLegendFontSizePx = this.clamp(
+                                              value,
+                                              EXPORT_DEFAULTS.MIN_LEGEND_FONT_SIZE_PX,
+                                              EXPORT_DEFAULTS.MAX_LEGEND_FONT_SIZE_PX,
+                                            );
+                                          });
                                         }
                                       }}
                                       @blur=${(e: Event) =>
@@ -1146,7 +1262,10 @@ export class ProtspaceControlBar extends LitElement {
                                           e,
                                           EXPORT_DEFAULTS.MIN_LEGEND_FONT_SIZE_PX,
                                           EXPORT_DEFAULTS.MAX_LEGEND_FONT_SIZE_PX,
-                                          (v) => (this.exportLegendFontSizePx = v),
+                                          (v) =>
+                                            this._applyUserExportSettingsChange(() => {
+                                              this.exportLegendFontSizePx = v;
+                                            }),
                                         )}
                                     />
                                     <span class="export-option-value-unit">px</span>
@@ -1161,9 +1280,11 @@ export class ProtspaceControlBar extends LitElement {
                                   step="1"
                                   .value=${String(this.exportLegendFontSizePx)}
                                   @input=${(e: Event) => {
-                                    this.exportLegendFontSizePx = parseInt(
-                                      (e.target as HTMLInputElement).value,
-                                    );
+                                    this._applyUserExportSettingsChange(() => {
+                                      this.exportLegendFontSizePx = parseInt(
+                                        (e.target as HTMLInputElement).value,
+                                      );
+                                    });
                                   }}
                                 />
                                 <div class="export-slider-labels">
@@ -1425,6 +1546,8 @@ export class ProtspaceControlBar extends LitElement {
     } catch (e) {
       console.error(e);
     }
+
+    this._syncExportPersistenceFromData(data);
     this.requestUpdate();
   }
 
@@ -1625,6 +1748,7 @@ export class ProtspaceControlBar extends LitElement {
           this.selectedAnnotation = this.annotations[0];
         }
 
+        this._syncExportPersistenceFromData(data);
         this.requestUpdate();
       }
     }

--- a/packages/core/src/components/control-bar/export-persistence-controller.test.ts
+++ b/packages/core/src/components/control-bar/export-persistence-controller.test.ts
@@ -1,0 +1,166 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  ExportPersistenceController,
+  type ExportPersistenceCallbacks,
+} from './export-persistence-controller';
+import type { PersistedExportOptions } from '@protspace/utils';
+
+vi.mock('@protspace/utils', () => ({
+  buildStorageKey: vi.fn(
+    (component: string, hash: string, annotation: string) => `${component}_${hash}_${annotation}`,
+  ),
+  generateDatasetHash: vi.fn((ids: string[]) => `hash_${ids.join('_')}`),
+  getStorageItem: vi.fn(),
+  removeAllStorageItemsByHash: vi.fn(),
+  setStorageItem: vi.fn(),
+}));
+
+import {
+  buildStorageKey,
+  generateDatasetHash,
+  getStorageItem,
+  removeAllStorageItemsByHash,
+  setStorageItem,
+} from '@protspace/utils';
+
+const createSettings = (
+  overrides: Partial<PersistedExportOptions> = {},
+): PersistedExportOptions => ({
+  imageWidth: 2048,
+  imageHeight: 1024,
+  lockAspectRatio: true,
+  legendWidthPercent: 25,
+  legendFontSizePx: 24,
+  includeLegendSettings: true,
+  includeExportOptions: true,
+  ...overrides,
+});
+
+describe('ExportPersistenceController', () => {
+  let controller: ExportPersistenceController;
+  let callbacks: ExportPersistenceCallbacks;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    callbacks = {
+      onSettingsLoaded: vi.fn(),
+      getCurrentSettings: vi.fn().mockReturnValue(createSettings()),
+    };
+
+    controller = new ExportPersistenceController(callbacks);
+  });
+
+  it('loads persisted settings per dataset and annotation', () => {
+    vi.mocked(getStorageItem).mockReturnValue(createSettings({ imageWidth: 4096 }));
+
+    controller.updateDatasetHash(['P1']);
+    controller.updateSelectedAnnotation('organism');
+    controller.loadSettings();
+
+    expect(generateDatasetHash).toHaveBeenCalledWith(['P1']);
+    expect(buildStorageKey).toHaveBeenCalledWith('control-bar', 'hash_P1', 'organism');
+    expect(callbacks.onSettingsLoaded).toHaveBeenCalledWith(createSettings({ imageWidth: 4096 }));
+    expect(setStorageItem).not.toHaveBeenCalled();
+  });
+
+  it('switches annotations without writing localStorage', () => {
+    controller.updateDatasetHash(['P1']);
+    controller.updateSelectedAnnotation('organism');
+
+    controller.updateSelectedAnnotation('family');
+    vi.mocked(getStorageItem).mockReturnValue(createSettings({ imageHeight: 2048 }));
+    controller.loadSettings();
+
+    expect(getStorageItem).toHaveBeenCalledWith(
+      'control-bar_hash_P1_family',
+      expect.objectContaining({ imageWidth: 2048 }),
+    );
+    expect(setStorageItem).not.toHaveBeenCalled();
+  });
+
+  it('persists default settings when the current export settings are reset', () => {
+    vi.mocked(callbacks.getCurrentSettings).mockReturnValue(createSettings());
+
+    controller.updateDatasetHash(['P1']);
+    controller.updateSelectedAnnotation('organism');
+    controller.saveSettings();
+
+    expect(setStorageItem).toHaveBeenCalledWith('control-bar_hash_P1_organism', createSettings());
+  });
+
+  it('writes imported file settings to localStorage immediately', () => {
+    controller.updateDatasetHash(['P1']);
+    controller.updateSelectedAnnotation('organism');
+
+    controller.setFileSettings({
+      organism: createSettings({ legendFontSizePx: 32 }),
+      family: createSettings({ imageWidth: 4096 }),
+    });
+
+    expect(removeAllStorageItemsByHash).toHaveBeenCalledWith('hash_P1');
+    expect(setStorageItem).toHaveBeenCalledWith(
+      'control-bar_hash_P1_organism',
+      createSettings({ legendFontSizePx: 32 }),
+    );
+    expect(setStorageItem).toHaveBeenCalledWith(
+      'control-bar_hash_P1_family',
+      createSettings({ imageWidth: 4096 }),
+    );
+  });
+
+  it('prioritizes file settings over local storage on first load only', () => {
+    controller.updateDatasetHash(['P1']);
+    controller.updateSelectedAnnotation('organism');
+
+    controller.setFileSettings({
+      organism: createSettings({ legendFontSizePx: 32 }),
+    });
+
+    vi.mocked(getStorageItem).mockReturnValue(createSettings({ legendFontSizePx: 18 }));
+
+    controller.loadSettings();
+    controller.loadSettings();
+
+    expect(callbacks.onSettingsLoaded).toHaveBeenNthCalledWith(
+      1,
+      createSettings({ legendFontSizePx: 32 }),
+    );
+    expect(callbacks.onSettingsLoaded).toHaveBeenNthCalledWith(
+      2,
+      createSettings({ legendFontSizePx: 18 }),
+    );
+  });
+
+  it('returns current annotation live state and other annotations from localStorage for export', () => {
+    vi.mocked(callbacks.getCurrentSettings).mockReturnValue(createSettings({ imageWidth: 3000 }));
+    vi.mocked(getStorageItem).mockImplementation((key: string) => {
+      if (key === 'control-bar_hash_P1_family') {
+        return { legendFontSizePx: 36 };
+      }
+      return {};
+    });
+
+    controller.updateDatasetHash(['P1']);
+    controller.updateSelectedAnnotation('organism');
+
+    expect(controller.getAllSettingsForExport(['organism', 'family', 'pathway'])).toEqual({
+      organism: createSettings({ imageWidth: 3000 }),
+      family: createSettings({ legendFontSizePx: 36 }),
+    });
+  });
+
+  it('clears persisted state for a new dataset', () => {
+    controller.updateDatasetHash(['P1']);
+    controller.updateSelectedAnnotation('organism');
+    controller.setFileSettings({
+      organism: createSettings(),
+    });
+
+    controller.clearForNewDataset('hash_NEW');
+
+    expect(removeAllStorageItemsByHash).toHaveBeenCalledWith('hash_NEW');
+    expect(controller.hasFileSettings).toBe(false);
+    expect(controller.settingsLoaded).toBe(false);
+  });
+});

--- a/packages/core/src/components/control-bar/export-persistence-controller.ts
+++ b/packages/core/src/components/control-bar/export-persistence-controller.ts
@@ -1,0 +1,167 @@
+import {
+  buildStorageKey,
+  generateDatasetHash,
+  getStorageItem,
+  removeAllStorageItemsByHash,
+  setStorageItem,
+  type ExportOptionsMap,
+  type PersistedExportOptions,
+} from '@protspace/utils';
+import { createDefaultExportOptions } from './control-bar-helpers';
+
+export interface ExportPersistenceCallbacks {
+  onSettingsLoaded: (settings: PersistedExportOptions) => void;
+  getCurrentSettings: () => PersistedExportOptions;
+}
+
+export class ExportPersistenceController {
+  private callbacks: ExportPersistenceCallbacks;
+
+  private _datasetHash: string = '';
+  private _selectedAnnotation: string = '';
+  private _settingsLoaded: boolean = false;
+  private _fileSettings: ExportOptionsMap | null = null;
+  private _appliedFileAnnotations: Set<string> = new Set();
+
+  constructor(callbacks: ExportPersistenceCallbacks) {
+    this.callbacks = callbacks;
+  }
+
+  get settingsLoaded(): boolean {
+    return this._settingsLoaded;
+  }
+
+  get hasFileSettings(): boolean {
+    return this._fileSettings !== null;
+  }
+
+  updateDatasetHash(proteinIds: string[]): boolean {
+    const newHash = generateDatasetHash(proteinIds);
+    if (newHash !== this._datasetHash) {
+      this._datasetHash = newHash;
+      this._settingsLoaded = false;
+      return true;
+    }
+    return false;
+  }
+
+  updateSelectedAnnotation(annotation: string): boolean {
+    if (annotation !== this._selectedAnnotation) {
+      this._selectedAnnotation = annotation;
+      this._settingsLoaded = false;
+      return true;
+    }
+    return false;
+  }
+
+  loadSettings(): void {
+    const key = this._getStorageKey();
+    if (!key) return;
+
+    const defaultSettings = createDefaultExportOptions();
+    let mergedSettings: PersistedExportOptions;
+
+    if (
+      this._fileSettings?.[this._selectedAnnotation] &&
+      !this._appliedFileAnnotations.has(this._selectedAnnotation)
+    ) {
+      mergedSettings = {
+        ...defaultSettings,
+        ...this._fileSettings[this._selectedAnnotation],
+      };
+      this._appliedFileAnnotations.add(this._selectedAnnotation);
+    } else {
+      const saved = getStorageItem<Partial<PersistedExportOptions>>(key, defaultSettings);
+      mergedSettings = {
+        ...defaultSettings,
+        ...saved,
+      };
+    }
+
+    this.callbacks.onSettingsLoaded(mergedSettings);
+    this._settingsLoaded = true;
+  }
+
+  saveSettings(): void {
+    const key = this._getStorageKey();
+    if (!key) return;
+
+    setStorageItem(key, this.callbacks.getCurrentSettings());
+  }
+
+  setFileSettings(
+    settings: ExportOptionsMap | null,
+    datasetHash?: string,
+    clearExistingStorage: boolean = true,
+  ): void {
+    this._fileSettings = settings;
+    this._appliedFileAnnotations.clear();
+
+    const hashToUse = datasetHash || this._datasetHash;
+
+    if (settings && hashToUse) {
+      if (clearExistingStorage) {
+        removeAllStorageItemsByHash(hashToUse);
+      }
+
+      for (const [annotationName, annotationSettings] of Object.entries(settings)) {
+        const key = buildStorageKey('control-bar', hashToUse, annotationName);
+        setStorageItem(key, annotationSettings);
+      }
+    }
+
+    if (settings && this._selectedAnnotation && settings[this._selectedAnnotation]) {
+      this._settingsLoaded = false;
+    }
+  }
+
+  clearForNewDataset(datasetHash: string): void {
+    removeAllStorageItemsByHash(datasetHash);
+
+    this._datasetHash = '';
+    this._selectedAnnotation = '';
+    this._settingsLoaded = false;
+    this._fileSettings = null;
+    this._appliedFileAnnotations.clear();
+  }
+
+  hasFileSettingsForAnnotation(annotation: string): boolean {
+    return this._fileSettings !== null && annotation in this._fileSettings;
+  }
+
+  getCurrentSettingsForExport(): PersistedExportOptions {
+    return this.callbacks.getCurrentSettings();
+  }
+
+  getAllSettingsForExport(annotationNames: string[]): ExportOptionsMap {
+    const result: ExportOptionsMap = {};
+
+    if (this._selectedAnnotation) {
+      result[this._selectedAnnotation] = this.getCurrentSettingsForExport();
+    }
+
+    for (const annotation of annotationNames) {
+      if (annotation === this._selectedAnnotation) continue;
+
+      const key = buildStorageKey('control-bar', this._datasetHash, annotation);
+      const saved = getStorageItem<Partial<PersistedExportOptions>>(key, {});
+
+      if (Object.keys(saved).length > 0) {
+        result[annotation] = {
+          ...createDefaultExportOptions(),
+          ...saved,
+        };
+      }
+    }
+
+    return result;
+  }
+
+  private _getStorageKey(): string | null {
+    if (!this._datasetHash || !this._selectedAnnotation) {
+      return null;
+    }
+
+    return buildStorageKey('control-bar', this._datasetHash, this._selectedAnnotation);
+  }
+}

--- a/packages/core/src/components/data-loader/utils/bundle-roundtrip.test.ts
+++ b/packages/core/src/components/data-loader/utils/bundle-roundtrip.test.ts
@@ -57,17 +57,30 @@ describe('round-trip with real data files', () => {
 
     // Create mock settings
     const mockSettings = {
-      testAnnotation: {
-        maxVisibleValues: 10,
-        includeShapes: true,
-        shapeSize: 24,
-        sortMode: 'size-desc' as const,
-        hiddenValues: [],
-        categories: {
-          category1: { zOrder: 0, color: '#ff0000', shape: 'circle' },
+      legendSettings: {
+        testAnnotation: {
+          maxVisibleValues: 10,
+          includeShapes: true,
+          shapeSize: 24,
+          sortMode: 'size-desc' as const,
+          hiddenValues: [],
+          categories: {
+            category1: { zOrder: 0, color: '#ff0000', shape: 'circle' },
+          },
+          enableDuplicateStackUI: false,
+          selectedPaletteId: 'kellys',
         },
-        enableDuplicateStackUI: false,
-        selectedPaletteId: 'kellys',
+      },
+      exportOptions: {
+        testAnnotation: {
+          imageWidth: 2048,
+          imageHeight: 1024,
+          lockAspectRatio: true,
+          legendWidthPercent: 25,
+          legendFontSizePx: 24,
+          includeLegendSettings: true,
+          includeExportOptions: true,
+        },
       },
     };
 

--- a/packages/core/src/components/data-loader/utils/bundle.test.ts
+++ b/packages/core/src/components/data-loader/utils/bundle.test.ts
@@ -137,98 +137,117 @@ describe('bundle utilities', () => {
 describe('BundleSettings type', () => {
   it('should have correct structure', () => {
     const settings: BundleSettings = {
-      organism: {
-        maxVisibleValues: 10,
-        includeShapes: true,
-        shapeSize: 24,
-        sortMode: 'size-desc',
-        hiddenValues: ['unknown'],
-        categories: {
-          human: { zOrder: 0, color: '#ff0000', shape: 'circle' },
+      legendSettings: {
+        organism: {
+          maxVisibleValues: 10,
+          includeShapes: true,
+          shapeSize: 24,
+          sortMode: 'size-desc',
+          hiddenValues: ['unknown'],
+          categories: {
+            human: { zOrder: 0, color: '#ff0000', shape: 'circle' },
+          },
+          enableDuplicateStackUI: false,
+          selectedPaletteId: 'kellys',
         },
-        enableDuplicateStackUI: false,
-        selectedPaletteId: 'kellys',
+      },
+      exportOptions: {
+        organism: {
+          imageWidth: 2048,
+          imageHeight: 1024,
+          lockAspectRatio: true,
+          legendWidthPercent: 25,
+          legendFontSizePx: 24,
+          includeLegendSettings: true,
+          includeExportOptions: true,
+        },
       },
     };
 
-    expect(settings.organism.maxVisibleValues).toBe(10);
-    expect(settings.organism.sortMode).toBe('size-desc');
-    expect(settings.organism.categories.human.color).toBe('#ff0000');
+    expect(settings.legendSettings.organism.maxVisibleValues).toBe(10);
+    expect(settings.legendSettings.organism.sortMode).toBe('size-desc');
+    expect(settings.legendSettings.organism.categories.human.color).toBe('#ff0000');
+    expect(settings.exportOptions.organism.imageWidth).toBe(2048);
   });
 
-  it('should accept settings with empty categories', () => {
+  it('should accept settings with empty maps', () => {
     const settings: BundleSettings = {
-      organism: {
-        maxVisibleValues: 10,
-        includeShapes: true,
-        shapeSize: 24,
-        sortMode: 'size-desc',
-        hiddenValues: [],
-        categories: {},
-        enableDuplicateStackUI: false,
-        selectedPaletteId: 'kellys',
-      },
+      legendSettings: {},
+      exportOptions: {},
     };
 
-    expect(Object.keys(settings.organism.categories)).toHaveLength(0);
-    expect(settings.organism.hiddenValues).toHaveLength(0);
+    expect(Object.keys(settings.legendSettings)).toHaveLength(0);
+    expect(Object.keys(settings.exportOptions)).toHaveLength(0);
   });
 
   it('should accept settings with extra/unknown fields (forward compatibility)', () => {
     // This simulates loading settings from a newer version with additional fields
     const settingsWithExtras = {
-      organism: {
-        maxVisibleValues: 10,
-        includeShapes: true,
-        shapeSize: 24,
-        sortMode: 'size-desc',
-        hiddenValues: [],
-        categories: {},
-        enableDuplicateStackUI: false,
-        selectedPaletteId: 'kellys',
-        // Future fields that might be added
-        unknownField: 'some value',
-        futureFeature: { nested: true },
-        newOption: 42,
+      legendSettings: {
+        organism: {
+          maxVisibleValues: 10,
+          includeShapes: true,
+          shapeSize: 24,
+          sortMode: 'size-desc',
+          hiddenValues: [],
+          categories: {},
+          enableDuplicateStackUI: false,
+          selectedPaletteId: 'kellys',
+          unknownField: 'some value',
+        },
       },
+      exportOptions: {},
     };
 
     // Type-cast to BundleSettings - extra fields should be ignored
     const settings = settingsWithExtras as BundleSettings;
-    expect(settings.organism.maxVisibleValues).toBe(10);
-    expect(settings.organism.sortMode).toBe('size-desc');
+    expect(settings.legendSettings.organism.maxVisibleValues).toBe(10);
+    expect(settings.legendSettings.organism.sortMode).toBe('size-desc');
   });
 
   it('should work with multiple annotations', () => {
     const settings: BundleSettings = {
-      organism: {
-        maxVisibleValues: 10,
-        includeShapes: true,
-        shapeSize: 24,
-        sortMode: 'size-desc',
-        hiddenValues: ['unknown'],
-        categories: {
-          human: { zOrder: 0, color: '#ff0000', shape: 'circle' },
+      legendSettings: {
+        organism: {
+          maxVisibleValues: 10,
+          includeShapes: true,
+          shapeSize: 24,
+          sortMode: 'size-desc',
+          hiddenValues: ['unknown'],
+          categories: {
+            human: { zOrder: 0, color: '#ff0000', shape: 'circle' },
+          },
+          enableDuplicateStackUI: false,
+          selectedPaletteId: 'kellys',
         },
-        enableDuplicateStackUI: false,
-        selectedPaletteId: 'kellys',
+        family: {
+          maxVisibleValues: 5,
+          includeShapes: false,
+          shapeSize: 16,
+          sortMode: 'alpha-asc',
+          hiddenValues: [],
+          categories: {
+            kinase: { zOrder: 1, color: '#00ff00', shape: 'square' },
+            phosphatase: { zOrder: 0, color: '#0000ff', shape: 'diamond' },
+          },
+          enableDuplicateStackUI: true,
+          selectedPaletteId: 'kellys',
+        },
       },
-      family: {
-        maxVisibleValues: 5,
-        includeShapes: false,
-        shapeSize: 16,
-        sortMode: 'alpha-asc',
-        hiddenValues: [],
-        categories: {
-          kinase: { zOrder: 1, color: '#00ff00', shape: 'square' },
-          phosphatase: { zOrder: 0, color: '#0000ff', shape: 'diamond' },
+      exportOptions: {
+        organism: {
+          imageWidth: 2048,
+          imageHeight: 1024,
+          lockAspectRatio: true,
+          legendWidthPercent: 25,
+          legendFontSizePx: 24,
+          includeLegendSettings: true,
+          includeExportOptions: true,
         },
-        enableDuplicateStackUI: true,
-        selectedPaletteId: 'kellys',
       },
     };
 
-    expect(Object.keys(settings)).toHaveLength(2);
-    expect(settings.family.categories.kinase.color).toBe('#00ff00');
+    expect(Object.keys(settings.legendSettings)).toHaveLength(2);
+    expect(settings.legendSettings.family.categories.kinase.color).toBe('#00ff00');
   });
 });

--- a/packages/core/src/components/data-loader/utils/bundle.ts
+++ b/packages/core/src/components/data-loader/utils/bundle.ts
@@ -2,7 +2,7 @@ import { parquetReadObjects } from 'hyparquet';
 import {
   BUNDLE_DELIMITER_BYTES,
   findBundleDelimiterPositions,
-  isValidBundleSettings,
+  normalizeBundleSettings,
   type BundleSettings,
 } from '@protspace/utils';
 import type { Rows, GenericRow } from './types';
@@ -118,14 +118,14 @@ async function extractSettings(settingsBuffer: ArrayBuffer): Promise<BundleSetti
     }
 
     const parsed = JSON.parse(settingsJson);
+    const normalized = normalizeBundleSettings(parsed);
 
-    // Validate structure using schema validation
-    if (!isValidBundleSettings(parsed)) {
+    if (!normalized) {
       console.warn('Settings JSON does not match expected schema, using defaults');
       return null;
     }
 
-    return parsed;
+    return normalized;
   } catch (error) {
     console.warn('Failed to parse settings from bundle, using defaults:', error);
     return null;

--- a/packages/core/src/components/legend/controllers/persistence-controller.test.ts
+++ b/packages/core/src/components/legend/controllers/persistence-controller.test.ts
@@ -65,6 +65,7 @@ describe('PersistenceController', () => {
         shapeSize: 16,
         sortMode: 'size-desc' as const,
         enableDuplicateStackUI: false,
+        selectedPaletteId: 'kellys',
       }),
     };
 
@@ -189,6 +190,7 @@ describe('PersistenceController', () => {
         shapeSize: 20,
         sortMode: 'alpha-asc' as const,
         enableDuplicateStackUI: true,
+        selectedPaletteId: 'kellys',
       });
 
       controller.saveSettings();
@@ -205,6 +207,7 @@ describe('PersistenceController', () => {
           [LEGEND_VALUES.NA_VALUE]: { zOrder: 1, color: '#888', shape: 'circle' },
         },
         enableDuplicateStackUI: true,
+        selectedPaletteId: 'kellys',
       });
     });
   });
@@ -584,6 +587,7 @@ describe('PersistenceController', () => {
           shapeSize: 20,
           sortMode: 'alpha-asc' as const,
           enableDuplicateStackUI: true,
+          selectedPaletteId: 'kellys',
         });
 
         const settings = controller.getCurrentSettingsForExport();

--- a/packages/core/src/components/legend/controllers/persistence-controller.ts
+++ b/packages/core/src/components/legend/controllers/persistence-controller.ts
@@ -6,7 +6,7 @@ import {
   setStorageItem,
   removeStorageItem,
   removeAllStorageItemsByHash,
-  type BundleSettings,
+  type LegendSettingsMap,
 } from '@protspace/utils';
 import type {
   LegendPersistedSettings,
@@ -51,7 +51,7 @@ export class PersistenceController implements ReactiveController {
    * File-based settings loaded from a parquetbundle.
    * These take priority over localStorage when present.
    */
-  private _fileSettings: BundleSettings | null = null;
+  private _fileSettings: LegendSettingsMap | null = null;
 
   /**
    * Track which annotations have had their file settings applied.
@@ -299,7 +299,11 @@ export class PersistenceController implements ReactiveController {
    * @param datasetHash - Optional dataset hash to use for localStorage keys (required when
    *                      the component's hash isn't yet computed from the new data)
    */
-  setFileSettings(settings: BundleSettings | null, datasetHash?: string): void {
+  setFileSettings(
+    settings: LegendSettingsMap | null,
+    datasetHash?: string,
+    clearExistingStorage: boolean = true,
+  ): void {
     this._fileSettings = settings;
     this._appliedFileAnnotations.clear();
 
@@ -308,7 +312,9 @@ export class PersistenceController implements ReactiveController {
     if (settings && hashToUse) {
       // Clear ALL existing settings for this hash before applying imported settings
       // This ensures the imported file is the single source of truth
-      removeAllStorageItemsByHash(hashToUse);
+      if (clearExistingStorage) {
+        removeAllStorageItemsByHash(hashToUse);
+      }
 
       // Persist all settings to localStorage so they're available for future exports
       for (const [annotationName, annotationSettings] of Object.entries(settings)) {
@@ -375,8 +381,8 @@ export class PersistenceController implements ReactiveController {
    * @param annotationNames - List of all available annotation names
    * @returns All persisted settings mapped by annotation name
    */
-  getAllSettingsForExport(annotationNames: string[]): BundleSettings {
-    const result: BundleSettings = {};
+  getAllSettingsForExport(annotationNames: string[]): LegendSettingsMap {
+    const result: LegendSettingsMap = {};
 
     // First, add the current annotation's settings (from live state)
     if (this._selectedAnnotation) {

--- a/packages/core/src/components/legend/legend.ts
+++ b/packages/core/src/components/legend/legend.ts
@@ -1,6 +1,7 @@
 import { LitElement, html } from 'lit';
 import { customElement, property, query, state } from 'lit/decorators.js';
 import { COLOR_SCHEMES } from '@protspace/utils';
+import type { LegendSettingsMap } from '@protspace/utils';
 
 // Configuration and styles
 import {
@@ -557,7 +558,7 @@ export class ProtspaceLegend extends LitElement {
    *
    * @returns Record mapping annotation names to their persisted settings
    */
-  public getAllPersistedSettings(): Record<string, LegendPersistedSettings> {
+  public getAllPersistedSettings(): LegendSettingsMap {
     const annotationNames = Object.keys(this.data?.annotations ?? {});
     return this._persistenceController.getAllSettingsForExport(annotationNames);
   }
@@ -572,10 +573,11 @@ export class ProtspaceLegend extends LitElement {
    *                      the component's hash isn't yet computed from the new data)
    */
   public setFileSettings(
-    settings: Record<string, LegendPersistedSettings> | null,
+    settings: LegendSettingsMap | null,
     datasetHash?: string,
+    clearExistingStorage: boolean = true,
   ): void {
-    this._persistenceController.setFileSettings(settings, datasetHash);
+    this._persistenceController.setFileSettings(settings, datasetHash, clearExistingStorage);
 
     // If current annotation has file settings, reload and apply them immediately
     if (settings?.[this.selectedAnnotation]) {

--- a/packages/utils/src/parquet/bundle-writer.test.ts
+++ b/packages/utils/src/parquet/bundle-writer.test.ts
@@ -45,29 +45,31 @@ const createMockVisualizationData = (): VisualizationData => ({
 });
 
 const createMockSettings = (): BundleSettings => ({
-  organism: {
-    maxVisibleValues: 10,
-    includeShapes: true,
-    shapeSize: 24,
-    sortMode: 'size-desc',
-    hiddenValues: [],
-    categories: {
-      human: { zOrder: 0, color: '#ff0000', shape: 'circle' },
-      mouse: { zOrder: 1, color: '#00ff00', shape: 'square' },
+  legendSettings: {
+    organism: {
+      maxVisibleValues: 10,
+      includeShapes: true,
+      shapeSize: 24,
+      sortMode: 'size-desc',
+      hiddenValues: [],
+      categories: {
+        human: { zOrder: 0, color: '#ff0000', shape: 'circle' },
+        mouse: { zOrder: 1, color: '#00ff00', shape: 'square' },
+      },
+      enableDuplicateStackUI: false,
+      selectedPaletteId: 'kellys',
     },
-    enableDuplicateStackUI: false,
   },
-  family: {
-    maxVisibleValues: 15,
-    includeShapes: false,
-    shapeSize: 20,
-    sortMode: 'alpha-asc',
-    hiddenValues: ['kinase'],
-    categories: {
-      kinase: { zOrder: 1, color: '#0000ff', shape: 'diamond' },
-      protease: { zOrder: 0, color: '#ffff00', shape: 'triangle-up' },
+  exportOptions: {
+    organism: {
+      imageWidth: 2048,
+      imageHeight: 1024,
+      lockAspectRatio: true,
+      legendWidthPercent: 25,
+      legendFontSizePx: 24,
+      includeLegendSettings: true,
+      includeExportOptions: true,
     },
-    enableDuplicateStackUI: true,
   },
 });
 
@@ -123,7 +125,7 @@ describe('bundle-writer', () => {
 
       const buffer = createParquetBundle(data, {
         includeSettings: true,
-        settings: {},
+        settings: { legendSettings: {}, exportOptions: {} },
       });
 
       const uint8Array = new Uint8Array(buffer);

--- a/packages/utils/src/parquet/bundle-writer.ts
+++ b/packages/utils/src/parquet/bundle-writer.ts
@@ -143,6 +143,17 @@ function createSettingsParquet(settings: BundleSettings): ArrayBuffer {
   return parquetWriteBuffer({ columnData });
 }
 
+function hasBundleSettings(settings: BundleSettings | undefined): settings is BundleSettings {
+  if (!settings) {
+    return false;
+  }
+
+  return (
+    Object.keys(settings.legendSettings).length > 0 ||
+    Object.keys(settings.exportOptions).length > 0
+  );
+}
+
 /**
  * Concatenate multiple ArrayBuffers with delimiters.
  */
@@ -174,9 +185,9 @@ function concatenateBuffers(buffers: ArrayBuffer[], delimiter: Uint8Array): Arra
 }
 
 export interface CreateBundleOptions {
-  /** Include legend settings in the bundle (4-part format) */
+  /** Include persisted settings in the bundle (4-part format) */
   includeSettings?: boolean;
-  /** Legend settings to include (required if includeSettings is true) */
+  /** Persisted settings to include (required if includeSettings is true) */
   settings?: BundleSettings;
 }
 
@@ -201,7 +212,7 @@ export function createParquetBundle(
   const buffers: ArrayBuffer[] = [annotationsBuffer, metadataBuffer, projectionsBuffer];
 
   // Optionally add settings as 4th part
-  if (includeSettings && settings && Object.keys(settings).length > 0) {
+  if (includeSettings && hasBundleSettings(settings)) {
     const settingsBuffer = createSettingsParquet(settings);
     buffers.push(settingsBuffer);
   }

--- a/packages/utils/src/parquet/index.ts
+++ b/packages/utils/src/parquet/index.ts
@@ -23,14 +23,24 @@ export { sanitizeValue, bigIntReplacer } from './bigint-utils';
 export {
   isValidLegendSettings,
   isValidBundleSettings,
+  isNormalizedBundleSettings,
+  isLegacyBundleSettings,
   isValidPersistedCategoryData,
+  isValidPersistedExportOptions,
+  isValidLegendSettingsMap,
+  isValidExportOptionsMap,
   isValidSortMode,
+  normalizeBundleSettings,
 } from './settings-validation';
 
 // Types
 export type {
   BundleSettings,
+  ExportOptionsMap,
+  LegacyBundleSettings,
   LegendPersistedSettings,
+  LegendSettingsMap,
+  PersistedExportOptions,
   PersistedCategoryData,
   LegendSortMode,
 } from '../types';

--- a/packages/utils/src/parquet/settings-validation.test.ts
+++ b/packages/utils/src/parquet/settings-validation.test.ts
@@ -1,28 +1,56 @@
 import { describe, it, expect } from 'vitest';
 import {
-  isValidLegendSettings,
+  isLegacyBundleSettings,
+  isNormalizedBundleSettings,
   isValidBundleSettings,
+  isValidLegendSettings,
   isValidPersistedCategoryData,
+  isValidPersistedExportOptions,
   isValidSortMode,
+  normalizeBundleSettings,
 } from './settings-validation';
-import type { LegendPersistedSettings, BundleSettings } from '../types';
+import type {
+  BundleSettings,
+  LegacyBundleSettings,
+  LegendPersistedSettings,
+  PersistedExportOptions,
+} from '../types';
+
+const createValidLegendSettings = (): LegendPersistedSettings => ({
+  maxVisibleValues: 10,
+  includeShapes: true,
+  shapeSize: 24,
+  sortMode: 'size-desc',
+  hiddenValues: ['unknown'],
+  categories: {
+    human: { zOrder: 0, color: '#ff0000', shape: 'circle' },
+  },
+  enableDuplicateStackUI: false,
+  selectedPaletteId: 'kellys',
+});
+
+const createValidExportOptions = (): PersistedExportOptions => ({
+  imageWidth: 2048,
+  imageHeight: 1024,
+  lockAspectRatio: true,
+  legendWidthPercent: 25,
+  legendFontSizePx: 24,
+  includeLegendSettings: true,
+  includeExportOptions: true,
+});
+
+const createNormalizedBundleSettings = (): BundleSettings => ({
+  legendSettings: {
+    organism: createValidLegendSettings(),
+  },
+  exportOptions: {
+    organism: createValidExportOptions(),
+  },
+});
 
 describe('settings-validation', () => {
-  // Helper to create a valid settings object
-  const createValidSettings = (): LegendPersistedSettings => ({
-    maxVisibleValues: 10,
-    includeShapes: true,
-    shapeSize: 24,
-    sortMode: 'size-desc',
-    hiddenValues: ['unknown'],
-    categories: {
-      human: { zOrder: 0, color: '#ff0000', shape: 'circle' },
-    },
-    enableDuplicateStackUI: false,
-  });
-
   describe('isValidSortMode', () => {
-    it('should accept valid sort modes', () => {
+    it('accepts valid sort modes', () => {
       expect(isValidSortMode('size-asc')).toBe(true);
       expect(isValidSortMode('size-desc')).toBe(true);
       expect(isValidSortMode('alpha-asc')).toBe(true);
@@ -31,231 +59,114 @@ describe('settings-validation', () => {
       expect(isValidSortMode('manual-reverse')).toBe(true);
     });
 
-    it('should reject invalid sort modes', () => {
+    it('rejects invalid sort modes', () => {
       expect(isValidSortMode('invalid')).toBe(false);
-      expect(isValidSortMode('')).toBe(false);
       expect(isValidSortMode(123)).toBe(false);
       expect(isValidSortMode(null)).toBe(false);
-      expect(isValidSortMode(undefined)).toBe(false);
     });
   });
 
   describe('isValidPersistedCategoryData', () => {
-    it('should accept valid category data', () => {
+    it('accepts valid category data', () => {
       expect(isValidPersistedCategoryData({ zOrder: 0, color: '#ff0000', shape: 'circle' })).toBe(
         true,
       );
-      expect(isValidPersistedCategoryData({ zOrder: 100, color: 'red', shape: 'square' })).toBe(
-        true,
-      );
     });
 
-    it('should reject invalid category data', () => {
-      expect(isValidPersistedCategoryData(null)).toBe(false);
-      expect(isValidPersistedCategoryData(undefined)).toBe(false);
-      expect(isValidPersistedCategoryData('string')).toBe(false);
-      expect(isValidPersistedCategoryData(123)).toBe(false);
-      expect(isValidPersistedCategoryData([])).toBe(false);
-    });
-
-    it('should reject category data with missing fields', () => {
-      expect(isValidPersistedCategoryData({ zOrder: 0, color: '#ff0000' })).toBe(false);
-      expect(isValidPersistedCategoryData({ zOrder: 0, shape: 'circle' })).toBe(false);
-      expect(isValidPersistedCategoryData({ color: '#ff0000', shape: 'circle' })).toBe(false);
-    });
-
-    it('should reject category data with wrong field types', () => {
+    it('rejects invalid category data', () => {
       expect(isValidPersistedCategoryData({ zOrder: '0', color: '#ff0000', shape: 'circle' })).toBe(
         false,
       );
-      expect(isValidPersistedCategoryData({ zOrder: 0, color: 123, shape: 'circle' })).toBe(false);
-      expect(isValidPersistedCategoryData({ zOrder: 0, color: '#ff0000', shape: 123 })).toBe(false);
+      expect(isValidPersistedCategoryData(null)).toBe(false);
     });
   });
 
   describe('isValidLegendSettings', () => {
-    it('should accept valid settings', () => {
-      expect(isValidLegendSettings(createValidSettings())).toBe(true);
+    it('accepts valid settings', () => {
+      expect(isValidLegendSettings(createValidLegendSettings())).toBe(true);
     });
 
-    it('should accept settings with empty categories', () => {
-      const settings = createValidSettings();
-      settings.categories = {};
-      expect(isValidLegendSettings(settings)).toBe(true);
-    });
-
-    it('should accept settings with empty hiddenValues', () => {
-      const settings = createValidSettings();
-      settings.hiddenValues = [];
-      expect(isValidLegendSettings(settings)).toBe(true);
-    });
-
-    it('should accept settings with extra/unknown fields (forward compatibility)', () => {
-      const settings = {
-        ...createValidSettings(),
-        unknownField: 'value',
-        anotherNewField: { nested: true },
-        futureFeature: 42,
-      };
-      expect(isValidLegendSettings(settings)).toBe(true);
-    });
-
-    it('should reject null or undefined', () => {
-      expect(isValidLegendSettings(null)).toBe(false);
-      expect(isValidLegendSettings(undefined)).toBe(false);
-    });
-
-    it('should reject non-objects', () => {
-      expect(isValidLegendSettings('string')).toBe(false);
-      expect(isValidLegendSettings(123)).toBe(false);
-      expect(isValidLegendSettings([])).toBe(false);
-      expect(isValidLegendSettings(true)).toBe(false);
-    });
-
-    it('should reject settings with wrong maxVisibleValues type', () => {
-      const settings = { ...createValidSettings(), maxVisibleValues: '10' };
-      expect(isValidLegendSettings(settings)).toBe(false);
-    });
-
-    it('should reject settings with wrong includeShapes type', () => {
-      const settings = { ...createValidSettings(), includeShapes: 'true' };
-      expect(isValidLegendSettings(settings)).toBe(false);
-    });
-
-    it('should reject settings with wrong shapeSize type', () => {
-      const settings = { ...createValidSettings(), shapeSize: '24' };
-      expect(isValidLegendSettings(settings)).toBe(false);
-    });
-
-    it('should reject settings with invalid sortMode', () => {
-      const settings = { ...createValidSettings(), sortMode: 'invalid' };
-      expect(isValidLegendSettings(settings)).toBe(false);
-    });
-
-    it('should reject settings with wrong enableDuplicateStackUI type', () => {
-      const settings = { ...createValidSettings(), enableDuplicateStackUI: 'false' };
-      expect(isValidLegendSettings(settings)).toBe(false);
-    });
-
-    it('should reject settings with non-array hiddenValues', () => {
-      const settings = { ...createValidSettings(), hiddenValues: 'unknown' };
-      expect(isValidLegendSettings(settings)).toBe(false);
-    });
-
-    it('should reject settings with non-string items in hiddenValues', () => {
-      const settings = { ...createValidSettings(), hiddenValues: [123, 'valid'] };
-      expect(isValidLegendSettings(settings)).toBe(false);
-    });
-
-    it('should reject settings with non-object categories', () => {
-      const settings = { ...createValidSettings(), categories: 'invalid' };
-      expect(isValidLegendSettings(settings)).toBe(false);
-    });
-
-    it('should reject settings with array categories', () => {
-      const settings = { ...createValidSettings(), categories: [] };
-      expect(isValidLegendSettings(settings)).toBe(false);
-    });
-
-    it('should reject settings with invalid category data', () => {
-      const settings = {
-        ...createValidSettings(),
-        categories: {
-          human: { zOrder: 0, color: '#ff0000' }, // missing shape
-        },
-      };
-      expect(isValidLegendSettings(settings)).toBe(false);
-    });
-
-    it('should reject partially valid settings (missing required fields)', () => {
-      // Missing maxVisibleValues
+    it('accepts extra fields for forward compatibility', () => {
       expect(
         isValidLegendSettings({
-          includeShapes: true,
-          shapeSize: 24,
-          sortMode: 'size-desc',
-          hiddenValues: [],
-          categories: {},
-          enableDuplicateStackUI: false,
+          ...createValidLegendSettings(),
+          futureField: { enabled: true },
         }),
-      ).toBe(false);
+      ).toBe(true);
+    });
 
-      // Missing sortMode
+    it('rejects invalid settings', () => {
       expect(
         isValidLegendSettings({
-          maxVisibleValues: 10,
-          includeShapes: true,
-          shapeSize: 24,
-          hiddenValues: [],
-          categories: {},
-          enableDuplicateStackUI: false,
-        }),
-      ).toBe(false);
-
-      // Missing categories
-      expect(
-        isValidLegendSettings({
-          maxVisibleValues: 10,
-          includeShapes: true,
-          shapeSize: 24,
-          sortMode: 'size-desc',
-          hiddenValues: [],
-          enableDuplicateStackUI: false,
+          ...createValidLegendSettings(),
+          categories: [],
         }),
       ).toBe(false);
     });
   });
 
-  describe('isValidBundleSettings', () => {
-    it('should accept valid bundle settings', () => {
-      const bundleSettings: BundleSettings = {
-        organism: createValidSettings(),
-        family: createValidSettings(),
+  describe('isValidPersistedExportOptions', () => {
+    it('accepts valid export options', () => {
+      expect(isValidPersistedExportOptions(createValidExportOptions())).toBe(true);
+    });
+
+    it('rejects invalid export options', () => {
+      expect(
+        isValidPersistedExportOptions({
+          ...createValidExportOptions(),
+          includeExportOptions: 'yes',
+        }),
+      ).toBe(false);
+      expect(isValidPersistedExportOptions(null)).toBe(false);
+    });
+  });
+
+  describe('bundle settings formats', () => {
+    it('accepts normalized bundle settings', () => {
+      const settings = createNormalizedBundleSettings();
+      expect(isNormalizedBundleSettings(settings)).toBe(true);
+      expect(isValidBundleSettings(settings)).toBe(true);
+    });
+
+    it('accepts legacy legend-only bundle settings', () => {
+      const legacy: LegacyBundleSettings = {
+        organism: createValidLegendSettings(),
+        family: createValidLegendSettings(),
       };
-      expect(isValidBundleSettings(bundleSettings)).toBe(true);
+
+      expect(isLegacyBundleSettings(legacy)).toBe(true);
+      expect(isValidBundleSettings(legacy)).toBe(true);
     });
 
-    it('should accept empty bundle settings', () => {
-      expect(isValidBundleSettings({})).toBe(true);
+    it('rejects malformed normalized bundle settings', () => {
+      expect(
+        isNormalizedBundleSettings({
+          legendSettings: { organism: createValidLegendSettings() },
+          exportOptions: { organism: { bad: true } },
+        }),
+      ).toBe(false);
+      expect(isValidBundleSettings({ legendSettings: [], exportOptions: {} })).toBe(false);
     });
 
-    it('should accept settings with extra/unknown fields in individual settings', () => {
-      const bundleSettings = {
-        organism: {
-          ...createValidSettings(),
-          unknownField: 'value',
-        },
+    it('normalizes legacy settings to the current shape', () => {
+      const legacy: LegacyBundleSettings = {
+        organism: createValidLegendSettings(),
       };
-      expect(isValidBundleSettings(bundleSettings)).toBe(true);
+
+      expect(normalizeBundleSettings(legacy)).toEqual({
+        legendSettings: legacy,
+        exportOptions: {},
+      });
     });
 
-    it('should reject null or undefined', () => {
-      expect(isValidBundleSettings(null)).toBe(false);
-      expect(isValidBundleSettings(undefined)).toBe(false);
+    it('returns normalized settings unchanged', () => {
+      const settings = createNormalizedBundleSettings();
+      expect(normalizeBundleSettings(settings)).toEqual(settings);
     });
 
-    it('should reject non-objects', () => {
-      expect(isValidBundleSettings('string')).toBe(false);
-      expect(isValidBundleSettings(123)).toBe(false);
-      expect(isValidBundleSettings([])).toBe(false);
-    });
-
-    it('should reject bundle settings with invalid legend settings', () => {
-      const bundleSettings = {
-        organism: createValidSettings(),
-        family: { invalid: true }, // Not a valid LegendPersistedSettings
-      };
-      expect(isValidBundleSettings(bundleSettings)).toBe(false);
-    });
-
-    it('should reject bundle settings with partially valid legend settings', () => {
-      const bundleSettings = {
-        organism: {
-          maxVisibleValues: 10,
-          // Missing other required fields
-        },
-      };
-      expect(isValidBundleSettings(bundleSettings)).toBe(false);
+    it('returns null for invalid settings', () => {
+      expect(normalizeBundleSettings({ nope: true })).toBeNull();
+      expect(normalizeBundleSettings(null)).toBeNull();
     });
   });
 });

--- a/packages/utils/src/parquet/settings-validation.ts
+++ b/packages/utils/src/parquet/settings-validation.ts
@@ -1,4 +1,13 @@
-import type { LegendPersistedSettings, PersistedCategoryData, LegendSortMode } from '../types';
+import type {
+  BundleSettings,
+  ExportOptionsMap,
+  LegacyBundleSettings,
+  LegendPersistedSettings,
+  LegendSettingsMap,
+  PersistedCategoryData,
+  PersistedExportOptions,
+  LegendSortMode,
+} from '../types';
 
 /**
  * Valid sort mode values for legend persistence.
@@ -70,22 +79,98 @@ export function isValidLegendSettings(obj: unknown): obj is LegendPersistedSetti
 }
 
 /**
- * Validates a BundleSettings object (annotation name -> legend settings map).
- * Returns true if all values are valid LegendPersistedSettings.
+ * Validates that a value is a valid PersistedExportOptions object.
  */
-export function isValidBundleSettings(
+export function isValidPersistedExportOptions(obj: unknown): obj is PersistedExportOptions {
+  if (typeof obj !== 'object' || obj === null) return false;
+
+  const settings = obj as Record<string, unknown>;
+  return (
+    typeof settings.imageWidth === 'number' &&
+    typeof settings.imageHeight === 'number' &&
+    typeof settings.lockAspectRatio === 'boolean' &&
+    typeof settings.legendWidthPercent === 'number' &&
+    typeof settings.legendFontSizePx === 'number' &&
+    typeof settings.includeLegendSettings === 'boolean' &&
+    typeof settings.includeExportOptions === 'boolean'
+  );
+}
+
+function isValidSettingsMap<Value>(
   obj: unknown,
-): obj is Record<string, LegendPersistedSettings> {
+  validator: (value: unknown) => value is Value,
+): obj is Record<string, Value> {
   if (typeof obj !== 'object' || obj === null || Array.isArray(obj)) {
     return false;
   }
 
-  const settings = obj as Record<string, unknown>;
-  for (const key of Object.keys(settings)) {
-    if (!isValidLegendSettings(settings[key])) {
+  const values = obj as Record<string, unknown>;
+  for (const key of Object.keys(values)) {
+    if (!validator(values[key])) {
       return false;
     }
   }
 
   return true;
+}
+
+/**
+ * Validates a legend settings map (annotation -> legend settings).
+ */
+export function isValidLegendSettingsMap(obj: unknown): obj is LegendSettingsMap {
+  return isValidSettingsMap(obj, isValidLegendSettings);
+}
+
+/**
+ * Validates an export options map (annotation -> export options).
+ */
+export function isValidExportOptionsMap(obj: unknown): obj is ExportOptionsMap {
+  return isValidSettingsMap(obj, isValidPersistedExportOptions);
+}
+
+/**
+ * Detects the legacy bundle settings format that stored only legend settings.
+ */
+export function isLegacyBundleSettings(obj: unknown): obj is LegacyBundleSettings {
+  return isValidLegendSettingsMap(obj);
+}
+
+/**
+ * Validates the current normalized bundle settings object.
+ */
+export function isNormalizedBundleSettings(obj: unknown): obj is BundleSettings {
+  if (typeof obj !== 'object' || obj === null || Array.isArray(obj)) {
+    return false;
+  }
+
+  const settings = obj as Record<string, unknown>;
+  return (
+    isValidLegendSettingsMap(settings.legendSettings) &&
+    isValidExportOptionsMap(settings.exportOptions)
+  );
+}
+
+/**
+ * Validates bundle settings in either the current or legacy format.
+ */
+export function isValidBundleSettings(obj: unknown): obj is BundleSettings | LegacyBundleSettings {
+  return isNormalizedBundleSettings(obj) || isLegacyBundleSettings(obj);
+}
+
+/**
+ * Normalize bundle settings to the current format.
+ */
+export function normalizeBundleSettings(obj: unknown): BundleSettings | null {
+  if (isNormalizedBundleSettings(obj)) {
+    return obj;
+  }
+
+  if (isLegacyBundleSettings(obj)) {
+    return {
+      legendSettings: obj,
+      exportOptions: {},
+    };
+  }
+
+  return null;
 }

--- a/packages/utils/src/types.ts
+++ b/packages/utils/src/types.ts
@@ -88,6 +88,31 @@ export interface LegendPersistedSettings {
 }
 
 /**
- * Bundle settings map: annotation name -> legend settings for that annotation.
+ * Export settings persisted per dataset + annotation.
  */
-export type BundleSettings = Record<string, LegendPersistedSettings>;
+export interface PersistedExportOptions {
+  imageWidth: number;
+  imageHeight: number;
+  lockAspectRatio: boolean;
+  legendWidthPercent: number;
+  legendFontSizePx: number;
+  includeLegendSettings: boolean;
+  includeExportOptions: boolean;
+}
+
+export type LegendSettingsMap = Record<string, LegendPersistedSettings>;
+
+export type ExportOptionsMap = Record<string, PersistedExportOptions>;
+
+/**
+ * Current bundle settings format.
+ */
+export interface BundleSettings {
+  legendSettings: LegendSettingsMap;
+  exportOptions: ExportOptionsMap;
+}
+
+/**
+ * Legacy bundle settings format used before export options were added.
+ */
+export type LegacyBundleSettings = LegendSettingsMap;


### PR DESCRIPTION
Closes #149.

## Summary
Users could already persist legend settings per dataset hash and annotation, and those settings could optionally be embedded into exported parquet bundles. Export options in the control bar, however, were not persisted with the same fidelity. That meant users had to repeatedly re-enter width, height, aspect-ratio, and legend export settings when switching annotations or reloading data, even though those choices are part of the same export workflow.

## Root cause
The persistence model only covered legend state. Export-option state lived in the control bar and was handled as transient UI state, so it was not represented in the shared bundle settings schema, it was not validated or normalized during bundle import, and it did not have its own dataset-hash-plus-annotation local storage controller. After the first implementation pass, export-option persistence also diverged from legend behavior by writing local storage too eagerly during hydration and annotation switching.

## Fix
This change introduces a normalized bundle settings payload that carries both legend settings and export options while remaining backward compatible with older legend-only bundles. Export options are now persisted per dataset hash and annotation, imported and exported alongside legend settings, and wired through the demo app so both settings families survive bundle round-trips.

The control-bar persistence behavior now mirrors the legend model closely. Hydration paths are read-only, annotation switches no longer create storage entries on their own, explicit user actions save through a shared helper, bundle imports materialize imported export options into local storage immediately, and parquet export includes the current annotation's live export settings together with the stored settings for sibling annotations.

## Validation
I validated the change with the repository checks and the new targeted persistence tests:

- `pnpm --filter @protspace/utils test:ci`
- `pnpm --filter @protspace/core test:ci`
- `pnpm type-check`
- pre-commit hooks also re-ran `turbo type-check` and `turbo test:ci` successfully during commit creation
