### PR TITLE
fix(publish): address PR #232 review (16 findings)

### DIFF
--- a/app/src/explore/export-handler.ts
+++ b/app/src/explore/export-handler.ts
@@ -142,11 +142,12 @@ export function createExportHandler({
               }
             }
             notify.success(getExportSuccessNotification(fname));
+            modal.remove();
           } catch (err) {
             console.error('Publish export failed:', err);
             notify.error(getExportFailureNotification(err));
+            // Leave the modal open so the user can retry without losing context.
           }
-          modal.remove();
         }) as EventListener);
 
         // Handle close — persist state to localStorage

--- a/app/src/explore/export-handler.ts
+++ b/app/src/explore/export-handler.ts
@@ -1,5 +1,5 @@
 import type { ProtspaceControlBar, ProtspaceLegend, ProtspaceScatterplot } from '@protspace/core';
-import { EXPORT_DEFAULTS } from '@protspace/core';
+import { EXPORT_DEFAULTS, pxToMm } from '@protspace/core';
 import type { BundleSettings } from '@protspace/utils';
 import {
   createExporter,
@@ -123,8 +123,8 @@ export function createExportHandler({
           try {
             const fname = generateFilename(state.format);
             if (state.format === 'pdf') {
-              const widthMm = (canvas.width * 25.4) / state.dpi;
-              const heightMm = (canvas.height * 25.4) / state.dpi;
+              const widthMm = pxToMm(canvas.width, state.dpi);
+              const heightMm = pxToMm(canvas.height, state.dpi);
               await exportCanvasAsPdf(canvas, { widthMm, heightMm, filename: fname });
             } else {
               const blob: Blob = await new Promise((resolve, reject) => {

--- a/app/tests/figure-editor.spec.ts
+++ b/app/tests/figure-editor.spec.ts
@@ -270,6 +270,87 @@ test.describe('figure editor — geometric inset zoom', () => {
     expect(at5x.colored).toBeGreaterThan(at1x.colored * 1.5);
   });
 
+  test('exports a PNG with embedded DPI metadata', async ({ page }) => {
+    // beforeEach already ran waitForExploreDataLoad, dismissTourIfPresent,
+    // and openFigureEditor. Set small dimensions to keep the test fast.
+    await page.evaluate(() => {
+      const m = document.querySelector('protspace-publish-modal') as
+        | (HTMLElement & {
+            _state: Record<string, unknown>;
+            requestUpdate: () => void;
+            _plotCacheKey: string;
+          })
+        | null;
+      if (!m) throw new Error('publish modal not mounted');
+      m._state = {
+        ...(m._state as Record<string, unknown>),
+        widthPx: 800,
+        heightPx: 600,
+        dpi: 150,
+        format: 'png',
+      };
+      m._plotCacheKey = '';
+      m.requestUpdate();
+    });
+    await page.waitForTimeout(300);
+
+    const downloadPromise = page.waitForEvent('download', { timeout: 15_000 });
+
+    // Click the Export button. The modal renders it as
+    //   <button class="btn-primary" @click=${this._handleExport}>Export</button>
+    // so the text-based fallback is the reliable identifier; we still try
+    // a few data attributes first in case future commits add one.
+    await page.evaluate(() => {
+      const m = document.querySelector('protspace-publish-modal') as
+        | (HTMLElement & { shadowRoot: ShadowRoot })
+        | null;
+      const root = m?.shadowRoot;
+      if (!root) throw new Error('modal shadow root missing');
+      const candidates = [
+        'button[data-action="export"]',
+        'button.publish-export-btn',
+        'button.publish-action-export',
+        '[data-testid="export-btn"]',
+      ];
+      for (const sel of candidates) {
+        const btn = root.querySelector(sel) as HTMLButtonElement | null;
+        if (btn) {
+          btn.click();
+          return;
+        }
+      }
+      // Match the actual primary button by text — current implementation.
+      const buttons = Array.from(root.querySelectorAll('button')) as HTMLButtonElement[];
+      const exportBtn = buttons.find((b) => b.textContent?.trim() === 'Export');
+      if (exportBtn) {
+        exportBtn.click();
+        return;
+      }
+      throw new Error('Export button not found in publish-modal shadow DOM');
+    });
+
+    const download = await downloadPromise;
+    const path = await download.path();
+    expect(path).toBeTruthy();
+
+    // Read the file back and verify the pHYs chunk carries the correct
+    // pixels-per-metre value. PNG chunk layout: length(4) | type(4) | data(N)
+    // | crc(4); buf.indexOf('pHYs') points at the type field, so the X-axis
+    // ppm uint32 begins at +4 bytes past that.
+    const fs = await import('node:fs');
+    const buf = fs.readFileSync(path!);
+    const tag = Buffer.from('pHYs', 'ascii');
+    const physOffset = buf.indexOf(tag);
+    expect(physOffset).toBeGreaterThan(-1);
+    // Pixels-per-metre at 150 DPI = round(150 * 39.3700787) = 5906.
+    const ppm =
+      (buf[physOffset + 4] << 24) |
+      (buf[physOffset + 5] << 16) |
+      (buf[physOffset + 6] << 8) |
+      buf[physOffset + 7];
+    expect(ppm >>> 0).toBe(5906);
+  });
+
   test('high-frequency target resize does not stall the modal', async ({ page }) => {
     const region = await findColoredRegion(page);
     await setInsets(page, [

--- a/knip.jsonc
+++ b/knip.jsonc
@@ -3,11 +3,13 @@
   "treatConfigHintsAsErrors": true,
   "workspaces": {
     ".": {
-      // Perf Playwright config is plugin-discovered; only keep the docs config
-      // explicit because Knip does not infer `docs/.vitepress/*`.
+      // Perf Playwright specs are not auto-discovered (perf playwright.config.ts
+      // sits in a non-default location), so list them explicitly. Docs config is
+      // listed because Knip does not infer `docs/.vitepress/*`.
       "entry": [
         "scripts/**/*.ts",
         "docs/.vitepress/config.mts",
+        "perf/**/*.spec.ts",
       ],
       "project": [
         "config/**/*.ts",

--- a/packages/core/src/components/data-loader/utils/bundle.ts
+++ b/packages/core/src/components/data-loader/utils/bundle.ts
@@ -7,6 +7,7 @@ import {
 } from '@protspace/utils';
 import type { Rows, GenericRow } from './types';
 import { assertValidParquetMagic, validateProjectionRows } from './validation';
+import { sanitizePublishState } from '../../publish/publish-state-validator';
 
 /**
  * Result of extracting data from a parquetbundle.
@@ -156,7 +157,7 @@ async function extractSettings(settingsBuffer: ArrayBuffer): Promise<BundleSetti
     }
 
     const parsed = JSON.parse(settingsJson);
-    const normalized = normalizeBundleSettings(parsed);
+    const normalized = normalizeBundleSettings(parsed, { sanitizePublishState });
 
     if (!normalized) {
       console.warn('Settings JSON does not match expected schema, using defaults');

--- a/packages/core/src/components/publish/publish-compositor.test.ts
+++ b/packages/core/src/components/publish/publish-compositor.test.ts
@@ -605,3 +605,22 @@ describe('waitForFonts', () => {
     await expect(waitForFonts()).resolves.toBeUndefined();
   });
 });
+
+describe('composeFigure null context', () => {
+  it('composeFigure does not throw when getContext returns null', () => {
+    const out = document.createElement('canvas');
+    out.width = 100;
+    out.height = 100;
+    const orig = out.getContext;
+    (out as unknown as { getContext: typeof out.getContext }).getContext = () => null;
+    expect(() =>
+      composeFigure(out, {
+        state: createDefaultPublishState(),
+        plotCanvas: document.createElement('canvas'),
+        legendItems: [],
+        legendTitle: '',
+      }),
+    ).not.toThrow();
+    (out as unknown as { getContext: typeof out.getContext }).getContext = orig;
+  });
+});

--- a/packages/core/src/components/publish/publish-compositor.test.ts
+++ b/packages/core/src/components/publish/publish-compositor.test.ts
@@ -327,6 +327,103 @@ describe('publish-compositor', () => {
       });
       expect(result).toBe(mockCanvas);
     });
+
+    /**
+     * jsdom doesn't implement canvas 2d. Instead of pixel sampling, spy on
+     * the output canvas's 2d context and assert drawImage's call signature.
+     */
+    function spyOutputContext(out: HTMLCanvasElement) {
+      const calls: Array<unknown[]> = [];
+      const ctx = {
+        clearRect: () => {},
+        fillRect: () => {},
+        drawImage: (...args: unknown[]) => calls.push(args),
+        fillStyle: '',
+      } as unknown as CanvasRenderingContext2D;
+      const origCreate = document.createElement.bind(document);
+      const createSpy = (tag: string) => {
+        const el = origCreate(tag);
+        if (tag === 'canvas') {
+          (el as HTMLCanvasElement).getContext = (() => ctx) as HTMLCanvasElement['getContext'];
+        }
+        return el;
+      };
+      document.createElement = createSpy as typeof document.createElement;
+      return {
+        calls,
+        restore: () => {
+          document.createElement = origCreate;
+          void out;
+        },
+      };
+    }
+
+    it('fallback uses 9-arg drawImage with source full pixel rect (no DPR halving)', () => {
+      const existing = document.createElement('canvas');
+      existing.width = 800;
+      existing.height = 600;
+      const plotEl = document.createElement('div');
+      plotEl.appendChild(existing);
+
+      // Activate the spy AFTER creating the source canvas so existing.getContext
+      // is unaffected; only newly-created canvases (the output) get the stub.
+      const spy = spyOutputContext(existing);
+      try {
+        const out = capturePlotCanvas(plotEl as HTMLElement, {
+          width: 800,
+          height: 600,
+          backgroundColor: '#ffffff',
+        });
+        expect(out.width).toBe(800);
+        expect(out.height).toBe(600);
+      } finally {
+        spy.restore();
+      }
+
+      // drawImage should be called with the 9-arg form: (img, sx, sy, sw, sh, dx, dy, dw, dh)
+      expect(spy.calls.length).toBe(1);
+      const args = spy.calls[0];
+      expect(args.length).toBe(9);
+      expect(args[0]).toBe(existing);
+      expect(args[1]).toBe(0); // sx
+      expect(args[2]).toBe(0); // sy
+      expect(args[3]).toBe(800); // sw — full source pixel width
+      expect(args[4]).toBe(600); // sh — full source pixel height
+      expect(args[5]).toBe(0); // dx
+      expect(args[6]).toBe(0); // dy
+      expect(args[7]).toBe(800); // dw
+      expect(args[8]).toBe(600); // dh
+    });
+
+    it('fallback samples the full source rect when source is HiDPI (2× CSS width)', () => {
+      const existing = document.createElement('canvas');
+      existing.width = 1600; // physical pixels
+      existing.height = 1200;
+      const plotEl = document.createElement('div');
+      plotEl.appendChild(existing);
+
+      const spy = spyOutputContext(existing);
+      try {
+        capturePlotCanvas(plotEl as HTMLElement, {
+          width: 800, // CSS pixels
+          height: 600,
+          backgroundColor: '#ffffff',
+        });
+      } finally {
+        spy.restore();
+      }
+
+      // Must use the 9-arg form passing full source pixel rect — only then is
+      // the HiDPI source sampled fully (5-arg form would silently halve it).
+      expect(spy.calls.length).toBe(1);
+      const args = spy.calls[0];
+      expect(args.length).toBe(9);
+      expect(args[0]).toBe(existing);
+      expect(args[3]).toBe(1600); // sw = source.width (full pixels), not 800
+      expect(args[4]).toBe(1200); // sh = source.height (full pixels), not 600
+      expect(args[7]).toBe(800); // dw = output CSS width
+      expect(args[8]).toBe(600); // dh = output CSS height
+    });
   });
 });
 

--- a/packages/core/src/components/publish/publish-compositor.ts
+++ b/packages/core/src/components/publish/publish-compositor.ts
@@ -72,7 +72,9 @@ export function capturePlotCanvas(
     const ctx = out.getContext('2d')!;
     ctx.fillStyle = opts.backgroundColor;
     ctx.fillRect(0, 0, opts.width, opts.height);
-    ctx.drawImage(existing, 0, 0, opts.width, opts.height);
+    // Pass the full source pixel rect so HiDPI live canvases (where existing.width
+    // > opts.width) aren't silently halved.
+    ctx.drawImage(existing, 0, 0, existing.width, existing.height, 0, 0, opts.width, opts.height);
     return out;
   }
   // Last resort: blank canvas

--- a/packages/core/src/components/publish/publish-compositor.ts
+++ b/packages/core/src/components/publish/publish-compositor.ts
@@ -229,20 +229,8 @@ function renderLegendCanvas(items: LegendItem[], opts: LegendRenderOptions): HTM
     );
   }
 
-  // Compute cumulative Y offsets per column
+  // Compute cumulative Y offsets per column from each item's actual height.
   const colYOffsets: number[][] = Array.from({ length: columns }, () => []);
-  for (let i = 0; i < renderItems.length; i++) {
-    const col = Math.floor(i / itemsPerCol);
-    const row = i % itemsPerCol;
-    const prevY =
-      row === 0
-        ? 0
-        : colYOffsets[col][row - 1] +
-          Math.max(itemHeight, lineCounts[i - columns >= 0 ? i : i] * lineHeight + itemPadding * 2);
-    colYOffsets[col].push(row === 0 ? 0 : prevY);
-  }
-
-  // Recompute properly: accumulate based on previous item's actual height
   for (let col = 0; col < columns; col++) {
     let y = 0;
     for (let row = 0; row < itemsPerCol; row++) {

--- a/packages/core/src/components/publish/publish-compositor.ts
+++ b/packages/core/src/components/publish/publish-compositor.ts
@@ -791,7 +791,11 @@ interface CompositeOptions {
  */
 export function composeFigure(outCanvas: HTMLCanvasElement, opts: CompositeOptions): void {
   const { state, plotCanvas, legendItems, legendTitle } = opts;
-  const ctx = outCanvas.getContext('2d')!;
+  const ctx = outCanvas.getContext('2d');
+  if (!ctx) {
+    console.warn('composeFigure: 2D context unavailable; skipping render');
+    return;
+  }
   const W = outCanvas.width;
   const H = outCanvas.height;
 

--- a/packages/core/src/components/publish/publish-modal-helpers.ts
+++ b/packages/core/src/components/publish/publish-modal-helpers.ts
@@ -10,7 +10,7 @@
 
 import type { PublishState } from './publish-state';
 import { getPreset, resolvePresetDimensions, type PresetId } from './journal-presets';
-import { mmToPx, pxToMm } from './dimension-utils';
+import { adjustDpiForWidthMm, mmToPx, pxToMm } from './dimension-utils';
 
 type ViewFingerprint = { projection: string; dimensionality: number };
 
@@ -64,7 +64,7 @@ export function computeWidthMmUpdate(state: PublishState, widthMm: number): Part
     return patch;
   }
   // Resample=OFF: pixels locked, dpi recomputes.
-  const dpi = Math.max(1, Math.round((state.widthPx * 25.4) / widthMm));
+  const dpi = Math.max(1, adjustDpiForWidthMm(state.widthPx, widthMm));
   return { dpi, preset: 'custom' };
 }
 
@@ -100,7 +100,7 @@ export function computeHeightMmUpdate(
     }
     return patch;
   }
-  const dpi = Math.max(1, Math.round((state.heightPx * 25.4) / heightMm));
+  const dpi = Math.max(1, adjustDpiForWidthMm(state.heightPx, heightMm));
   return { dpi, preset: 'custom' };
 }
 

--- a/packages/core/src/components/publish/publish-modal.test.ts
+++ b/packages/core/src/components/publish/publish-modal.test.ts
@@ -1014,3 +1014,75 @@ describe('<protspace-publish-modal> disconnect guard', () => {
     }
   });
 });
+
+describe('<protspace-publish-modal> fingerprint warning', () => {
+  beforeEach(() => {
+    document.body.innerHTML = '';
+  });
+
+  it('renders the fingerprint warning when saved fingerprint mismatches current', async () => {
+    const stubCtx = new Proxy(
+      {},
+      { get: () => () => undefined },
+    ) as unknown as CanvasRenderingContext2D;
+    const origGetContext = HTMLCanvasElement.prototype.getContext;
+    HTMLCanvasElement.prototype.getContext = function () {
+      return stubCtx;
+    } as typeof HTMLCanvasElement.prototype.getContext;
+
+    try {
+      const modal = document.createElement('protspace-publish-modal') as HTMLElement & {
+        savedPublishState: Record<string, unknown>;
+        currentProjection: { projection: string; dimensionality: number };
+        updateComplete: Promise<unknown>;
+        shadowRoot: ShadowRoot;
+      };
+      modal.savedPublishState = {
+        viewFingerprint: { projection: 'umap', dimensionality: 2 },
+        overlays: [{ type: 'label', x: 0.5, y: 0.5, text: 't', fontSize: 14, color: '#000' }],
+      };
+      modal.currentProjection = { projection: 'pca', dimensionality: 2 };
+      document.body.appendChild(modal);
+      await modal.updateComplete;
+
+      const warn = modal.shadowRoot.querySelector('.publish-warning');
+      expect(warn).not.toBeNull();
+      modal.remove();
+    } finally {
+      HTMLCanvasElement.prototype.getContext = origGetContext;
+    }
+  });
+
+  it('does not render the fingerprint warning when fingerprints match', async () => {
+    const stubCtx = new Proxy(
+      {},
+      { get: () => () => undefined },
+    ) as unknown as CanvasRenderingContext2D;
+    const origGetContext = HTMLCanvasElement.prototype.getContext;
+    HTMLCanvasElement.prototype.getContext = function () {
+      return stubCtx;
+    } as typeof HTMLCanvasElement.prototype.getContext;
+
+    try {
+      const modal = document.createElement('protspace-publish-modal') as HTMLElement & {
+        savedPublishState: Record<string, unknown>;
+        currentProjection: { projection: string; dimensionality: number };
+        updateComplete: Promise<unknown>;
+        shadowRoot: ShadowRoot;
+      };
+      modal.savedPublishState = {
+        viewFingerprint: { projection: 'umap', dimensionality: 2 },
+        overlays: [],
+      };
+      modal.currentProjection = { projection: 'umap', dimensionality: 2 };
+      document.body.appendChild(modal);
+      await modal.updateComplete;
+
+      const warn = modal.shadowRoot.querySelector('.publish-warning');
+      expect(warn).toBeNull();
+      modal.remove();
+    } finally {
+      HTMLCanvasElement.prototype.getContext = origGetContext;
+    }
+  });
+});

--- a/packages/core/src/components/publish/publish-modal.test.ts
+++ b/packages/core/src/components/publish/publish-modal.test.ts
@@ -813,3 +813,62 @@ describe('<protspace-publish-modal> selection + keyboard delete', () => {
     expect(internals._state.overlays).toHaveLength(1);
   });
 });
+
+describe('<protspace-publish-modal> plot cache key', () => {
+  beforeEach(() => {
+    document.body.innerHTML = '';
+  });
+
+  it('invalidates the plot cache when background toggles white ↔ transparent', async () => {
+    const captures: Array<{ bg: string }> = [];
+    const fakePlotEl = {
+      captureAtResolution: (w: number, h: number, opts: { backgroundColor?: string }) => {
+        captures.push({ bg: opts.backgroundColor ?? '' });
+        const c = document.createElement('canvas');
+        c.width = w;
+        c.height = h;
+        return c;
+      },
+    } as unknown as HTMLElement;
+
+    // jsdom doesn't implement canvas getContext; stub it so composeFigure
+    // (called downstream of _redraw) doesn't throw an unhandled exception
+    // inside a requestAnimationFrame callback.
+    const stubCtx = new Proxy(
+      {},
+      { get: () => () => undefined },
+    ) as unknown as CanvasRenderingContext2D;
+    const origGetContext = HTMLCanvasElement.prototype.getContext;
+    HTMLCanvasElement.prototype.getContext = function () {
+      return stubCtx;
+    } as typeof HTMLCanvasElement.prototype.getContext;
+
+    try {
+      const modal = document.createElement('protspace-publish-modal') as HTMLElement & {
+        plotElement: HTMLElement;
+        _state: { background: 'white' | 'transparent' };
+        requestUpdate: () => void;
+        updateComplete: Promise<unknown>;
+      };
+      modal.plotElement = fakePlotEl;
+      document.body.appendChild(modal);
+      await modal.updateComplete;
+
+      modal._state = { ...modal._state, background: 'white' };
+      modal.requestUpdate();
+      await modal.updateComplete;
+      await new Promise((r) => requestAnimationFrame(r));
+
+      modal._state = { ...modal._state, background: 'transparent' };
+      modal.requestUpdate();
+      await modal.updateComplete;
+      await new Promise((r) => requestAnimationFrame(r));
+
+      expect(captures.some((c) => c.bg === '#ffffff')).toBe(true);
+      expect(captures.some((c) => c.bg === 'rgba(0,0,0,0)')).toBe(true);
+      modal.remove();
+    } finally {
+      HTMLCanvasElement.prototype.getContext = origGetContext;
+    }
+  });
+});

--- a/packages/core/src/components/publish/publish-modal.test.ts
+++ b/packages/core/src/components/publish/publish-modal.test.ts
@@ -871,4 +871,62 @@ describe('<protspace-publish-modal> plot cache key', () => {
       HTMLCanvasElement.prototype.getContext = origGetContext;
     }
   });
+
+  it('inset render skips fast-path when invoked from export', async () => {
+    const captures: Array<{ w: number; h: number }> = [];
+    const fakePlotEl = {
+      captureAtResolution: (w: number, h: number) => {
+        captures.push({ w, h });
+        const c = document.createElement('canvas');
+        c.width = w;
+        c.height = h;
+        return c;
+      },
+      getDataExtent: () => ({ xMin: 0, xMax: 1, yMin: 0, yMax: 1 }),
+      getRenderInfo: () => ({ marginLeft: 0, marginRight: 0, marginTop: 0, marginBottom: 0 }),
+    } as unknown as HTMLElement;
+
+    const modal = document.createElement('protspace-publish-modal') as HTMLElement & {
+      plotElement: HTMLElement;
+      _state: Record<string, unknown>;
+      _lastInsetRenderAt: number;
+      _lastInsetCanvases: Array<HTMLCanvasElement | undefined>;
+      _captureInsetRenders: (
+        plotEl: unknown,
+        state: unknown,
+        plotRect: { w: number; h: number },
+        bgColor: string,
+        opts?: { forExport?: boolean },
+      ) => Array<HTMLCanvasElement | null>;
+    };
+    modal.plotElement = fakePlotEl;
+    document.body.appendChild(modal);
+    modal._lastInsetRenderAt = performance.now();
+    // Simulate a prior preview-resolution render sitting in the cache. Without
+    // the export bypass this is what _handleExport would silently return at
+    // tiny preview dims instead of a fresh export-resolution render.
+    const previewCanvas = document.createElement('canvas');
+    previewCanvas.width = 100;
+    previewCanvas.height = 60;
+    modal._lastInsetCanvases = [previewCanvas];
+    modal._state = {
+      ...(modal._state as Record<string, unknown>),
+      insets: [
+        {
+          sourceRect: { x: 0, y: 0, w: 0.5, h: 0.5 },
+          targetRect: { x: 0.5, y: 0.5, w: 0.4, h: 0.4 },
+          border: 0,
+          connector: 'none',
+        },
+      ],
+    };
+    captures.length = 0;
+
+    modal._captureInsetRenders(fakePlotEl, modal._state, { w: 1000, h: 600 }, '#ffffff', {
+      forExport: true,
+    });
+
+    expect(captures.length).toBeGreaterThan(0);
+    modal.remove();
+  });
 });

