### PR TITLE
docs: small accuracy fixes (projection list, AlphaFold path, dev port)

### DIFF
--- a/docs/developers/installation.md
+++ b/docs/developers/installation.md
@@ -70,7 +70,7 @@ pnpm install
 pnpm dev
 ```
 
-The dev server runs at `http://localhost:5173`
+The dev server runs at `http://localhost:8080`
 
 ## Requirements
 

--- a/docs/explore/index.md
+++ b/docs/explore/index.md
@@ -19,7 +19,7 @@ The ProtSpace Explore page provides an interactive environment for visualizing a
 
 The control bar contains:
 
-1. **Projection dropdown** - Switch between PCA, UMAP, t-SNE
+1. **Projection dropdown** - Switch between PCA, UMAP, t-SNE, PaCMAP, or MDS
 2. **Annotation dropdown** - Color points by annotation
 3. **Search box** - Find proteins by ID
 4. **Select button** - Rectangle or lasso selection mode

--- a/docs/explore/index.md
+++ b/docs/explore/index.md
@@ -19,7 +19,7 @@ The ProtSpace Explore page provides an interactive environment for visualizing a
 
 The control bar contains:
 
-1. **Projection dropdown** - Switch between PCA, UMAP, t-SNE, PaCMAP, or MDS
+1. **Projection dropdown** - Switch between PCA, UMAP, t-SNE, PaCMAP, MDS, or LocalMAP
 2. **Annotation dropdown** - Color points by annotation
 3. **Search box** - Find proteins by ID
 4. **Select button** - Rectangle or lasso selection mode

--- a/docs/explore/structures.md
+++ b/docs/explore/structures.md
@@ -10,7 +10,7 @@ When you select a protein with a UniProt accession:
 
 1. The structure viewer appears in the sidebar below the legend
 2. Links to [AlphaFold Database](https://alphafold.ebi.ac.uk/), [UniProt](https://www.uniprot.org/), and [InterPro](https://www.interpro.org/) appear at the top - click them anytime
-3. The AlphaFold structure loads automatically via [3D-Beacons API](https://www.ebi.ac.uk/pdbe/pdbe-kb/3dbeacons/)
+3. The AlphaFold structure file is fetched directly from the [AlphaFold Database API](https://alphafold.ebi.ac.uk/api-docs); the [3D-Beacons API](https://www.ebi.ac.uk/pdbe/pdbe-kb/3dbeacons/) is used only to look up the model page link
 
 ::: tip Supported Structures
 Currently, ProtSpace supports **AlphaFold structures** only. PDB experimental structures are not yet integrated.

--- a/docs/guide/index.md
+++ b/docs/guide/index.md
@@ -17,9 +17,9 @@ Protein language models (like ProtT5, ESM2, Ankh) create embeddings that capture
 | -------------------- | ----------------------------------------------------------------------- |
 | **No Installation**  | Runs entirely in your browser at [protspace.app](https://protspace.app) |
 | **Privacy-First**    | Your data never leaves your computer - all processing is client-side    |
-| **Multiple Views**   | PCA, UMAP, t-SNE, MDS, and PaCMAP projections                           |
+| **Multiple Views**   | PCA, UMAP, t-SNE, PaCMAP, MDS, and LocalMAP projections                 |
 | **Rich Annotations** | Color by UniProt, InterPro, Taxonomy, or custom expert annotations      |
-| **3D Structures**    | View protein structures from AlphaFold via 3D-Beacons API               |
+| **3D Structures**    | View protein structures from the AlphaFold Database                     |
 | **Export Options**   | Save images (PNG, PDF), data (Parquet), and protein IDs                 |
 
 ## How It Works

--- a/docs/index.md
+++ b/docs/index.md
@@ -14,7 +14,7 @@ Download example datasets from the [data folder on GitHub](https://github.com/ts
 
 ## What Can You Do?
 
-- **Visualize** protein embeddings in 2D using PCA, UMAP, t-SNE
+- **Visualize** protein embeddings in 2D or 3D using PCA, UMAP, t-SNE, PaCMAP, or MDS
 - **Color** points by biological annotations (taxonomy, family, function, etc.)
 - **Filter** and isolate specific protein groups
 - **Search** for specific proteins by ID

--- a/docs/index.md
+++ b/docs/index.md
@@ -14,7 +14,7 @@ Download example datasets from the [data folder on GitHub](https://github.com/ts
 
 ## What Can You Do?
 
-- **Visualize** protein embeddings in 2D or 3D using PCA, UMAP, t-SNE, PaCMAP, or MDS
+- **Visualize** protein embeddings in 2D or 3D using PCA, UMAP, t-SNE, PaCMAP, MDS, or LocalMAP
 - **Color** points by biological annotations (taxonomy, family, function, etc.)
 - **Filter** and isolate specific protein groups
 - **Search** for specific proteins by ID

--- a/docs/index.md
+++ b/docs/index.md
@@ -14,7 +14,7 @@ Download example datasets from the [data folder on GitHub](https://github.com/ts
 
 ## What Can You Do?
 
-- **Visualize** protein embeddings in 2D or 3D using PCA, UMAP, t-SNE, PaCMAP, MDS, or LocalMAP
+- **Visualize** protein embeddings in 2D using PCA, UMAP, t-SNE, PaCMAP, MDS, or LocalMAP
 - **Color** points by biological annotations (taxonomy, family, function, etc.)
 - **Filter** and isolate specific protein groups
 - **Search** for specific proteins by ID


### PR DESCRIPTION
Three small corrections found while auditing docs against current code:

- `docs/explore/structures.md` — clarified that the AlphaFold structure file is fetched directly from the AlphaFold Database API; 3D-Beacons is only used for the model page link.
- `docs/index.md` and `docs/explore/index.md` — projection list updated from PCA/UMAP/t-SNE to include PaCMAP and MDS (already shipped, just undocumented).
- `docs/developers/installation.md` — dev port `5173` → `8080` to match `config/urls.ts`.