### PR TITLE
docs(explore): document Product Tour and Recovery Banner

### DIFF
--- a/docs/explore/importing-data.md
+++ b/docs/explore/importing-data.md
@@ -63,6 +63,20 @@ OPFS may be unavailable in private/incognito browsing mode, when browser storage
 ProtSpace still works normally without OPFS. Your dataset loads for the current session, but you will need to import it again after reloading the page.
 :::
 
+## When a Previous Load Crashed
+
+If a previous session failed to finish loading a dataset (browser crash, tab closed mid-load, or a corrupt file), ProtSpace shows a recovery banner above the scatterplot when you return. The banner names the file that didn't finish and offers three actions:
+
+- **Try again** — re-attempts the load from the stored copy. Useful if the previous failure was transient (network hiccup, momentary browser stall).
+- **Load default** — replaces the stored file with the demo dataset. Use this if you don't need to recover the specific file.
+- **Clear stored data** — deletes the stored file without loading anything. Choose this if the file is corrupt or you'd rather import a fresh copy yourself.
+
+After three failed retries the banner shifts tone, recommending you clear or load the demo rather than continue retrying.
+
+::: info Why a banner instead of just retrying?
+Auto-retry would loop forever on a genuinely broken file. The banner makes the failure visible and lets you choose the recovery path that fits the situation.
+:::
+
 ## Need a Data File?
 
 To create your own `.parquetbundle` files:

--- a/docs/explore/index.md
+++ b/docs/explore/index.md
@@ -61,6 +61,16 @@ When you select a protein, the 3D viewer appears and fetches its structure from 
 
 <img src="./images/structure-viewer.png" alt="Structure Viewer - showing 3D protein structure" style="max-width: 50%; display: block; margin: 1em 0;" />
 
+## Product Tour
+
+The first time you load a dataset, ProtSpace plays a short guided tour highlighting the projection picker, search, selection tools, the Export menu, and the legend. The tour pauses on each step until you click **Next**, and you can dismiss it any time with **Skip** or by pressing <kbd>Esc</kbd>.
+
+To replay the tour later, click the **?** icon in the top-right of the scatterplot to open the Tips popover, then click **Take a Tour**.
+
+::: tip Keyboard Shortcuts
+The same Tips popover lists all keyboard shortcuts (search, selection, navigation). Worth a glance even if you skip the tour.
+:::
+
 ## Next Steps
 
 - [Importing Data](/explore/importing-data) - Load your protein data


### PR DESCRIPTION
Two undocumented user-facing features surfaced by the docs audit:

- **Product Tour** (`app/src/tour/product-tour.ts`, auto-started 800 ms after first `data-loaded`, replayable via "Take a Tour" in the Tips popover) — added a short section to `docs/explore/index.md` covering when it triggers, how to dismiss (Esc / Skip), and how to replay.
- **Recovery Banner** (`app/src/explore/recovery-banner.ts`) — added a section to `docs/explore/importing-data.md` describing what triggers it and what each of the three actions does (Try again / Load default / Clear stored data), plus the post-3-failures escalation copy.

Pure markdown additions, no images. Image embedding for these (and Figure Editor) will follow in a separate PR that also extends the Playwright capture spec.