### PR TITLE
fix(publish): review followup — lifecycle, validator, area cap, fonts

### DIFF
--- a/packages/core/src/components/publish/publish-compositor.test.ts
+++ b/packages/core/src/components/publish/publish-compositor.test.ts
@@ -2,7 +2,12 @@
  * @vitest-environment jsdom
  */
 import { describe, it, expect } from 'vitest';
-import { computeLayout, computeInsetBoost, capturePlotCanvas } from './publish-compositor';
+import {
+  computeLayout,
+  computeInsetBoost,
+  capturePlotCanvas,
+  MAX_CANVAS_PIXELS,
+} from './publish-compositor';
 import type { LegendLayout } from './publish-state';
 
 function makeLegend(overrides: Partial<LegendLayout> = {}): LegendLayout {
@@ -298,6 +303,49 @@ describe('publish-compositor', () => {
         },
       ];
       expect(computeInsetBoost(insets)).toBe(1);
+    });
+
+    it('clamps boost so plotPixelArea * boost² stays under MAX_CANVAS_PIXELS', () => {
+      const insets = [
+        {
+          sourceRect: { x: 0, y: 0, w: 0.05, h: 0.05 },
+          targetRect: { x: 0.5, y: 0.5, w: 0.5, h: 0.5 },
+          border: 2,
+          connector: 'lines' as const,
+        },
+      ];
+      // Without area cap, this would return 4. A 6000×3000 plot (18M pixels)
+      // at boost=4 would need 18M × 16 = 288M pixels — over the cap.
+      const plotPixelArea = 6000 * 3000;
+      const boost = computeInsetBoost(insets, 4, plotPixelArea);
+      expect(boost).toBeLessThan(4);
+      expect(plotPixelArea * boost * boost).toBeLessThanOrEqual(MAX_CANVAS_PIXELS);
+    });
+
+    it('does not clamp below 1 even on huge plots', () => {
+      const insets = [
+        {
+          sourceRect: { x: 0, y: 0, w: 0.1, h: 0.1 },
+          targetRect: { x: 0.5, y: 0.5, w: 0.4, h: 0.4 },
+          border: 2,
+          connector: 'lines' as const,
+        },
+      ];
+      const huge = 50_000 * 50_000;
+      expect(computeInsetBoost(insets, 4, huge)).toBe(1);
+    });
+
+    it('keeps boost when plot area is within budget', () => {
+      const insets = [
+        {
+          sourceRect: { x: 0, y: 0, w: 0.1, h: 0.1 },
+          targetRect: { x: 0.5, y: 0.5, w: 0.3, h: 0.3 },
+          border: 2,
+          connector: 'lines' as const,
+        },
+      ];
+      // 1024×1024 ≈ 1M pixels; boost=3 → 9M, well under cap.
+      expect(computeInsetBoost(insets, 4, 1024 * 1024)).toBe(3);
     });
   });
 

