### PR TITLE
fix(core): reject files without .parquetbundle extension before loading

### DIFF
--- a/packages/core/src/components/data-loader/data-loader.ts
+++ b/packages/core/src/components/data-loader/data-loader.ts
@@ -9,6 +9,7 @@ import { readFileOptimized } from './utils/file-io';
 import { extractRowsFromParquetBundle } from './utils/bundle';
 import { convertParquetToVisualizationDataOptimized } from './utils/conversion';
 import {
+  assertValidFileExtension,
   assertWithinFileSizeLimit,
   assertValidParquetMagic,
   validateRowsBasic,
@@ -85,7 +86,7 @@ export class DataLoader extends LitElement {
       <input
         type="file"
         class="hidden-input"
-        accept=".parquet,.parquetbundle"
+        accept=".parquetbundle"
         @change=${this.handleFileSelect}
         style="display:none"
       />
@@ -147,6 +148,17 @@ export class DataLoader extends LitElement {
    */
   async loadFromFile(file: File, options?: { source?: DataLoadSource }) {
     const source: DataLoadSource = options?.source ?? 'user';
+
+    // Validate extension before any loading UI appears
+    try {
+      assertValidFileExtension(file.name);
+    } catch (error) {
+      const originalError = error instanceof Error ? error : new Error(String(error));
+      this.error = originalError.message;
+      this.dispatchError(this.error, originalError);
+      return;
+    }
+
     this.setLoading(true);
     this.error = null;
     this.dispatchLoadingStart();

--- a/packages/core/src/components/data-loader/utils/validation.ts
+++ b/packages/core/src/components/data-loader/utils/validation.ts
@@ -25,6 +25,14 @@ export function assertValidParquetMagic(buffer: ArrayBuffer): void {
   }
 }
 
+const ACCEPTED_EXTENSION = '.parquetbundle';
+
+export function assertValidFileExtension(fileName: string): void {
+  if (!fileName.endsWith(ACCEPTED_EXTENSION)) {
+    throw new Error(`Unsupported file format. Please upload a ${ACCEPTED_EXTENSION} file.`);
+  }
+}
+
 export function assertWithinFileSizeLimit(
   sizeBytes: number,
   maxSizeBytes = MAX_FILE_SIZE_BYTES_DEFAULT,


### PR DESCRIPTION
## Summary
- Validate file extension before showing any loading UI — files without `.parquetbundle` extension are rejected immediately with an error notification
- Update file picker to only accept `.parquetbundle` files

Closes #209