### PR TITLE
fix(scatter-plot): extend brush extent to full canvas for edge selection

### DIFF
--- a/packages/core/src/components/scatter-plot/scatter-plot.ts
+++ b/packages/core/src/components/scatter-plot/scatter-plot.ts
@@ -746,8 +746,8 @@ export class ProtspaceScatterplot extends LitElement {
         // Keep the UX simple: no resize handles, just drag a rectangle.
         .handleSize(0)
         .extent([
-          [config.margin.left, config.margin.top],
-          [config.width - config.margin.right, config.height - config.margin.bottom],
+          [0, 0],
+          [config.width, config.height],
         ])
         .on('end', (event) => this._handleBrushEnd(event));
 


### PR DESCRIPTION
## Summary

- Expand the D3 brush .extent() from the margin-constrained plot area to the full SVG canvas ([0, 0] to [width, height])
- This allows users to draw selection rectangles beyond the data min/max boundaries, making it easy to capture points near the edges of the embedding space

## Root cause

The brush extent was set to [margin.left, margin.top] to [width - margin.right, height - margin.bottom], which clamped the draggable area to the plot margins. D3 brush automatically constrains selection coordinates to its extent, so edge points could not be reached.

## Verification

- 534 unit tests pass
- 29 Playwright e2e tests pass
- pnpm precommit (format + lint + type-check + knip) clean
- Brush coordinates and scale coordinates remain in the same local coordinate system (the brush group pre-transform space), so zoom interactions are unaffected

Fixes #189