### PR TITLE
feat(tooltip): add headers for bitscore and evidence annotations

### DIFF
--- a/packages/core/src/components/scatter-plot/protein-tooltip-helpers.test.ts
+++ b/packages/core/src/components/scatter-plot/protein-tooltip-helpers.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from 'vitest';
 import { LEGEND_VALUES } from '@protspace/utils';
 import {
   filterAnnotationValues,
+  getAnnotationHeaderType,
   getGeneName,
   getProteinName,
   getUniprotKbId,
@@ -102,5 +103,47 @@ describe('getUniprotKbId', () => {
 
   it('joins multiple IDs', () => {
     expect(getUniprotKbId({ uniprot_kb_id: ['P04637', 'Q9NZC2'] })).toBe('P04637, Q9NZC2');
+  });
+});
+
+describe('getAnnotationHeaderType', () => {
+  it('returns null when both scores and evidence are empty', () => {
+    expect(getAnnotationHeaderType([], [])).toBeNull();
+  });
+
+  it('returns null when scores are all null and evidence are all null', () => {
+    expect(getAnnotationHeaderType([null, null], [null, null])).toBeNull();
+  });
+
+  it('returns "bitscore" when scores contain non-empty arrays', () => {
+    expect(getAnnotationHeaderType([[1.5e-10]], [null])).toBe('bitscore');
+  });
+
+  it('returns "bitscore" when scores have multiple values', () => {
+    expect(getAnnotationHeaderType([[1.5e-10, 2.3e-5]], [null])).toBe('bitscore');
+  });
+
+  it('returns "evidence" when evidence codes are present but no scores', () => {
+    expect(getAnnotationHeaderType([null], ['ECO:0000269'])).toBe('evidence');
+  });
+
+  it('returns "evidence" for short evidence codes like EXP', () => {
+    expect(getAnnotationHeaderType([], ['EXP'])).toBe('evidence');
+  });
+
+  it('returns "bitscore" when both scores and evidence are present (scores take priority)', () => {
+    expect(getAnnotationHeaderType([[42]], ['EXP'])).toBe('bitscore');
+  });
+
+  it('returns null when scores are empty arrays', () => {
+    expect(getAnnotationHeaderType([[]], [])).toBeNull();
+  });
+
+  it('returns "bitscore" when at least one entry has scores among nulls', () => {
+    expect(getAnnotationHeaderType([null, [0.5], null], [null, null, null])).toBe('bitscore');
+  });
+
+  it('returns "evidence" when at least one entry has evidence among nulls', () => {
+    expect(getAnnotationHeaderType([null, null], [null, 'IDA'])).toBe('evidence');
   });
 });

--- a/packages/core/src/components/scatter-plot/protein-tooltip-helpers.ts
+++ b/packages/core/src/components/scatter-plot/protein-tooltip-helpers.ts
@@ -38,3 +38,17 @@ export function getProteinName(annotationValues: Record<string, string[]>): stri
 export function getUniprotKbId(annotationValues: Record<string, string[]>): string | null {
   return filterAnnotationValues(annotationValues?.uniprot_kb_id);
 }
+
+/**
+ * Determine the annotation header type based on available scores and evidence.
+ * Returns 'bitscore' if any scores are present, 'evidence' if any evidence codes
+ * are present (but no scores), or null if neither exists.
+ */
+export function getAnnotationHeaderType(
+  scores: (number[] | null)[],
+  evidence: (string | null)[],
+): 'bitscore' | 'evidence' | null {
+  if (scores.some((s) => Array.isArray(s) && s.length > 0)) return 'bitscore';
+  if (evidence.some((e) => e != null)) return 'evidence';
+  return null;
+}

--- a/packages/core/src/components/scatter-plot/protein-tooltip.styles.ts
+++ b/packages/core/src/components/scatter-plot/protein-tooltip.styles.ts
@@ -105,6 +105,17 @@ export const proteinTooltipStyles = css`
     gap: 0.25rem;
   }
 
+  .tooltip-annotation-header {
+    font-size: 0.625rem;
+    font-weight: 600;
+    color: #94a3b8;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    display: flex;
+    justify-content: space-between;
+    margin-bottom: 0.125rem;
+  }
+
   .tooltip-annotation {
     font-size: 0.75rem;
     color: #64748b;

--- a/packages/core/src/components/scatter-plot/protein-tooltip.ts
+++ b/packages/core/src/components/scatter-plot/protein-tooltip.ts
@@ -3,7 +3,17 @@ import { customElement, property } from 'lit/decorators.js';
 import { toDisplayValue, toInternalValue } from '@protspace/utils';
 import type { PlotDataPoint } from '@protspace/utils';
 import { proteinTooltipStyles } from './protein-tooltip.styles';
-import { getGeneName, getProteinName, getUniprotKbId } from './protein-tooltip-helpers';
+import {
+  getAnnotationHeaderType,
+  getGeneName,
+  getProteinName,
+  getUniprotKbId,
+} from './protein-tooltip-helpers';
+
+const ANNOTATION_HEADER_LABELS: Record<string, string> = {
+  bitscore: 'Bitscore',
+  evidence: 'Evidence',
+};
 
 const SUPERSCRIPT_DIGITS: Record<string, string> = {
   '0': '\u2070',
@@ -84,6 +94,17 @@ class ProtspaceProteinTooltip extends LitElement {
               </div>`
             : ''}
           <div class="tooltip-annotations">