--- a/packages/core/src/components/publish/publish-compositor.ts
+++ b/packages/core/src/components/publish/publish-compositor.ts
@@ -423,11 +423,26 @@ export function computeLayout(
 // ── Inset helpers ────────────────────────────────────────────────────
 
 /**
+ * Browsers cap canvas total area at roughly 16384² ≈ 268M pixels. Beyond that,
+ * `getContext('2d')` may return null or draw to a zero-sized canvas silently,
+ * yielding a blank export. We pick a conservative cap below the lowest known
+ * limit so the boosted capture stays well inside the safe envelope.
+ */
+export const MAX_CANVAS_PIXELS = 256_000_000;
+
+/**
  * Compute how much to boost the plot capture resolution so inset source
  * regions have enough pixels to fill their target rects without upscaling.
  * Returns 1 when there are no insets.
+ *
+ * If `plotPixelArea` is provided, the returned boost is also capped so that
+ * `plotPixelArea * boost²` stays under {@link MAX_CANVAS_PIXELS}.
  */
-export function computeInsetBoost(insets: readonly Inset[], maxBoost = 4): number {
+export function computeInsetBoost(
+  insets: readonly Inset[],
+  maxBoost = 4,
+  plotPixelArea?: number,
+): number {
   if (insets.length === 0) return 1;
   let maxZoom = 1;
   for (const inset of insets) {
@@ -435,7 +450,12 @@ export function computeInsetBoost(insets: readonly Inset[], maxBoost = 4): numbe
     const zy = inset.targetRect.h / inset.sourceRect.h;
     maxZoom = Math.max(maxZoom, zx, zy);
   }
-  return Math.min(Math.ceil(maxZoom), maxBoost);
+  let boost = Math.min(Math.ceil(maxZoom), maxBoost);
+  if (plotPixelArea && plotPixelArea > 0) {
+    const maxBoostByArea = Math.sqrt(MAX_CANVAS_PIXELS / plotPixelArea);
+    if (boost > maxBoostByArea) boost = Math.max(1, Math.floor(maxBoostByArea));
+  }
+  return boost;
 }
 
 // ── Inset rendering ──────────────────────────────────────────────────

--- a/packages/core/src/components/publish/publish-modal.ts
+++ b/packages/core/src/components/publish/publish-modal.ts
@@ -19,6 +19,7 @@ import {
   type Overlay,
   type Inset,
 } from './publish-state';
+import { validatePublishState } from './publish-state-validate';
 import { pxToMm, mmToPx } from './dimension-utils';
 import {
   capturePlotCanvas,
@@ -117,7 +118,12 @@ export class ProtspacePublishModal extends LitElement {
     super.connectedCallback();
     if (this.savedPublishState) {
       const defaults = createDefaultPublishState();
-      this._state = { ...defaults, ...this.savedPublishState } as PublishState;
+      const validated = validatePublishState(this.savedPublishState);
+      this._state = {
+        ...defaults,
+        ...validated,
+        legend: { ...defaults.legend, ...(validated.legend ?? {}) },
+      };
     } else {
       this._state = createDefaultPublishState();
     }
@@ -264,7 +270,7 @@ export class ProtspacePublishModal extends LitElement {
 
     // Boosted capture for crisp inset rendering
     let insetPlotCanvas: HTMLCanvasElement | undefined;
-    const boost = computeInsetBoost(s.insets);
+    const boost = computeInsetBoost(s.insets, 4, plotRect.w * plotRect.h);
     if (boost > 1) {
       const insetKey = `${plotRect.w * boost}x${plotRect.h * boost}`;
       if (insetKey !== this._insetCacheKey || !this._cachedInsetCanvas) {
@@ -381,9 +387,18 @@ export class ProtspacePublishModal extends LitElement {
 
   // ── Export ─────────────────────────────────────────
 
-  private _handleExport() {
+  private async _handleExport() {
     // Re-render at full resolution for export
     if (!this.plotElement) return;
+    // Wait for any pending webfonts so the first export doesn't render with a
+    // fallback face. Cheap when fonts are already loaded.
+    if (typeof document !== 'undefined' && document.fonts?.ready) {
+      try {
+        await document.fonts.ready;
+      } catch {
+        // Non-fatal — proceed with whatever fonts are loaded.
+      }
+    }
     const s = this._state;
     const visibleCount = this._legendItems.filter((it) => it.isVisible).length;
     const { plotRect } = computeLayout(s.widthPx, s.heightPx, s.legend, visibleCount);
@@ -398,7 +413,7 @@ export class ProtspacePublishModal extends LitElement {
 
     // Boosted capture for crisp inset rendering
     let insetPlotCanvas: HTMLCanvasElement | undefined;
-    const boost = computeInsetBoost(s.insets);
+    const boost = computeInsetBoost(s.insets, 4, plotRect.w * plotRect.h);
     if (boost > 1) {
       insetPlotCanvas = capturePlotCanvas(plotEl, {
         width: plotRect.w * boost,

--- a/packages/core/src/components/publish/publish-overlay-controller.test.ts
+++ b/packages/core/src/components/publish/publish-overlay-controller.test.ts
@@ -449,10 +449,11 @@ describe('PublishOverlayController', () => {
     it('removes event listeners on destroy', () => {
       const spy = vi.spyOn(canvas, 'removeEventListener');
       controller.destroy();
-      expect(spy).toHaveBeenCalledTimes(3);
+      expect(spy).toHaveBeenCalledTimes(4);
       expect(spy).toHaveBeenCalledWith('pointerdown', expect.any(Function));
       expect(spy).toHaveBeenCalledWith('pointermove', expect.any(Function));
       expect(spy).toHaveBeenCalledWith('pointerup', expect.any(Function));
+      expect(spy).toHaveBeenCalledWith('pointercancel', expect.any(Function));
     });
   });
 
@@ -488,6 +489,49 @@ describe('PublishOverlayController', () => {
       canvas.dispatchEvent(pointerEvent('pointerup', 200, 200));
 
       expect(callbacks.requestRedraw).toHaveBeenCalled();
+    });
+  });
+
+  describe('pointer lifecycle', () => {
+    it('releases pointer capture on pointerup', () => {
+      controller.tool = 'circle';
+      canvas.dispatchEvent(pointerEvent('pointerdown', 100, 100));
+      expect(canvas.setPointerCapture).toHaveBeenCalledWith(1);
+      canvas.dispatchEvent(pointerEvent('pointerup', 200, 200));
+      expect(canvas.releasePointerCapture).toHaveBeenCalledWith(1);
+    });
+
+    it('aborts drag and releases capture on pointercancel', () => {
+      controller.tool = 'circle';
+      canvas.dispatchEvent(pointerEvent('pointerdown', 100, 100));
+      expect(canvas.setPointerCapture).toHaveBeenCalledWith(1);
+      callbacks.requestRedraw.mockClear();
+      canvas.dispatchEvent(pointerEvent('pointercancel', 0, 0));
+      expect(canvas.releasePointerCapture).toHaveBeenCalledWith(1);
+      expect(callbacks.requestRedraw).toHaveBeenCalled();
+      // Subsequent pointermove must NOT mutate state
+      canvas.dispatchEvent(pointerEvent('pointermove', 500, 500));
+      // No overlay was created (drag was cancelled before pointerup)
+      canvas.dispatchEvent(pointerEvent('pointerup', 500, 500));
+      expect(callbacks.onOverlayAdded).not.toHaveBeenCalled();
+    });
+
+    it('destroy() releases pointer capture and removes listeners', () => {
+      controller.tool = 'circle';
+      canvas.dispatchEvent(pointerEvent('pointerdown', 100, 100));
+      expect(canvas.setPointerCapture).toHaveBeenCalledWith(1);
+
+      controller.destroy();
+      expect(canvas.releasePointerCapture).toHaveBeenCalledWith(1);
+
+      // After destroy, dispatching events should not call any callbacks
+      callbacks.onOverlayAdded.mockClear();
+      callbacks.requestRedraw.mockClear();
+      canvas.dispatchEvent(pointerEvent('pointermove', 500, 500));
+      canvas.dispatchEvent(pointerEvent('pointerup', 500, 500));
+      canvas.dispatchEvent(pointerEvent('pointercancel', 0, 0));
+      expect(callbacks.onOverlayAdded).not.toHaveBeenCalled();
+      expect(callbacks.requestRedraw).not.toHaveBeenCalled();
     });
   });
 });

--- a/packages/core/src/components/publish/publish-overlay-controller.ts
+++ b/packages/core/src/components/publish/publish-overlay-controller.ts
@@ -70,6 +70,7 @@ export class PublishOverlayController {
     | 'inset-tgt-br'
     | null = null;
   private legendDragging = false;
+  private _capturedPointerId: number | null = null;
 
   constructor(canvas: HTMLCanvasElement, callbacks: OverlayCallbacks) {
     this.canvas = canvas;
@@ -77,6 +78,7 @@ export class PublishOverlayController {
     this.canvas.addEventListener('pointerdown', this.onPointerDown);
     this.canvas.addEventListener('pointermove', this.onPointerMove);
     this.canvas.addEventListener('pointerup', this.onPointerUp);
+    this.canvas.addEventListener('pointercancel', this.onPointerCancel);
   }
 
   get tool(): OverlayTool {
@@ -88,24 +90,55 @@ export class PublishOverlayController {
     this.canvas.style.cursor = value === 'select' ? 'default' : 'crosshair';
   }
 
+  /** Reset transient drag/handle state without re-rendering. */
+  private _resetTransientState() {
+    this.drag.active = false;
+    this.handleMode = null;
+    this.legendDragging = false;
+  }
+
+  /** Release captured pointer if we still hold one. Safe if already released. */
+  private _releaseCapturedPointer() {
+    if (this._capturedPointerId === null) return;
+    try {
+      this.canvas.releasePointerCapture(this._capturedPointerId);
+    } catch {
+      // ignore — already released
+    }
+    this._capturedPointerId = null;
+  }
+
   destroy() {
+    this._releaseCapturedPointer();
+    this._resetTransientState();
     this.canvas.removeEventListener('pointerdown', this.onPointerDown);
     this.canvas.removeEventListener('pointermove', this.onPointerMove);
     this.canvas.removeEventListener('pointerup', this.onPointerUp);
+    this.canvas.removeEventListener('pointercancel', this.onPointerCancel);
   }
 
-  /** Convert canvas-pixel coord to normalised 0–1 within the plot rect */
-  private toNorm(canvasX: number, canvasY: number): { nx: number; ny: number } {
+  /**
+   * Convert canvas-pixel coord to normalised 0–1 within the plot rect.
+   * `clamp` defaults to true (creation paths). Pass `false` for handle drags
+   * so dragging past the plot edge doesn't snap the dragged endpoint to the
+   * boundary and collapse the overlay's dimensions.
+   */
+  private toNorm(
+    canvasX: number,
+    canvasY: number,
+    opts: { clamp?: boolean } = {},
+  ): { nx: number; ny: number } {
+    const { clamp = true } = opts;
     const pr = this.callbacks.getPlotRect();
     const rect = this.canvas.getBoundingClientRect();
     const scaleX = this.canvas.width / rect.width;
     const scaleY = this.canvas.height / rect.height;
     const px = canvasX * scaleX;
     const py = canvasY * scaleY;
-    return {
-      nx: Math.max(0, Math.min(1, (px - pr.x) / pr.w)),
-      ny: Math.max(0, Math.min(1, (py - pr.y) / pr.h)),
-    };
+    const nx = (px - pr.x) / pr.w;
+    const ny = (py - pr.y) / pr.h;
+    if (!clamp) return { nx, ny };
+    return { nx: Math.max(0, Math.min(1, nx)), ny: Math.max(0, Math.min(1, ny)) };
   }
 
   private hitTestOverlay(nx: number, ny: number, a: Overlay): boolean {
@@ -303,7 +336,7 @@ export class PublishOverlayController {
     const inset = insets[this.selected.index];
     if (!inset) return;
 
-    const norm = this.toNorm(this.drag.currentX, this.drag.currentY);
+    const norm = this.toNorm(this.drag.currentX, this.drag.currentY, { clamp: false });
     const isSource = this.handleMode.startsWith('inset-src-');
     const rect = isSource ? inset.sourceRect : inset.targetRect;
     const corner = this.handleMode.slice(-2); // 'tl', 'tr', 'bl', 'br'
@@ -410,7 +443,7 @@ export class PublishOverlayController {
       a.type === 'arrow' &&
       (this.handleMode === 'arrow-start' || this.handleMode === 'arrow-end')
     ) {
-      const norm = this.toNorm(this.drag.currentX, this.drag.currentY);
+      const norm = this.toNorm(this.drag.currentX, this.drag.currentY, { clamp: false });
       if (this.handleMode === 'arrow-start') {
         this.callbacks.onOverlayUpdated(this.selected.index, { ...a, x1: norm.nx, y1: norm.ny });
       } else {
@@ -474,6 +507,7 @@ export class PublishOverlayController {
     const y = e.clientY - rect.top;
     this.drag = { active: true, startX: x, startY: y, currentX: x, currentY: y };
     this.canvas.setPointerCapture(e.pointerId);
+    this._capturedPointerId = e.pointerId;
 
     if (this._tool === 'select') {
       const norm = this.toNorm(x, y);
@@ -675,9 +709,20 @@ export class PublishOverlayController {
     this.callbacks.requestRedraw();
   };
 
+  private onPointerCancel = (_e: PointerEvent) => {
+    if (!this.drag.active && this._capturedPointerId === null) return;
+    this._releaseCapturedPointer();
+    this._resetTransientState();
+    this.callbacks.requestRedraw();
+  };
+
   private onPointerUp = (e: PointerEvent) => {
-    if (!this.drag.active) return;
+    if (!this.drag.active) {
+      this._releaseCapturedPointer();
+      return;
+    }
     this.drag.active = false;
+    this._releaseCapturedPointer();
 
     const rect = this.canvas.getBoundingClientRect();
     const endX = e.clientX - rect.left;

--- a/packages/core/src/components/publish/publish-state-validate.test.ts
+++ b/packages/core/src/components/publish/publish-state-validate.test.ts
@@ -1,0 +1,176 @@
+import { describe, it, expect } from 'vitest';
+import { validatePublishState } from './publish-state-validate';
+
+describe('validatePublishState', () => {
+  it('returns empty for non-objects', () => {
+    expect(validatePublishState(null)).toEqual({});
+    expect(validatePublishState(undefined)).toEqual({});
+    expect(validatePublishState('not-an-object')).toEqual({});
+    expect(validatePublishState(42)).toEqual({});
+    expect(validatePublishState([1, 2, 3])).toEqual({});
+  });
+
+  it('drops invalid overlay types', () => {
+    const out = validatePublishState({
+      overlays: [
+        {
+          type: 'circle',
+          cx: 0.5,
+          cy: 0.5,
+          rx: 0.1,
+          ry: 0.1,
+          rotation: 0,
+          color: '#000',
+          strokeWidth: 2,
+        },
+        { type: 'unknown' },
+        { type: 'arrow' /* missing required fields */ },
+        'not-an-object',
+        null,
+      ],
+    });
+    expect(out.overlays).toHaveLength(1);
+    expect(out.overlays?.[0].type).toBe('circle');
+  });
+
+  it('drops overlays with out-of-range coords', () => {
+    const out = validatePublishState({
+      overlays: [
+        {
+          type: 'circle',
+          cx: -0.5,
+          cy: 0.5,
+          rx: 0.1,
+          ry: 0.1,
+          rotation: 0,
+          color: '#000',
+          strokeWidth: 2,
+        },
+        {
+          type: 'circle',
+          cx: 1.5,
+          cy: 0.5,
+          rx: 0.1,
+          ry: 0.1,
+          rotation: 0,
+          color: '#000',
+          strokeWidth: 2,
+        },
+        { type: 'arrow', x1: 0, y1: 0, x2: 1, y2: 1, color: '#000', width: 2 },
+      ],
+    });
+    expect(out.overlays).toHaveLength(1);
+    expect(out.overlays?.[0].type).toBe('arrow');
+  });
+
+  it('rejects NaN/Infinity in coords', () => {
+    const out = validatePublishState({
+      overlays: [
+        { type: 'arrow', x1: NaN, y1: 0, x2: 1, y2: 1, color: '#000', width: 2 },
+        { type: 'arrow', x1: 0, y1: Infinity, x2: 1, y2: 1, color: '#000', width: 2 },
+      ],
+    });
+    expect(out.overlays).toEqual([]);
+  });
+
+  it('drops insets with invalid rects', () => {
+    const out = validatePublishState({
+      insets: [
+        {
+          sourceRect: { x: 0.1, y: 0.1, w: 0.2, h: 0.2 },
+          targetRect: { x: 0.5, y: 0.5, w: 0.3, h: 0.3 },
+          border: 2,
+          connector: 'lines',
+        },
+        // Bad: w is negative
+        {
+          sourceRect: { x: 0.1, y: 0.1, w: -0.2, h: 0.2 },
+          targetRect: { x: 0.5, y: 0.5, w: 0.3, h: 0.3 },
+          border: 2,
+          connector: 'lines',
+        },
+        // Bad: connector value
+        {
+          sourceRect: { x: 0.1, y: 0.1, w: 0.2, h: 0.2 },
+          targetRect: { x: 0.5, y: 0.5, w: 0.3, h: 0.3 },
+          border: 2,
+          connector: 'arrows',
+        },
+      ],
+    });
+    expect(out.insets).toHaveLength(1);
+  });
+
+  it('keeps valid scalar fields', () => {
+    const out = validatePublishState({
+      preset: 'custom',
+      sizeMode: 'flexible',
+      widthPx: 2048,
+      heightPx: 1024,
+      dpi: 300,
+      format: 'png',
+      background: 'white',
+      referenceWidth: 2048,
+    });
+    expect(out.preset).toBe('custom');
+    expect(out.sizeMode).toBe('flexible');
+    expect(out.widthPx).toBe(2048);
+    expect(out.heightPx).toBe(1024);
+    expect(out.dpi).toBe(300);
+    expect(out.format).toBe('png');
+    expect(out.background).toBe('white');
+    expect(out.referenceWidth).toBe(2048);
+  });
+
+  it('drops out-of-range scalars', () => {
+    const out = validatePublishState({
+      widthPx: -1,
+      heightPx: 0,
+      dpi: NaN,
+      format: 'jpeg',
+      background: 'red',
+      sizeMode: 'unknown',
+    });
+    expect(out.widthPx).toBeUndefined();
+    expect(out.heightPx).toBeUndefined();
+    expect(out.dpi).toBeUndefined();
+    expect(out.format).toBeUndefined();
+    expect(out.background).toBeUndefined();
+    expect(out.sizeMode).toBeUndefined();
+  });
+
+  it('partial legend fields are kept independently', () => {
+    const out = validatePublishState({
+      legend: {
+        visible: true,
+        position: 'unknown-pos',
+        widthPercent: 25,
+        fontSizePx: 14,
+        columns: 2,
+        overflow: 'multi-column',
+      },
+    });
+    expect(out.legend?.visible).toBe(true);
+    expect(out.legend?.position).toBeUndefined();
+    expect(out.legend?.widthPercent).toBe(25);
+    expect(out.legend?.fontSizePx).toBe(14);
+    expect(out.legend?.columns).toBe(2);
+    expect(out.legend?.overflow).toBe('multi-column');
+  });
+
+  it('keeps a complete viewFingerprint', () => {
+    const out = validatePublishState({
+      viewFingerprint: { projection: 'umap', dimensionality: 2 },
+    });
+    expect(out.viewFingerprint).toEqual({ projection: 'umap', dimensionality: 2 });
+  });
+
+  it('drops viewFingerprint with missing fields', () => {
+    expect(
+      validatePublishState({ viewFingerprint: { projection: 'umap' } }).viewFingerprint,
+    ).toBeUndefined();
+    expect(
+      validatePublishState({ viewFingerprint: { dimensionality: 2 } }).viewFingerprint,
+    ).toBeUndefined();
+  });
+});

--- a/packages/core/src/components/publish/publish-state-validate.ts
+++ b/packages/core/src/components/publish/publish-state-validate.ts
@@ -1,0 +1,213 @@
+/**
+ * Runtime validator for `PublishState` loaded from untrusted sources
+ * (localStorage, parquet bundle). Returns a `Partial<PublishState>` containing
+ * only fields that pass shape checks; bad overlays/insets are dropped.
+ *
+ * Centralises the parsing decisions so a corrupt or pre-migration save can't
+ * silently merge garbage into the modal's state via spread + cast.
+ */
+
+import type {
+  PublishState,
+  Overlay,
+  CircleOverlay,
+  ArrowOverlay,
+  LabelOverlay,
+  Inset,
+  NormRect,
+  LegendLayout,
+  LegendPosition,
+  LegendOverflow,
+  LegendFreePosition,
+} from './publish-state';
+import { getPreset } from './journal-presets';
+
+const LEGEND_POSITIONS: ReadonlySet<LegendPosition> = new Set([
+  'right',
+  'left',
+  'top',
+  'bottom',
+  'tr',
+  'tl',
+  'br',
+  'bl',
+  'free',
+  'none',
+]);
+const LEGEND_OVERFLOWS: ReadonlySet<LegendOverflow> = new Set([
+  'scale',
+  'truncate',
+  'multi-column',
+]);
+const SIZE_MODES = new Set<PublishState['sizeMode']>(['1-column', '2-column', 'flexible']);
+
+function isFiniteNumber(v: unknown): v is number {
+  return typeof v === 'number' && Number.isFinite(v);
+}
+
+function isString(v: unknown): v is string {
+  return typeof v === 'string';
+}
+
+function isObject(v: unknown): v is Record<string, unknown> {
+  return typeof v === 'object' && v !== null && !Array.isArray(v);
+}
+
+/** Numbers in `[0, 1]`. NaN/Infinity rejected. */
+function inUnit(v: unknown): v is number {
+  return isFiniteNumber(v) && v >= 0 && v <= 1;
+}
+
+function asNormRect(v: unknown): NormRect | null {
+  if (!isObject(v)) return null;
+  if (!inUnit(v.x) || !inUnit(v.y)) return null;
+  if (!isFiniteNumber(v.w) || !isFiniteNumber(v.h)) return null;
+  if (v.w <= 0 || v.h <= 0) return null;
+  if (v.x + v.w > 1.001 || v.y + v.h > 1.001) return null;
+  return { x: v.x, y: v.y, w: v.w, h: v.h };
+}
+
+function asCircleOverlay(v: Record<string, unknown>): CircleOverlay | null {
+  if (!inUnit(v.cx) || !inUnit(v.cy)) return null;
+  if (!isFiniteNumber(v.rx) || !isFiniteNumber(v.ry) || v.rx <= 0 || v.ry <= 0) return null;
+  if (!isString(v.color)) return null;
+  if (!isFiniteNumber(v.strokeWidth) || v.strokeWidth <= 0) return null;
+  return {
+    type: 'circle',
+    cx: v.cx,
+    cy: v.cy,
+    rx: v.rx,
+    ry: v.ry,
+    rotation: isFiniteNumber(v.rotation) ? v.rotation : 0,
+    color: v.color,
+    strokeWidth: v.strokeWidth,
+  };
+}
+
+function asArrowOverlay(v: Record<string, unknown>): ArrowOverlay | null {
+  if (!inUnit(v.x1) || !inUnit(v.y1) || !inUnit(v.x2) || !inUnit(v.y2)) return null;
+  if (!isString(v.color)) return null;
+  if (!isFiniteNumber(v.width) || v.width <= 0) return null;
+  return { type: 'arrow', x1: v.x1, y1: v.y1, x2: v.x2, y2: v.y2, color: v.color, width: v.width };
+}
+
+function asLabelOverlay(v: Record<string, unknown>): LabelOverlay | null {
+  if (!inUnit(v.x) || !inUnit(v.y)) return null;
+  if (!isString(v.text)) return null;
+  if (!isFiniteNumber(v.fontSize) || v.fontSize <= 0) return null;
+  if (!isString(v.color)) return null;
+  return {
+    type: 'label',
+    x: v.x,
+    y: v.y,
+    text: v.text,
+    fontSize: v.fontSize,
+    rotation: isFiniteNumber(v.rotation) ? v.rotation : 0,
+    color: v.color,
+  };
+}
+
+function asOverlay(v: unknown): Overlay | null {
+  if (!isObject(v)) return null;
+  switch (v.type) {
+    case 'circle':
+      return asCircleOverlay(v);
+    case 'arrow':
+      return asArrowOverlay(v);
+    case 'label':
+      return asLabelOverlay(v);
+    default:
+      return null;
+  }
+}
+
+function asInset(v: unknown): Inset | null {
+  if (!isObject(v)) return null;
+  const sourceRect = asNormRect(v.sourceRect);
+  const targetRect = asNormRect(v.targetRect);
+  if (!sourceRect || !targetRect) return null;
+  if (!isFiniteNumber(v.border) || v.border < 0) return null;
+  if (v.connector !== 'lines' && v.connector !== 'none') return null;
+  return { sourceRect, targetRect, border: v.border, connector: v.connector };
+}
+
+function asLegendFreePos(v: unknown): LegendFreePosition | undefined {
+  if (!isObject(v)) return undefined;
+  if (!inUnit(v.nx) || !inUnit(v.ny)) return undefined;
+  return { nx: v.nx, ny: v.ny };
+}
+
+function asLegendLayout(v: unknown): Partial<LegendLayout> {
+  if (!isObject(v)) return {};
+  const out: Partial<LegendLayout> = {};
+  if (typeof v.visible === 'boolean') out.visible = v.visible;
+  if (isString(v.position) && LEGEND_POSITIONS.has(v.position as LegendPosition)) {
+    out.position = v.position as LegendPosition;
+  }
+  if (isFiniteNumber(v.widthPercent) && v.widthPercent > 0 && v.widthPercent <= 100) {
+    out.widthPercent = v.widthPercent;
+  }
+  if (isFiniteNumber(v.fontSizePx) && v.fontSizePx > 0) out.fontSizePx = v.fontSizePx;
+  if (isFiniteNumber(v.columns) && Number.isInteger(v.columns) && v.columns > 0) {
+    out.columns = v.columns;
+  }
+  if (isString(v.overflow) && LEGEND_OVERFLOWS.has(v.overflow as LegendOverflow)) {
+    out.overflow = v.overflow as LegendOverflow;
+  }
+  const free = asLegendFreePos(v.freePos);
+  if (free) out.freePos = free;
+  return out;
+}
+
+/**
+ * Parse arbitrary `unknown` input into a `Partial<PublishState>` containing
+ * only fields that pass type/range checks. Bad overlays/insets are silently
+ * dropped; the caller spreads this over a default state to fill the rest.
+ */
+export function validatePublishState(raw: unknown): Partial<PublishState> {
+  if (!isObject(raw)) return {};
+
+  const out: Partial<PublishState> = {};
+
+  if (isString(raw.preset)) {
+    if (raw.preset === 'custom' || getPreset(raw.preset)) {
+      out.preset = raw.preset as PublishState['preset'];
+    }
+  }
+  if (isString(raw.sizeMode) && SIZE_MODES.has(raw.sizeMode as PublishState['sizeMode'])) {
+    out.sizeMode = raw.sizeMode as PublishState['sizeMode'];
+  }
+  if (isFiniteNumber(raw.widthPx) && raw.widthPx > 0) out.widthPx = raw.widthPx;
+  if (isFiniteNumber(raw.heightPx) && raw.heightPx > 0) out.heightPx = raw.heightPx;
+  if (isFiniteNumber(raw.dpi) && raw.dpi > 0) out.dpi = raw.dpi;
+  if (raw.format === 'png' || raw.format === 'pdf') out.format = raw.format;
+  if (raw.background === 'white' || raw.background === 'transparent')
+    out.background = raw.background;
+  if (isFiniteNumber(raw.referenceWidth) && raw.referenceWidth > 0) {
+    out.referenceWidth = raw.referenceWidth;
+  }
+
+  const legend = asLegendLayout(raw.legend);
+  if (Object.keys(legend).length > 0) out.legend = legend as LegendLayout;
+
+  if (Array.isArray(raw.overlays)) {
+    out.overlays = raw.overlays.map(asOverlay).filter((o): o is Overlay => o !== null);
+  }
+  if (Array.isArray(raw.insets)) {
+    out.insets = raw.insets.map(asInset).filter((i): i is Inset => i !== null);
+  }
+
+  if (isObject(raw.viewFingerprint)) {
+    if (
+      isString(raw.viewFingerprint.projection) &&
+      isFiniteNumber(raw.viewFingerprint.dimensionality)
+    ) {
+      out.viewFingerprint = {
+        projection: raw.viewFingerprint.projection,
+        dimensionality: raw.viewFingerprint.dimensionality,
+      };
+    }
+  }
+
+  return out;
+}


### PR DESCRIPTION
Followup to #232. Addresses the must-fix and should-fix items from my review there. Targeting `feat/publish-editor` so it merges back into that PR's diff cleanly.

## Patches

### Must-fix
- **Pointer capture leak** — `publish-overlay-controller.ts:476` called `setPointerCapture` but never released it, and there was no `pointercancel` handler. OS-level cancels left `drag.active` stuck `true`. Fix: track `_capturedPointerId`, register `pointercancel`, release in `onPointerUp` / `onPointerCancel` / `destroy()`.
- **`destroy()` mid-drag left zombie state** — only removed listeners, didn't reset `drag.active` / `handleMode` / `legendDragging` or release pointer capture. Fix: symmetric cleanup before listener removal.

### Should-fix
- **`toNorm` clamped during handle drags** — collapsing arrow endpoints / inset corners on fast drags past the edge. Fix: `clamp` is opt-in (default `true` for creation paths). Handle drags pass `{ clamp: false }`.
- **Blind cast on saved state** — `{ ...defaults, ...savedPublishState } as PublishState` would silently merge garbage. Fix: new `publish-state-validate.ts` runs shape checks on every field. Drops invalid overlays, out-of-range coords, NaN, bogus enums.
- **No canvas-area cap** — 8192² with a 4× inset boost would silently exceed the browser's ~268M pixel canvas limit; export came back blank. Fix: `MAX_CANVAS_PIXELS = 256_000_000`. `computeInsetBoost` gains an optional `plotPixelArea` and clamps against the area budget. Both modal callers wired up.
- **Fonts not awaited before export** — first export with a webfont preset would render with a fallback face. Fix: `_handleExport` is async and awaits `document.fonts.ready` (with SSR guard + try/catch).

## Tests

17 new + 1 updated:
- 3 pointer-lifecycle tests (releases on pointerup, aborts on pointercancel, destroy releases capture)
- 1 listener-count fix in existing destroy test (3 → 4)
- 10 validator tests (rejects non-objects, drops invalid overlays/insets, NaN/Infinity, partial legend, viewFingerprint shape)
- 4 area-cap tests on `computeInsetBoost`

All 681/681 pass. Type-check, lint (0 errors), knip, docs build all clean. Manually smoke-tested on `pnpm dev`.

## Follow-up considerations (deferred — design calls, no code patches)

These were flagged in review but not addressed here. No current users are affected by any of them; flagging so a decision can be made before merge or filed as separate issues:

1. **Per-annotation export prefs consolidation.** Removing `ExportPersistenceController` (-55), `control-bar-helpers.ts` (-40), and per-annotation state in `control-bar.ts` (-432) consolidates persistence into a single global `localStorage['protspace_publishState']` key (`app/src/explore/export-handler.ts:49`). Worth confirming the consolidation was deliberate vs. accidental — no users are affected today, but the intent matters for what to document.
2. **Light-DOM `document.querySelector('protspace-legend')`** at `publish-modal.ts:68`. Works today because the legend lives in the same document; breaks if the modal is ever mounted inside another shadow root (embedded mode, third-party integration). Pass legend export state in via property, the way `plotElement` is.
3. **`publish-modal.ts:86` styles list** — `[tokens, buttonMixin, publishModalStyles]` skips `inputMixin` and `overlayMixins`, so `publish-modal.styles.ts` reimplements ~510 lines of scaffolding the codebase already has. Pure CSS refactor; separate PR.

## Test plan
- [x] `pnpm type-check`
- [x] `pnpm test` — 681/681
- [x] `pnpm lint` — 0 errors
- [x] `pnpm knip`, `pnpm docs:build`
- [x] Manual smoke on `pnpm dev`: publish modal opens, drawing / resizing / export work, no console errors