### PR TITLE
fix(core): clear scatterplot isolation state on dataset load

### DIFF
--- a/app/src/demo/main.ts
+++ b/app/src/demo/main.ts
@@ -202,6 +202,7 @@ export async function initializeDemo() {
 
         // Update scatterplot with new data
         console.log('📊 Updating scatterplot with new data...');
+        plotElement.clearIsolationState();
         const oldData = plotElement.data;
         plotElement.data = newData;
         plotElement.requestUpdate('data', oldData);

--- a/packages/core/src/components/scatter-plot/scatter-plot.ts
+++ b/packages/core/src/components/scatter-plot/scatter-plot.ts
@@ -2055,8 +2055,7 @@ export class ProtspaceScatterplot extends LitElement {
   }
 
   resetIsolation() {
-    this._isolationHistory = [];
-    this._isolationMode = false;
+    this.clearIsolationState();
     this.selectedProteinIds = [];
 
     // Invalidate data ref so _processData takes the full rebuild path

--- a/packages/core/src/components/scatter-plot/scatter-plot.ts
+++ b/packages/core/src/components/scatter-plot/scatter-plot.ts
@@ -2048,6 +2048,12 @@ export class ProtspaceScatterplot extends LitElement {
     }
   }
 
+  /** Clear isolation state without reprocessing. Use before loading new data. */
+  clearIsolationState(): void {
+    this._isolationHistory = [];
+    this._isolationMode = false;
+  }
+
   resetIsolation() {
     this._isolationHistory = [];
     this._isolationMode = false;


### PR DESCRIPTION
## Summary
- Adds `clearIsolationState()` to scatterplot and calls it before loading new data
- Fixes legend rendering empty when switching datasets while in isolation mode

Closes #206