--- a/packages/core/src/components/publish/publish-modal.test.ts
+++ b/packages/core/src/components/publish/publish-modal.test.ts
@@ -931,6 +931,37 @@ describe('<protspace-publish-modal> plot cache key', () => {
   });
 });
 
+describe('<protspace-publish-modal> preset sizeMode sync', () => {
+  beforeEach(() => {
+    document.body.innerHTML = '';
+  });
+
+  it('switches sizeMode to 1-column when applying a 1-column preset', async () => {
+    const stubCtx = new Proxy(
+      {},
+      { get: () => () => undefined },
+    ) as unknown as CanvasRenderingContext2D;
+    const origGetContext = HTMLCanvasElement.prototype.getContext;
+    HTMLCanvasElement.prototype.getContext = function () {
+      return stubCtx;
+    } as typeof HTMLCanvasElement.prototype.getContext;
+
+    try {
+      const modal = document.createElement('protspace-publish-modal') as HTMLElement & {
+        _state: { sizeMode: string; preset: string };
+        _applyPreset: (id: string) => void;
+      };
+      document.body.appendChild(modal);
+      modal._state = { ...modal._state, sizeMode: '2-column' };
+      modal._applyPreset('nature-1col');
+      expect(modal._state.sizeMode).toBe('1-column');
+      modal.remove();
+    } finally {
+      HTMLCanvasElement.prototype.getContext = origGetContext;
+    }
+  });
+});
+
 describe('<protspace-publish-modal> disconnect guard', () => {
   beforeEach(() => {
     document.body.innerHTML = '';

--- a/packages/core/src/components/publish/publish-modal.test.ts
+++ b/packages/core/src/components/publish/publish-modal.test.ts
@@ -930,3 +930,56 @@ describe('<protspace-publish-modal> plot cache key', () => {
     modal.remove();
   });
 });
+
+describe('<protspace-publish-modal> disconnect guard', () => {
+  beforeEach(() => {
+    document.body.innerHTML = '';
+  });
+
+  it('does not call _setupOverlay after disconnect during _applyStateAndRebuild', async () => {
+    // jsdom doesn't implement canvas getContext; stub it so the redraw
+    // path triggered by _applyStateAndRebuild doesn't throw inside a rAF
+    // callback.
+    const stubCtx = new Proxy(
+      {},
+      { get: () => () => undefined },
+    ) as unknown as CanvasRenderingContext2D;
+    const origGetContext = HTMLCanvasElement.prototype.getContext;
+    HTMLCanvasElement.prototype.getContext = function () {
+      return stubCtx;
+    } as typeof HTMLCanvasElement.prototype.getContext;
+
+    try {
+      const modal = document.createElement('protspace-publish-modal') as HTMLElement & {
+        _setupOverlay: () => void;
+        _applyStateAndRebuild: (s: unknown) => void;
+        _state: Record<string, unknown>;
+        plotElement: HTMLElement;
+        updateComplete: Promise<unknown>;
+      };
+      modal.plotElement = document.createElement('div');
+      document.body.appendChild(modal);
+      // Wait for the first render so firstUpdated() (which itself calls
+      // _setupOverlay) has already fired before we start counting.
+      await modal.updateComplete;
+
+      let setupCalls = 0;
+      const orig = modal._setupOverlay.bind(modal);
+      modal._setupOverlay = () => {
+        setupCalls++;
+        orig();
+      };
+
+      modal._applyStateAndRebuild({ ...modal._state });
+      modal.remove();
+
+      await Promise.resolve();
+      await Promise.resolve();
+      await new Promise((r) => requestAnimationFrame(r));
+
+      expect(setupCalls).toBe(0);
+    } finally {
+      HTMLCanvasElement.prototype.getContext = origGetContext;
+    }
+  });
+});

--- a/packages/core/src/components/publish/publish-modal.ts
+++ b/packages/core/src/components/publish/publish-modal.ts
@@ -366,7 +366,7 @@ export class ProtspacePublishModal extends LitElement {
     const plotEl = this.plotElement as CaptureablePlotElement;
     const bgColor = s.background === 'white' ? '#ffffff' : 'rgba(0,0,0,0)';
 
-    const cacheKey = `${plotRect.w}x${plotRect.h}`;
+    const cacheKey = `${plotRect.w}x${plotRect.h}|${bgColor}`;
     if (cacheKey !== this._plotCacheKey || !this._cachedPlotCanvas) {
       this._cachedPlotCanvas = capturePlotCanvas(plotEl, {
         width: plotRect.w,

--- a/packages/core/src/components/publish/publish-modal.ts
+++ b/packages/core/src/components/publish/publish-modal.ts
@@ -177,9 +177,11 @@ export class ProtspacePublishModal extends LitElement {
    *  user stops moving so we replace the stretched cache with a fresh,
    *  full-resolution render. */
   private _settleTimer: ReturnType<typeof setTimeout> | null = null;
+  private _disposed = false;
 
   override connectedCallback() {
     super.connectedCallback();
+    this._disposed = false;
     this._state = this.savedPublishState
       ? sanitizePublishState(this.savedPublishState)
       : createDefaultPublishState();
@@ -198,6 +200,7 @@ export class ProtspacePublishModal extends LitElement {
 
   override disconnectedCallback() {
     super.disconnectedCallback();
+    this._disposed = true;
     window.removeEventListener('keydown', this._onKeyDown);
     this._overlayController?.destroy();
     this._overlayController = null;
@@ -783,7 +786,10 @@ export class ProtspacePublishModal extends LitElement {
     this._plotCacheKey = '';
     this._overlayController?.destroy();
     this._overlayController = null;
-    this.updateComplete.then(() => this._setupOverlay());
+    this.updateComplete.then(() => {
+      if (this._disposed) return;
+      this._setupOverlay();
+    });
   }
 
   private _clearOverlays() {

--- a/packages/core/src/components/publish/publish-modal.ts
+++ b/packages/core/src/components/publish/publish-modal.ts
@@ -20,7 +20,15 @@ import {
   type Overlay,
   type Inset,
 } from './publish-state';
-import { pxToMm, mmToIn, mmToCm, inToMm, cmToMm, mmToPx } from './dimension-utils';
+import {
+  pxToMm,
+  mmToIn,
+  mmToCm,
+  inToMm,
+  cmToMm,
+  mmToPx,
+  SIZE_MODE_WIDTH_MM,
+} from './dimension-utils';
 import { sanitizePublishState } from './publish-state-validator';
 import {
   capturePlotCanvas,
@@ -496,17 +504,20 @@ export class ProtspacePublishModal extends LitElement {
       const maxPx = mmToPx(preset.maxHeightMm, preset.dpi);
       heightPx = Math.min(heightPx, maxPx);
     }
+    // Match the preset's mm width to the corresponding sizeMode so the UI's
+    // width-locked logic stays consistent with the dimensions being applied.
+    let sizeMode = this._state.sizeMode;
+    if (preset?.widthMm === SIZE_MODE_WIDTH_MM['1-column']) sizeMode = '1-column';
+    else if (preset?.widthMm === SIZE_MODE_WIDTH_MM['2-column']) sizeMode = '2-column';
+    else if (preset?.widthMm === undefined) sizeMode = 'flexible';
     this._state = {
       ...this._state,
       ...patch,
       heightPx,
+      sizeMode,
     };
     this._plotCacheKey = '';
-    if (wasResampleOff) {
-      this._showResampleNote = true;
-    } else {
-      this._showResampleNote = false;
-    }
+    this._showResampleNote = wasResampleOff;
   }
 
   /**

--- a/packages/core/src/components/publish/publish-modal.ts
+++ b/packages/core/src/components/publish/publish-modal.ts
@@ -170,20 +170,10 @@ export class ProtspacePublishModal extends LitElement {
   private _redrawHandle: number | null = null;
   private _plotCacheKey = '';
   private _cachedPlotCanvas: HTMLCanvasElement | null = null;
-  /** Per-inset geometric capture cache. Keyed by sourceRect + target dims +
-   *  plotRect dims + dot scale + bgColor — renders at the target rect's
-   *  exact pixel dims so dot pixel sizes map 1:1 to display. */
   private _insetRenderCache = new Map<string, HTMLCanvasElement>();
-  /** Last WebGL-rendered canvas per inset index. Used as a stretchable
-   *  fallback during high-frequency state updates (drag-resize) to skip
-   *  the ~15–30 ms WebGL context setup + shader compile per frame. The
-   *  compositor's drawImage stretches it to the live target rect — minor
-   *  blur during drag, replaced by a fresh render once activity settles. */
+  /** Stretchable fallback during drag — saves ~15–30 ms WebGL setup per frame. */
   private _lastInsetCanvases: Array<HTMLCanvasElement | null> = [];
   private _lastInsetRenderAt = 0;
-  /** When fastPath skipped a render, fire a follow-up rAF tick after the
-   *  user stops moving so we replace the stretched cache with a fresh,
-   *  full-resolution render. */
   private _settleTimer: ReturnType<typeof setTimeout> | null = null;
   private _disposed = false;
 

--- a/packages/core/src/components/publish/publish-modal.ts
+++ b/packages/core/src/components/publish/publish-modal.ts
@@ -523,6 +523,7 @@ export class ProtspacePublishModal extends LitElement {
     state: PublishState,
     plotRect: { w: number; h: number },
     bgColor: string,
+    opts: { forExport?: boolean } = {},
   ): Array<HTMLCanvasElement | null> {
     if (state.insets.length === 0) {
       this._insetRenderCache.clear();
@@ -560,7 +561,7 @@ export class ProtspacePublishModal extends LitElement {
       typeof performance !== 'undefined' && typeof performance.now === 'function'
         ? performance.now()
         : Date.now();
-    const fastPath = now - this._lastInsetRenderAt < 80;
+    const fastPath = !opts.forExport && now - this._lastInsetRenderAt < 80;
     const livingKeys = new Set<string>();
     if (this._lastInsetCanvases.length !== state.insets.length) {
       this._lastInsetCanvases.length = state.insets.length;
@@ -721,7 +722,9 @@ export class ProtspacePublishModal extends LitElement {
     });
 
     // Per-inset geometric renders for the export.
-    const insetRenders = this._captureInsetRenders(plotEl, s, plotRect, bgColor);
+    const insetRenders = this._captureInsetRenders(plotEl, s, plotRect, bgColor, {
+      forExport: true,
+    });
 
     const outCanvas = document.createElement('canvas');
     outCanvas.width = s.widthPx;

--- a/packages/core/src/components/publish/publish-overlay-controller.test.ts
+++ b/packages/core/src/components/publish/publish-overlay-controller.test.ts
@@ -402,6 +402,71 @@ describe('PublishOverlayController', () => {
       // Should select index 1 (last drawn = topmost)
       expect(callbacks.onSelectionChanged).toHaveBeenCalledWith('overlay', 1);
     });
+
+    it('hit-tests a rotated ellipse using its rotated frame, not the AABB', () => {
+      // Canvas is 1000×500. rxPx=50, ryPx=100 (before rotation). After 90° rotation
+      // the ry axis lies horizontally, so the boundary on the right reaches
+      // (cx + ryPx, cy) = (600, 250) — outside the unrotated AABB (cx ± rxPx =
+      // 450..550 horizontally), so a buggy AABB-only test would miss this hit.
+      const ellipse: Overlay = {
+        type: 'circle',
+        cx: 0.5,
+        cy: 0.5,
+        rx: 0.05,
+        ry: 0.2,
+        rotation: Math.PI / 2,
+        color: '#000000',
+        strokeWidth: 2,
+      };
+      callbacks.getOverlays.mockReturnValue([ellipse]);
+      controller.tool = 'select';
+
+      canvas.dispatchEvent(pointerEvent('pointerdown', 600, 250));
+      canvas.dispatchEvent(pointerEvent('pointerup', 600, 250));
+
+      expect(callbacks.onSelectionChanged).toHaveBeenCalledWith('overlay', 0);
+    });
+
+    it('does not hit-test a click far from a rotated ellipse', () => {
+      const ellipse: Overlay = {
+        type: 'circle',
+        cx: 0.5,
+        cy: 0.5,
+        rx: 0.05,
+        ry: 0.2,
+        rotation: Math.PI / 2,
+        color: '#000000',
+        strokeWidth: 2,
+      };
+      callbacks.getOverlays.mockReturnValue([ellipse]);
+      controller.tool = 'select';
+
+      // (800, 250) sits well past the rotated ellipse's right boundary (~600px).
+      canvas.dispatchEvent(pointerEvent('pointerdown', 800, 250));
+      canvas.dispatchEvent(pointerEvent('pointerup', 800, 250));
+
+      expect(callbacks.onSelectionChanged).toHaveBeenCalledWith(null, -1);
+    });
+
+    it('does not select a zero-size circle even when clicking its centre', () => {
+      const degenerate: Overlay = {
+        type: 'circle',
+        cx: 0.5,
+        cy: 0.5,
+        rx: 0,
+        ry: 0,
+        rotation: 0,
+        color: '#000000',
+        strokeWidth: 2,
+      };
+      callbacks.getOverlays.mockReturnValue([degenerate]);
+      controller.tool = 'select';
+
+      canvas.dispatchEvent(pointerEvent('pointerdown', 500, 250));
+      canvas.dispatchEvent(pointerEvent('pointerup', 500, 250));
+
+      expect(callbacks.onSelectionChanged).toHaveBeenCalledWith(null, -1);
+    });
   });
 
   describe('select mode — movement', () => {

--- a/packages/core/src/components/publish/publish-state-validator.test.ts
+++ b/packages/core/src/components/publish/publish-state-validator.test.ts
@@ -265,4 +265,58 @@ describe('sanitizePublishState', () => {
     expect(result.resample).toBe(true);
     expect(result.aspectLocked).toBe(true);
   });
+
+  it('clamps NormRect width when x + w slightly exceeds 1', () => {
+    const out = sanitizePublishState({
+      insets: [
+        {
+          sourceRect: { x: 0.5, y: 0.5, w: 0.5009, h: 0.4 },
+          targetRect: { x: 0, y: 0, w: 0.2, h: 0.2 },
+          border: 0,
+          connector: 'none',
+        },
+      ],
+    });
+    expect(out.insets).toHaveLength(1);
+    expect(out.insets[0].sourceRect.x + out.insets[0].sourceRect.w).toBeLessThanOrEqual(1);
+  });
+
+  it('rejects NormRect when x + w exceeds the slack tolerance', () => {
+    const out = sanitizePublishState({
+      insets: [
+        {
+          sourceRect: { x: 0.5, y: 0, w: 0.6, h: 0.2 },
+          targetRect: { x: 0, y: 0, w: 0.2, h: 0.2 },
+          border: 0,
+          connector: 'none',
+        },
+      ],
+    });
+    expect(out.insets).toHaveLength(0);
+  });
+
+  it('caps label text length to MAX_LABEL_TEXT_LENGTH', () => {
+    const huge = 'a'.repeat(10_000);
+    const out = sanitizePublishState({
+      overlays: [{ type: 'label', x: 0.1, y: 0.1, text: huge, fontSize: 14, color: '#000' }],
+    });
+    expect(out.overlays).toHaveLength(1);
+    const label = out.overlays[0] as { text: string };
+    expect(label.text.length).toBe(256);
+  });
+
+  it('does not mutate Object.prototype when given a __proto__ payload', () => {
+    const originalToString = Object.prototype.toString;
+    sanitizePublishState(JSON.parse('{"__proto__": {"isAdmin": true}, "overlays": []}'));
+    expect((Object.prototype as unknown as { isAdmin?: boolean }).isAdmin).toBeUndefined();
+    expect(Object.prototype.toString).toBe(originalToString);
+  });
+
+  it('survives deeply nested junk values without throwing', () => {
+    let nested: unknown = 'leaf';
+    for (let i = 0; i < 200; i++) nested = { wrap: nested };
+    expect(() =>
+      sanitizePublishState({ overlays: [nested], insets: [{ sourceRect: nested }] }),
+    ).not.toThrow();
+  });
 });

--- a/packages/core/src/components/publish/publish-state-validator.ts
+++ b/packages/core/src/components/publish/publish-state-validator.ts
@@ -36,6 +36,10 @@ function isValidPixelDim(v: unknown): v is number {
   return isFiniteNumber(v) && v > 0 && v <= MAX_CANVAS_PIXEL_DIM;
 }
 
+/** Max length for label text. Anything longer is truncated to keep state
+ *  size bounded (a crafted bundle could otherwise blow localStorage quota). */
+const MAX_LABEL_TEXT_LENGTH = 256;
+
 function sanitizeOverlay(raw: unknown): Overlay | null {
   if (!isObject(raw)) return null;
   const type = raw.type;
@@ -79,7 +83,7 @@ function sanitizeOverlay(raw: unknown): Overlay | null {
       type: 'label',
       x: raw.x,
       y: raw.y,
-      text: raw.text,
+      text: raw.text.slice(0, MAX_LABEL_TEXT_LENGTH),
       fontSize: raw.fontSize,
       rotation: isFiniteNumber(raw.rotation) ? raw.rotation : 0,
       color: raw.color,
@@ -93,8 +97,14 @@ function sanitizeNormRect(raw: unknown): NormRect | null {
   if (!inUnit(raw.x) || !inUnit(raw.y)) return null;
   if (!isFiniteNumber(raw.w) || !isFiniteNumber(raw.h)) return null;
   if (raw.w <= 0 || raw.h <= 0) return null;
-  if (raw.x + raw.w > 1.001 || raw.y + raw.h > 1.001) return null;
-  return { x: raw.x, y: raw.y, w: raw.w, h: raw.h };
+  const SLACK = 0.001;
+  if (raw.x + raw.w > 1 + SLACK || raw.y + raw.h > 1 + SLACK) return null;
+  return {
+    x: raw.x,
+    y: raw.y,
+    w: Math.min(raw.w, 1 - raw.x),
+    h: Math.min(raw.h, 1 - raw.y),
+  };
 }
 
 function sanitizeInset(raw: unknown): Inset | null {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -39,6 +39,7 @@ export type {
   LegendOverflow,
 } from './components/publish/publish-state';
 export type { PresetId, JournalPreset } from './components/publish/journal-presets';
+export { pxToMm } from './components/publish/dimension-utils';
 
 // Utilities for data loading
 export { readFileOptimized } from './components/data-loader/utils/file-io';

--- a/packages/utils/src/parquet/index.ts
+++ b/packages/utils/src/parquet/index.ts
@@ -31,6 +31,7 @@ export {
   isValidExportOptionsMap,
   isValidSortMode,
   normalizeBundleSettings,
+  type NormalizeBundleSettingsOptions,
 } from './settings-validation';
 
 // Types

--- a/packages/utils/src/parquet/settings-validation.test.ts
+++ b/packages/utils/src/parquet/settings-validation.test.ts
@@ -262,5 +262,31 @@ describe('settings-validation', () => {
       expect(result).not.toBeNull();
       expect(result!.publishState).toEqual({ widthPx: 1051, dpi: 300, annotations: [] });
     });
+
+    it('runs the optional publishState sanitizer when provided', () => {
+      const calls: unknown[] = [];
+      const fakeSanitizer = (input: unknown) => {
+        calls.push(input);
+        return { sanitized: true };
+      };
+      const obj = {
+        legendSettings: {},
+        exportOptions: {},
+        publishState: { fromBundle: true },
+      };
+      const result = normalizeBundleSettings(obj, { sanitizePublishState: fakeSanitizer });
+      expect(calls).toEqual([{ fromBundle: true }]);
+      expect(result?.publishState).toEqual({ sanitized: true });
+    });
+
+    it('passes publishState through unchanged when no sanitizer is provided (back-compat)', () => {
+      const obj = {
+        legendSettings: {},
+        exportOptions: {},
+        publishState: { raw: 1 },
+      };
+      const result = normalizeBundleSettings(obj);
+      expect(result?.publishState).toEqual({ raw: 1 });
+    });
   });
 });

--- a/packages/utils/src/parquet/settings-validation.ts
+++ b/packages/utils/src/parquet/settings-validation.ts
@@ -291,15 +291,27 @@ function sanitizeExportOptionsMap(obj: unknown): ExportOptionsMap | null {
   return result;
 }
 
+export interface NormalizeBundleSettingsOptions {
+  /** Optional sanitizer applied to `publishState` before it leaves the boundary.
+   *  Injected because `@protspace/utils` cannot depend on `@protspace/core`. */
+  sanitizePublishState?: (input: unknown) => unknown;
+}
+
 /**
  * Normalize bundle settings to the current format.
  */
-export function normalizeBundleSettings(obj: unknown): BundleSettings | null {
+export function normalizeBundleSettings(
+  obj: unknown,
+  options: NormalizeBundleSettingsOptions = {},
+): BundleSettings | null {
   if (isNormalizedBundleSettings(obj)) {
     return {
       legendSettings: sanitizeLegendSettingsMap(obj.legendSettings) ?? obj.legendSettings,
       exportOptions: sanitizeExportOptionsMap(obj.exportOptions) ?? obj.exportOptions,
-      publishState: obj.publishState,
+      publishState:
+        options.sanitizePublishState && obj.publishState !== undefined
+          ? (options.sanitizePublishState(obj.publishState) as Record<string, unknown>)
+          : obj.publishState,
     };
   }
 
@@ -317,12 +329,16 @@ export function normalizeBundleSettings(obj: unknown): BundleSettings | null {
     const sanitizedExportOptions = sanitizeExportOptionsMap(settings.exportOptions) ?? {};
 
     if (sanitizedLegendSettings) {
-      const publishState =
+      const rawPublishState =
         typeof settings.publishState === 'object' &&
         settings.publishState !== null &&
         !Array.isArray(settings.publishState)
           ? (settings.publishState as Record<string, unknown>)
           : undefined;
+      const publishState =
+        options.sanitizePublishState && rawPublishState !== undefined
+          ? (options.sanitizePublishState(rawPublishState) as Record<string, unknown>)
+          : rawPublishState;
       return {
         legendSettings: sanitizedLegendSettings,
         exportOptions: sanitizedExportOptions,

--- a/packages/utils/src/png/phys-chunk.test.ts
+++ b/packages/utils/src/png/phys-chunk.test.ts
@@ -146,18 +146,6 @@ describe('pngWithDpi', () => {
     expect(readUint32(buf, ihdr!.dataOffset + 4)).toBe(1);
   });
 
-  it('pHYs chunk carries a correct CRC32', async () => {
-    const blob = new Blob([ONE_BY_ONE_PNG], { type: 'image/png' });
-    const out = await pngWithDpi(blob, 300);
-    const buf = new Uint8Array(await out.arrayBuffer());
-    const phys = findChunk(buf, 'pHYs');
-    expect(phys).not.toBeNull();
-    // CRC sits immediately after the 9-byte data block.
-    const crcOffset = phys!.dataOffset + 9;
-    const storedCrc = readUint32(buf, crcOffset);
-    expect(storedCrc).toBe(0x78a53f76); // independently computed for {type='pHYs', ppm=11811, ppm=11811, unit=1}
-  });
-
   it('replaces a pre-existing pHYs chunk rather than duplicating it', async () => {
     const blob = new Blob([ONE_BY_ONE_PNG], { type: 'image/png' });
     const first = await pngWithDpi(blob, 96);
@@ -183,5 +171,64 @@ describe('pngWithDpi', () => {
     // And it carries the new (300 DPI) value, not the stale one.
     const phys = findChunk(buf, 'pHYs');
     expect(readUint32(buf, phys!.dataOffset)).toBe(11811);
+  });
+
+  it('returns the input unchanged when the PNG signature is missing', async () => {
+    const notAPng = new Uint8Array(64).fill(0xab);
+    const blob = new Blob([notAPng], { type: 'image/png' });
+    const out = await pngWithDpi(blob, 300);
+    // Same bytes back — no pHYs injected.
+    const buf = new Uint8Array(await out.arrayBuffer());
+    expect(buf.length).toBe(notAPng.length);
+    expect(buf[0]).toBe(0xab);
+  });
+
+  it('returns the input unchanged when a chunk length runs past the buffer', async () => {
+    // Take a valid 1×1 PNG, corrupt the IDAT length to a huge value.
+    const corrupt = new Uint8Array(ONE_BY_ONE_PNG);
+    // IDAT length sits at signature(8) + IHDR(25) = 33.
+    corrupt[33] = 0xff;
+    corrupt[34] = 0xff;
+    corrupt[35] = 0xff;
+    corrupt[36] = 0xff;
+    const out = await pngWithDpi(new Blob([corrupt], { type: 'image/png' }), 300);
+    const outBuf = new Uint8Array(await out.arrayBuffer());
+    expect(outBuf.length).toBe(corrupt.length);
+  });
+
+  it('CRC32 matches an independent reference implementation', async () => {
+    // Reference: standard CRC-32 (IEEE 802.3, polynomial 0xEDB88320).
+    // Computed inline so the test isn't relying on the same code under test.
+    const refCrc32 = (data: Uint8Array): number => {
+      let crc = 0xffffffff;
+      for (let i = 0; i < data.length; i++) {
+        crc ^= data[i];
+        for (let k = 0; k < 8; k++) {
+          crc = crc & 1 ? (crc >>> 1) ^ 0xedb88320 : crc >>> 1;
+        }
+      }
+      return (crc ^ 0xffffffff) >>> 0;
+    };
+    // Build the type+data the production code computes CRC over for 300 DPI.
+    const ppm = Math.round(300 * 39.3700787401575); // 11811
+    const typeAndData = new Uint8Array(13);
+    typeAndData.set([0x70, 0x48, 0x59, 0x73], 0); // 'pHYs'
+    typeAndData[4] = (ppm >>> 24) & 0xff;
+    typeAndData[5] = (ppm >>> 16) & 0xff;
+    typeAndData[6] = (ppm >>> 8) & 0xff;
+    typeAndData[7] = ppm & 0xff;
+    typeAndData[8] = (ppm >>> 24) & 0xff;
+    typeAndData[9] = (ppm >>> 16) & 0xff;
+    typeAndData[10] = (ppm >>> 8) & 0xff;
+    typeAndData[11] = ppm & 0xff;
+    typeAndData[12] = 1; // unit = metres
+    const expectedCrc = refCrc32(typeAndData);
+
+    const blob = new Blob([ONE_BY_ONE_PNG], { type: 'image/png' });
+    const out = await pngWithDpi(blob, 300);
+    const buf = new Uint8Array(await out.arrayBuffer());
+    const phys = findChunk(buf, 'pHYs')!;
+    const crcOffset = phys.dataOffset + 9;
+    expect(readUint32(buf, crcOffset)).toBe(expectedCrc);
   });
 });

--- a/packages/utils/src/png/phys-chunk.ts
+++ b/packages/utils/src/png/phys-chunk.ts
@@ -14,6 +14,7 @@
 
 const PNG_SIGNATURE_LENGTH = 8;
 const INCH_PER_METRE = 39.3700787401575;
+const PNG_SIGNATURE: ReadonlyArray<number> = [0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a];
 
 const CRC_TABLE: Uint32Array = (() => {
   const table = new Uint32Array(256);
@@ -72,33 +73,46 @@ export async function pngWithDpi(blob: Blob, dpi: number): Promise<Blob> {
   const ab: ArrayBuffer = await blob.arrayBuffer();
   const buf = new Uint8Array(ab);
   if (buf.length < PNG_SIGNATURE_LENGTH) return blob;
+  for (let i = 0; i < PNG_SIGNATURE_LENGTH; i++) {
+    if (buf[i] !== PNG_SIGNATURE[i]) {
+      console.warn('pngWithDpi: input is not a PNG (signature mismatch); returning unchanged');
+      return blob;
+    }
+  }
 
   // IHDR is always the first chunk, fixed-size: 4 length + 4 type + 13 data + 4 crc = 25 bytes.
   const ihdrEnd = PNG_SIGNATURE_LENGTH + 25;
   if (ihdrEnd > buf.length) return blob;
 
-  // Collect the byte ranges to include in the output (as [start, end) offsets into buf).
-  const ranges: Array<[number, number]> = [[0, ihdrEnd]]; // head (sig + IHDR)
+  const ranges: Array<[number, number]> = [[0, ihdrEnd]];
 
-  // Scan the tail, collecting non-pHYs chunk ranges.
   let cursor = ihdrEnd;
+  let malformed = false;
   while (cursor < buf.length) {
     if (cursor + 8 > buf.length) {
       ranges.push([cursor, buf.length]);
       break;
     }
     const length = readUint32(buf, cursor);
+    const total = 12 + length;
+    if (cursor + total > buf.length) {
+      malformed = true;
+      break;
+    }
     const tag = String.fromCharCode(
       buf[cursor + 4],
       buf[cursor + 5],
       buf[cursor + 6],
       buf[cursor + 7],
     );
-    const total = 12 + length;
     if (tag !== 'pHYs') {
       ranges.push([cursor, cursor + total]);
     }
     cursor += total;
+  }
+  if (malformed) {
+    console.warn('pngWithDpi: chunk length runs past end of buffer; returning unchanged');
+    return blob;
   }
 
   const phys = buildPhysChunk(dpi);

--- a/packages/utils/src/visualization/export-utils.test.ts
+++ b/packages/utils/src/visualization/export-utils.test.ts
@@ -111,50 +111,6 @@ describe('ProtSpaceExporter.validateCanvasDimensions', () => {
   });
 });
 
-describe('Export dimension calculations', () => {
-  describe('legend width percentage calculations', () => {
-    it('calculates correct legend width from percentage', () => {
-      // If scatterplot is 2048px and legend is 25%, total should be 2048 / 0.75 = 2730.67
-      // Legend width = 2730.67 * 0.25 = 682.67
-      const scatterWidth = 2048;
-      const legendPercent = 25 / 100;
-      const legendWidth = Math.round(scatterWidth * (legendPercent / (1 - legendPercent)));
-
-      expect(legendWidth).toBe(683); // Rounded
-    });
-
-    it('handles different legend percentages', () => {
-      const scatterWidth = 1000;
-
-      // 15% legend
-      const legend15 = Math.round(scatterWidth * (0.15 / 0.85));
-      expect(legend15).toBe(176);
-
-      // 50% legend
-      const legend50 = Math.round(scatterWidth * (0.5 / 0.5));
-      expect(legend50).toBe(1000);
-    });
-  });
-
-  describe('target dimensions for export', () => {
-    it('calculates target width excluding legend', () => {
-      const imageWidth = 2048;
-      const legendPercent = 25 / 100;
-      const targetWidth = Math.round(imageWidth * (1 - legendPercent));
-
-      expect(targetWidth).toBe(1536);
-    });
-
-    it('handles various image widths', () => {
-      const legendPercent = 0.25;
-
-      expect(Math.round(800 * (1 - legendPercent))).toBe(600);
-      expect(Math.round(4096 * (1 - legendPercent))).toBe(3072);
-      expect(Math.round(8192 * (1 - legendPercent))).toBe(6144);
-    });
-  });
-});
-
 describe('Export scale factor calculations', () => {
   const BASE_FONT_SIZE = 24;
 
@@ -244,28 +200,6 @@ describe('Export options validation', () => {
   });
 });
 
-describe('getOptionsWithDefaults includeLegend behavior', () => {
-  // getOptionsWithDefaults is private, so we test its behavior via the
-  // static defaults and the ExportOptions contract it consumes.
-
-  it('should default includeLegend to true when not specified', () => {
-    // The private method does: includeLegend: options.includeLegend ?? true
-    // Verify the default is correct by checking the contract:
-    const unset = undefined ?? true;
-    expect(unset).toBe(true);
-  });
-
-  it('should respect explicit false', () => {
-    const explicit = false ?? true;
-    expect(explicit).toBe(false);
-  });
-
-  it('should respect explicit true', () => {
-    const explicit = true ?? true;
-    expect(explicit).toBe(true);
-  });
-});
-
 describe('Export filename generation', () => {
   it('generates consistent filename format', () => {
     // Expected format: protspace_{projection}_{annotation}_{date}.{ext}
@@ -290,51 +224,6 @@ describe('Export filename generation', () => {
     expect(removeDimensionSuffix('pca_2')).toBe('pca');
     expect(removeDimensionSuffix('umap_3')).toBe('umap');
     expect(removeDimensionSuffix('tsne_2d')).toBe('tsne_2d'); // Only removes _2 or _3
-  });
-});
-
-describe('Export constants', () => {
-  // These tests verify the expected export constant values
-  describe('canvas limits', () => {
-    const MAX_CANVAS_DIMENSION = 8192;
-    const MAX_CANVAS_AREA = 268435456;
-    const SAFE_DIMENSION_MARGIN = 0.95;
-
-    it('has correct maximum dimension limit', () => {
-      expect(MAX_CANVAS_DIMENSION).toBe(8192);
-    });
-
-    it('has correct maximum area limit (~268M pixels)', () => {
-      expect(MAX_CANVAS_AREA).toBe(268435456);
-    });
-
-    it('calculates safe dimension correctly', () => {
-      const safeDimension = Math.floor(MAX_CANVAS_DIMENSION * SAFE_DIMENSION_MARGIN);
-      expect(safeDimension).toBe(7782);
-    });
-
-    it('calculates safe area correctly', () => {
-      const safeArea = MAX_CANVAS_AREA * SAFE_DIMENSION_MARGIN;
-      expect(safeArea).toBe(255013683.2);
-    });
-  });
-
-  describe('PDF constants', () => {
-    const PDF_MARGIN = 2;
-    const PDF_GAP = 4;
-    const PDF_MAX_WIDTH = 210; // A4 width in mm
-
-    it('has correct PDF margin', () => {
-      expect(PDF_MARGIN).toBe(2);
-    });
-
-    it('has correct PDF gap', () => {
-      expect(PDF_GAP).toBe(4);
-    });
-
-    it('has correct A4 max width', () => {
-      expect(PDF_MAX_WIDTH).toBe(210);
-    });
   });
 });
 


### PR DESCRIPTION
Addresses every Critical, Important, Minor, and test-coverage finding from the `/review` of PR #232.

## What's fixed

**Critical**
- Plot-cache key now includes background color (white ↔ transparent toggles invalidate)
- Inset render fast-path bypassed during export (no preview-resolution downgrades)
- `_setupOverlay` guarded against post-disconnect resolution (no leaked listeners)

**Important**
- `pngWithDpi` validates PNG signature and chunk-length bounds; warns on malformed input
- `sanitizeNormRect` clamps slack overrun instead of leaking past `[0,1]`
- Label text capped at 256 chars (localStorage quota DoS guard)
- `publishState` sanitized at the parquet ingest boundary (injectable sanitizer keeps utils → core boundary clean)
- `_applyPreset` derives `sizeMode` from preset width
- DRY: `25.4` literals replaced with `pxToMm`/`adjustDpiForWidthMm`
- Dead first pass in legend Y-offset removed
- `capturePlotCanvas` fallback passes full source pixel rect (no HiDPI halving)
- `composeFigure` null-checks 2D context (soft fail instead of crash)
- Modal stays open on export failure (state already persisted; user can retry)

**Test coverage**
- CRC32 cross-validated against an independent reference implementation
- Prototype-pollution + deeply-nested payloads covered in state validator
- Rotated and zero-size overlay hit-testing
- Fingerprint stale-warn DOM rendering
- E2E click-to-Export + verify pHYs ppm in downloaded PNG
- Three tautological export-utils suites dropped (no behavior, just JS-operator identity)

Plus a baseline knip entry registration (`perf/**/*.spec.ts`) so precommit passes.

Plan: `docs/superpowers/plans/2026-05-05-publish-editor-review-fixes.md`.