+            ${(() => {
+              const headerType = getAnnotationHeaderType(
+                tooltipAnnotationScores,
+                tooltipAnnotationEvidence,
+              );
+              return html`<div class="tooltip-annotation-header">
+                <span>${this.selectedAnnotation}</span>${headerType
+                  ? html`<span>${ANNOTATION_HEADER_LABELS[headerType]}</span>`
+                  : ''}
+              </div>`;
+            })()}
             ${tooltipAnnotationValues.map((value, idx) => {
               const scores = tooltipAnnotationScores[idx];
               const evidence = tooltipAnnotationEvidence[idx];

--- a/packages/core/src/components/scatter-plot/protein-tooltip.ts
+++ b/packages/core/src/components/scatter-plot/protein-tooltip.ts
@@ -10,7 +10,7 @@ import {
   getUniprotKbId,
 } from './protein-tooltip-helpers';
 
-const ANNOTATION_HEADER_LABELS: Record<string, string> = {
+const ANNOTATION_HEADER_LABELS: Record<'bitscore' | 'evidence', string> = {
   bitscore: 'Bitscore',
   evidence: 'Evidence',
 };
@@ -65,6 +65,7 @@ class ProtspaceProteinTooltip extends LitElement {
     const tooltipAnnotationScores = this.protein.annotationScores?.[this.selectedAnnotation] ?? [];
     const tooltipAnnotationEvidence =
       this.protein.annotationEvidence?.[this.selectedAnnotation] ?? [];
+    const headerType = getAnnotationHeaderType(tooltipAnnotationScores, tooltipAnnotationEvidence);
 
     return html`
       <div class="tooltip">
@@ -94,17 +95,10 @@ class ProtspaceProteinTooltip extends LitElement {
               </div>`
             : ''}
           <div class="tooltip-annotations">
-            ${(() => {
-              const headerType = getAnnotationHeaderType(
-                tooltipAnnotationScores,
-                tooltipAnnotationEvidence,
-              );
-              return html`<div class="tooltip-annotation-header">
-                <span>${this.selectedAnnotation}</span>${headerType
-                  ? html`<span>${ANNOTATION_HEADER_LABELS[headerType]}</span>`
-                  : ''}
-              </div>`;
-            })()}
+            <div class="tooltip-annotation-header">
+              <span>${this.selectedAnnotation}</span>
+              ${headerType ? html`<span>${ANNOTATION_HEADER_LABELS[headerType]}</span>` : ''}
+            </div>
             ${tooltipAnnotationValues.map((value, idx) => {
               const scores = tooltipAnnotationScores[idx];
               const evidence = tooltipAnnotationEvidence[idx];


### PR DESCRIPTION
## Summary
- Adds subtle column headers ("Bitscore" / "Evidence") to protein tooltip annotations when scores or evidence codes are present
- Uses the actual annotation name (e.g. "EC", "CATH") as the left column header
- Extracts header logic into a testable `getAnnotationHeaderType()` helper with unit tests

Closes #165

🤖 Generated with [Claude Code](https://claude.com/claude-code)