### PR TITLE
feat: multi-annotation hover tooltip (#234)

### DIFF
--- a/app/src/explore/control-bar-events.ts
+++ b/app/src/explore/control-bar-events.ts
@@ -40,6 +40,10 @@ export function bindControlBarEvents({
 
   addControlBarListener('projection-change', viewController.handleUserProjectionChange);
 
+  addControlBarListener('tooltip-annotations-change', () => {
+    viewController.handleUserTooltipAnnotationsChange();
+  });
+
   addControlBarListener('selection-disabled-notification', (event: Event) => {
     const customEvent = event as CustomEvent<SelectionDisabledNotificationDetail>;
     notify.warning(getSelectionDisabledNotification(customEvent.detail));

--- a/app/src/explore/data-renderer.ts
+++ b/app/src/explore/data-renderer.ts
@@ -25,6 +25,7 @@ interface ResolvedInitialView {
   annotation: string;
   projectionIndex: number;
   projectionName: string;
+  tooltip: string[];
 }
 
 function resolveRenderableView(
@@ -37,11 +38,24 @@ function resolveRenderableView(
     newData.projections.findIndex((projection) => projection.name === projectionName),
   );
   const firstAnnotationKey = Object.keys(newData.annotations)[0] || '';
+  const annotation = initialView?.annotation ?? firstAnnotationKey;
+
+  const availableAnnotations = new Set(Object.keys(newData.annotations));
+  const seenTooltip = new Set<string>();
+  const tooltip: string[] = [];
+  for (const name of initialView?.tooltip ?? []) {
+    if (name === annotation) continue;
+    if (!availableAnnotations.has(name)) continue;
+    if (seenTooltip.has(name)) continue;
+    seenTooltip.add(name);
+    tooltip.push(name);
+  }
 
   return {
-    annotation: initialView?.annotation ?? firstAnnotationKey,
+    annotation,
     projectionIndex,
     projectionName,
+    tooltip,
   };
 }
 
@@ -69,6 +83,7 @@ function applyPlotState(
   plotElement.data = newData;
   plotElement.selectedProjectionIndex = initialView.projectionIndex;
   plotElement.selectedAnnotation = initialView.annotation;
+  plotElement.tooltipAnnotations = [...initialView.tooltip];
   plotElement.selectedProteinIds = [];
   plotElement.selectionMode = false;
   plotElement.hiddenAnnotationValues = [];
@@ -78,6 +93,7 @@ function applyPlotState(
 function applyControlBarState(controlBar: ProtspaceControlBar, initialView: ResolvedInitialView) {
   controlBar.selectedProjection = initialView.projectionName;
   controlBar.selectedAnnotation = initialView.annotation;
+  controlBar.tooltipAnnotations = [...initialView.tooltip];
   controlBar.selectionMode = false;
   controlBar.selectedProteinsCount = 0;
   controlBar.requestUpdate();
@@ -229,6 +245,7 @@ export function createDataRenderer({
       return {
         annotation: resolvedInitialView.annotation,
         projection: resolvedInitialView.projectionName,
+        tooltip: [...resolvedInitialView.tooltip],
       };
     } finally {
       if (isLargeDataset && !getIsDisposed()) {

--- a/app/src/explore/dataset-controller.ts
+++ b/app/src/explore/dataset-controller.ts
@@ -19,6 +19,7 @@ import type { InteractionController } from './interaction-controller';
 import type { LoadQueue } from './load-queue';
 import { createPersistedDatasetController } from './persisted-dataset';
 import type { PersistedLoadOutcome } from './persisted-dataset';
+import { readTooltipAnnotations, writeTooltipAnnotations } from './tooltip-annotations-store';
 import type { ViewController } from './view-controller';
 
 interface DatasetControllerOptions {
@@ -83,6 +84,13 @@ export function createDatasetController({
     },
     setCurrentDatasetIsDemo,
     setCurrentDatasetName,
+  });
+
+  let currentDatasetHash: string | null = null;
+  viewController.subscribeToViewChanges((change) => {
+    if (currentDatasetHash !== null) {
+      writeTooltipAnnotations(currentDatasetHash, change.effective.tooltip);
+    }
   });
 
   const handleDataLoaded = async (event: Event) => {
@@ -151,6 +159,26 @@ export function createDatasetController({
         setCurrentDatasetName(defaultDatasetName);
         setCurrentDatasetIsDemo(true);
       }
+
+      const latestRequest = viewController.getLatestViewRequest();
+      if (!latestRequest.present.tooltip) {
+        const persistedTooltip = readTooltipAnnotations(datasetHash);
+        if (persistedTooltip.length > 0) {
+          viewController.setRequestedView({
+            ...latestRequest,
+            requested: {
+              ...latestRequest.requested,
+              tooltip: persistedTooltip,
+            },
+            present: {
+              ...latestRequest.present,
+              tooltip: true,
+            },
+          });
+        }
+      }
+
+      currentDatasetHash = datasetHash;
 
       viewController.applyLatestViewForDatasetLoad(data);
 

--- a/app/src/explore/dataset-controller.ts
+++ b/app/src/explore/dataset-controller.ts
@@ -163,23 +163,70 @@ export function createDatasetController({
       // Must be set before the restore block so that any view-change emitted by
       // setRequestedView below is persisted under the new dataset's key, not the
       // previous dataset's key.
+      const hadPreviousDataset = currentDatasetHash !== null;
       currentDatasetHash = datasetHash;
 
       const latestRequest = viewController.getLatestViewRequest();
-      if (!latestRequest.present.tooltip) {
-        const persistedTooltip = readTooltipAnnotations(datasetHash);
-        if (persistedTooltip.length > 0) {
+      // A first-ever load (no previous dataset) that happens to be a user file drop
+      // is NOT a stale-URL situation — there is no previous dataset whose tooltip
+      // param could be carried over — so honor the URL like annotation/projection do.
+      const isUserImport = loadMeta.kind === 'user' && hadPreviousDataset;
+
+      // Read the persisted tooltip set once; used in both branches below.
+      const savedTooltip = readTooltipAnnotations(datasetHash);
+
+      if (isUserImport) {
+        // The URL may still carry a tooltip= param that was set for the PREVIOUSLY
+        // loaded dataset (A). That param is stale for the newly imported dataset (B)
+        // and must be ignored. We always restore B's own persisted tooltip set and,
+        // when the URL had a stale tooltip param, we force a URL rewrite so the URL
+        // reflects B's state rather than A's.
+        //
+        // Only emit a view change when there is something to do:
+        //   - saved has entries (need to restore them), OR
+        //   - URL had a stale param (need to erase it from the URL).
+        const staleUrlHadTooltip = latestRequest.present.tooltip;
+        if (savedTooltip.length > 0 || staleUrlHadTooltip) {
           viewController.setRequestedView({
             ...latestRequest,
             requested: {
               ...latestRequest.requested,
-              tooltip: persistedTooltip,
+              tooltip: savedTooltip.length > 0 ? savedTooltip : undefined,
             },
             present: {
               ...latestRequest.present,
-              tooltip: true,
+              tooltip: savedTooltip.length > 0,
+            },
+            normalize: {
+              ...latestRequest.normalize,
+              // Setting normalize.tooltip=true forces the URL-sync handler to
+              // rewrite (or delete) the tooltip param so the URL matches B's
+              // effective tooltip instead of carrying A's stale value.
+              // This is needed for both the "saved non-empty" case (case 1, sets
+              // tooltip=<saved>) and the "saved empty" case (case 2, removes the
+              // param). When the URL had no stale param and saved is non-empty
+              // (case 3), this stays false so the URL is left silent as expected.
+              tooltip: staleUrlHadTooltip || latestRequest.normalize.tooltip,
             },
           });
+        }
+      } else {
+        // Default load ('default') or OPFS restore ('opfs'): the URL tooltip param
+        // is authoritative. Only restore the persisted set when the URL is silent.
+        if (!latestRequest.present.tooltip) {
+          if (savedTooltip.length > 0) {
+            viewController.setRequestedView({
+              ...latestRequest,
+              requested: {
+                ...latestRequest.requested,
+                tooltip: savedTooltip,
+              },
+              present: {
+                ...latestRequest.present,
+                tooltip: true,
+              },
+            });
+          }
         }
       }
 

--- a/app/src/explore/dataset-controller.ts
+++ b/app/src/explore/dataset-controller.ts
@@ -160,6 +160,11 @@ export function createDatasetController({
         setCurrentDatasetIsDemo(true);
       }
 
+      // Must be set before the restore block so that any view-change emitted by
+      // setRequestedView below is persisted under the new dataset's key, not the
+      // previous dataset's key.
+      currentDatasetHash = datasetHash;
+
       const latestRequest = viewController.getLatestViewRequest();
       if (!latestRequest.present.tooltip) {
         const persistedTooltip = readTooltipAnnotations(datasetHash);
@@ -177,8 +182,6 @@ export function createDatasetController({
           });
         }
       }
-
-      currentDatasetHash = datasetHash;
 
       viewController.applyLatestViewForDatasetLoad(data);
 

--- a/app/src/explore/tooltip-annotations-store.test.ts
+++ b/app/src/explore/tooltip-annotations-store.test.ts
@@ -1,0 +1,58 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { readTooltipAnnotations, writeTooltipAnnotations } from './tooltip-annotations-store';
+
+const HASH = 'abc12345';
+const KEY = `protspace:tooltip-annotations:${HASH}`;
+
+const localStorageMock = (() => {
+  let store: Record<string, string> = {};
+  return {
+    getItem: vi.fn((key: string) => store[key] ?? null),
+    setItem: vi.fn((key: string, value: string) => {
+      store[key] = value;
+    }),
+    removeItem: vi.fn((key: string) => {
+      delete store[key];
+    }),
+    clear: vi.fn(() => {
+      store = {};
+    }),
+    get length() {
+      return Object.keys(store).length;
+    },
+    key: vi.fn((index: number) => Object.keys(store)[index] ?? null),
+  };
+})();
+
+vi.stubGlobal('localStorage', localStorageMock);
+
+describe('tooltip-annotations-store', () => {
+  beforeEach(() => {
+    localStorageMock.clear();
+  });
+
+  it('returns an empty array when nothing is stored', () => {
+    expect(readTooltipAnnotations(HASH)).toEqual([]);
+  });
+
+  it('writes and reads back a list of names', () => {
+    writeTooltipAnnotations(HASH, ['ec', 'go']);
+    expect(readTooltipAnnotations(HASH)).toEqual(['ec', 'go']);
+  });
+
+  it('overwrites previous values on write', () => {
+    writeTooltipAnnotations(HASH, ['ec', 'go']);
+    writeTooltipAnnotations(HASH, ['pfam']);
+    expect(readTooltipAnnotations(HASH)).toEqual(['pfam']);
+  });
+
+  it('ignores non-string entries from corrupted storage', () => {
+    localStorageMock.setItem(KEY, JSON.stringify(['ec', 42, null, 'go']));
+    expect(readTooltipAnnotations(HASH)).toEqual(['ec', 'go']);
+  });
+
+  it('returns an empty array for non-array stored values', () => {
+    localStorageMock.setItem(KEY, JSON.stringify({ bogus: true }));
+    expect(readTooltipAnnotations(HASH)).toEqual([]);
+  });
+});

--- a/app/src/explore/tooltip-annotations-store.ts
+++ b/app/src/explore/tooltip-annotations-store.ts
@@ -1,0 +1,17 @@
+import { buildStorageKey, getStorageItem, setStorageItem } from '@protspace/utils';
+
+const COMPONENT_KEY = 'tooltip-annotations';
+
+function keyForHash(datasetHash: string): string {
+  return buildStorageKey(COMPONENT_KEY, datasetHash);
+}
+
+export function readTooltipAnnotations(datasetHash: string): string[] {
+  const value = getStorageItem<unknown>(keyForHash(datasetHash), null);
+  if (!Array.isArray(value)) return [];
+  return value.filter((entry): entry is string => typeof entry === 'string');
+}
+
+export function writeTooltipAnnotations(datasetHash: string, annotations: readonly string[]): void {
+  setStorageItem(keyForHash(datasetHash), [...annotations]);
+}

--- a/app/src/explore/url-state.test.ts
+++ b/app/src/explore/url-state.test.ts
@@ -11,14 +11,18 @@ describe('explore url state', () => {
     const parsed = parseExploreViewRequest(new URLSearchParams(''));
 
     expect(parsed).toEqual({
-      requested: {},
+      requested: {
+        tooltip: undefined,
+      },
       present: {
         annotation: false,
         projection: false,
+        tooltip: false,
       },
       normalize: {
         annotation: false,
         projection: false,
+        tooltip: false,
       },
     });
   });
@@ -32,14 +36,17 @@ describe('explore url state', () => {
       requested: {
         annotation: 'ec',
         projection: 'UMAP',
+        tooltip: undefined,
       },
       present: {
         annotation: true,
         projection: true,
+        tooltip: false,
       },
       normalize: {
         annotation: true,
         projection: true,
+        tooltip: false,
       },
     });
   });
@@ -49,29 +56,36 @@ describe('explore url state', () => {
     const resolved = resolveExploreView(parsed.requested, ['ec', 'pfam'], ['UMAP', 'PCA']);
 
     expect(parsed).toEqual({
-      requested: {},
+      requested: {
+        tooltip: undefined,
+      },
       present: {
         annotation: true,
         projection: true,
+        tooltip: false,
       },
       normalize: {
         annotation: true,
         projection: true,
+        tooltip: false,
       },
     });
     expect(resolved).toEqual({
       effective: {
         annotation: 'ec',
         projection: 'UMAP',
+        tooltip: [],
       },
       matchesRequested: {
         annotation: false,
         projection: false,
+        tooltip: false,
       },
     });
     expect(getResolvedExploreViewNormalization(parsed, resolved!)).toEqual({
       annotation: true,
       projection: true,
+      tooltip: false,
     });
   });
 
@@ -83,15 +97,18 @@ describe('explore url state', () => {
       effective: {
         annotation: 'pfam',
         projection: 'PCA',
+        tooltip: [],
       },
       matchesRequested: {
         annotation: true,
         projection: true,
+        tooltip: false,
       },
     });
     expect(getResolvedExploreViewNormalization(parsed, resolved!)).toEqual({
       annotation: false,
       projection: false,
+      tooltip: false,
     });
   });
 
@@ -105,15 +122,18 @@ describe('explore url state', () => {
       effective: {
         annotation: 'pfam',
         projection: 'PCA',
+        tooltip: [],
       },
       matchesRequested: {
         annotation: true,
         projection: true,
+        tooltip: false,
       },
     });
     expect(getResolvedExploreViewNormalization(parsed, resolved!)).toEqual({
       annotation: true,
       projection: true,
+      tooltip: false,
     });
   });
 
@@ -127,15 +147,18 @@ describe('explore url state', () => {
       effective: {
         annotation: 'pfam',
         projection: 'UMAP',
+        tooltip: [],
       },
       matchesRequested: {
         annotation: true,
         projection: false,
+        tooltip: false,
       },
     });
     expect(getResolvedExploreViewNormalization(parsed, resolved!)).toEqual({
       annotation: false,
       projection: true,
+      tooltip: false,
     });
   });
 
@@ -149,15 +172,18 @@ describe('explore url state', () => {
       effective: {
         annotation: 'ec',
         projection: 'UMAP',
+        tooltip: [],
       },
       matchesRequested: {
         annotation: false,
         projection: false,
+        tooltip: false,
       },
     });
     expect(getResolvedExploreViewNormalization(parsed, resolved!)).toEqual({
       annotation: true,
       projection: true,
+      tooltip: false,
     });
   });
 
@@ -174,6 +200,7 @@ describe('explore url state', () => {
       {
         annotation: 'pfam',
         projection: 'PCA',
+        tooltip: [],
       },
       { mode: 'user' },
     );
@@ -187,16 +214,136 @@ describe('explore url state', () => {
       {
         annotation: 'pfam',
         projection: 'UMAP',
+        tooltip: [],
       },
       {
         mode: 'normalize',
         normalize: {
           annotation: false,
           projection: true,
+          tooltip: false,
         },
       },
     );
 
     expect(next.toString()).toBe('annotation=pfam&projection=UMAP&webglPerf=1');
+  });
+
+  describe('tooltip param', () => {
+    it('parses comma-separated tooltip annotations', () => {
+      const parsed = parseExploreViewRequest(
+        new URLSearchParams('annotation=pfam&tooltip=ec%2Cgo'),
+      );
+      expect(parsed.requested.tooltip).toEqual(['ec', 'go']);
+      expect(parsed.present.tooltip).toBe(true);
+      expect(parsed.normalize.tooltip).toBe(false);
+    });
+
+    it('drops duplicates within the tooltip param and marks for normalization', () => {
+      const parsed = parseExploreViewRequest(new URLSearchParams('tooltip=ec%2Cec%2Cgo'));
+      expect(parsed.requested.tooltip).toEqual(['ec', 'go']);
+      expect(parsed.normalize.tooltip).toBe(true);
+    });
+
+    it('drops empty segments within the tooltip param and marks for normalization', () => {
+      const parsed = parseExploreViewRequest(new URLSearchParams('tooltip=ec%2C%2Cgo'));
+      expect(parsed.requested.tooltip).toEqual(['ec', 'go']);
+      expect(parsed.normalize.tooltip).toBe(true);
+    });
+
+    it('treats a fully empty tooltip param as present but invalid', () => {
+      const parsed = parseExploreViewRequest(new URLSearchParams('tooltip='));
+      expect(parsed.requested.tooltip).toBeUndefined();
+      expect(parsed.present.tooltip).toBe(true);
+      expect(parsed.normalize.tooltip).toBe(true);
+    });
+
+    it('flags duplicate tooltip keys for normalization', () => {
+      const parsed = parseExploreViewRequest(new URLSearchParams('tooltip=ec&tooltip=go'));
+      expect(parsed.requested.tooltip).toEqual(['ec']);
+      expect(parsed.normalize.tooltip).toBe(true);
+    });
+
+    it('drops tooltip entries equal to the effective primary annotation', () => {
+      const parsed = parseExploreViewRequest(
+        new URLSearchParams('annotation=pfam&tooltip=pfam%2Cec'),
+      );
+      const resolved = resolveExploreView(parsed.requested, ['ec', 'pfam', 'go'], ['UMAP']);
+
+      expect(resolved!.effective.tooltip).toEqual(['ec']);
+      expect(resolved!.matchesRequested.tooltip).toBe(false);
+      expect(getResolvedExploreViewNormalization(parsed, resolved!).tooltip).toBe(true);
+    });
+
+    it('drops tooltip entries not present in the dataset', () => {
+      const parsed = parseExploreViewRequest(
+        new URLSearchParams('annotation=pfam&tooltip=ec%2Cunknown%2Cgo'),
+      );
+      const resolved = resolveExploreView(parsed.requested, ['ec', 'pfam', 'go'], ['UMAP']);
+
+      expect(resolved!.effective.tooltip).toEqual(['ec', 'go']);
+      expect(resolved!.matchesRequested.tooltip).toBe(false);
+      expect(getResolvedExploreViewNormalization(parsed, resolved!).tooltip).toBe(true);
+    });
+
+    it('preserves a valid tooltip set without normalization', () => {
+      const parsed = parseExploreViewRequest(
+        new URLSearchParams('annotation=pfam&tooltip=ec%2Cgo'),
+      );
+      const resolved = resolveExploreView(parsed.requested, ['ec', 'pfam', 'go'], ['UMAP']);
+
+      expect(resolved!.effective.tooltip).toEqual(['ec', 'go']);
+      expect(resolved!.matchesRequested.tooltip).toBe(true);
+      expect(getResolvedExploreViewNormalization(parsed, resolved!).tooltip).toBe(false);
+    });
+
+    it('serializes tooltip annotations on user writes', () => {
+      const next = buildSearchParamsWithExploreView(
+        new URLSearchParams(),
+        {
+          annotation: 'pfam',
+          projection: 'UMAP',
+          tooltip: ['ec', 'go'],
+        },
+        { mode: 'user' },
+      );
+
+      expect(next.get('tooltip')).toBe('ec,go');
+    });
+
+    it('removes the tooltip param when the effective set is empty on user writes', () => {
+      const next = buildSearchParamsWithExploreView(
+        new URLSearchParams('tooltip=ec'),
+        {
+          annotation: 'pfam',
+          projection: 'UMAP',
+          tooltip: [],
+        },
+        { mode: 'user' },
+      );
+
+      expect(next.has('tooltip')).toBe(false);
+    });
+
+    it('normalizes the tooltip param when flagged during replace writes', () => {
+      const next = buildSearchParamsWithExploreView(
+        new URLSearchParams('annotation=pfam&projection=UMAP&tooltip=pfam%2Cec'),
+        {
+          annotation: 'pfam',
+          projection: 'UMAP',
+          tooltip: ['ec'],
+        },
+        {
+          mode: 'normalize',
+          normalize: {
+            annotation: false,
+            projection: false,
+            tooltip: true,
+          },
+        },
+      );
+
+      expect(next.get('tooltip')).toBe('ec');
+    });
   });
 });

--- a/app/src/explore/url-state.ts
+++ b/app/src/explore/url-state.ts
@@ -20,10 +20,59 @@ function getRequestedValue(searchParams: URLSearchParams, key: 'annotation' | 'p
   return value;
 }
 
+interface ParsedTooltipParam {
+  value: string[] | undefined;
+  present: boolean;
+  normalize: boolean;
+}
+
+function parseTooltipParam(searchParams: URLSearchParams): ParsedTooltipParam {
+  if (!searchParams.has('tooltip')) {
+    return { value: undefined, present: false, normalize: false };
+  }
+
+  const all = searchParams.getAll('tooltip');
+  const duplicated = all.length > 1;
+  const raw = all[0] ?? '';
+
+  if (raw.trim() === '') {
+    return { value: undefined, present: true, normalize: true };
+  }
+
+  const seen = new Set<string>();
+  const parsed: string[] = [];
+  let sawDuplicate = false;
+  for (const part of raw.split(',')) {
+    const token = part.trim();
+    if (!token) {
+      sawDuplicate = true;
+      continue;
+    }
+    if (seen.has(token)) {
+      sawDuplicate = true;
+      continue;
+    }
+    seen.add(token);
+    parsed.push(token);
+  }
+
+  if (parsed.length === 0) {
+    return { value: undefined, present: true, normalize: true };
+  }
+
+  return {
+    value: parsed,
+    present: true,
+    normalize: duplicated || sawDuplicate,
+  };
+}
+
 export function parseExploreViewRequest(searchParams: URLSearchParams): ExploreViewRequestState {
+  const tooltip = parseTooltipParam(searchParams);
   const requested = {
     annotation: getRequestedValue(searchParams, 'annotation'),
     projection: getRequestedValue(searchParams, 'projection'),
+    tooltip: tooltip.value,
   };
 
   return {
@@ -31,6 +80,7 @@ export function parseExploreViewRequest(searchParams: URLSearchParams): ExploreV
     present: {
       annotation: searchParams.has('annotation'),
       projection: searchParams.has('projection'),
+      tooltip: tooltip.present,
     },
     normalize: {
       annotation:
@@ -39,6 +89,7 @@ export function parseExploreViewRequest(searchParams: URLSearchParams): ExploreV
       projection:
         (searchParams.has('projection') && requested.projection === undefined) ||
         searchParams.getAll('projection').length > 1,
+      tooltip: tooltip.normalize,
     },
   };
 }
@@ -49,10 +100,12 @@ export function createEmptyExploreViewRequest(): ExploreViewRequestState {
     present: {
       annotation: false,
       projection: false,
+      tooltip: false,
     },
     normalize: {
       annotation: false,
       projection: false,
+      tooltip: false,
     },
   };
 }
@@ -64,16 +117,54 @@ export function cloneExploreViewRequest(
     requested: {
       annotation: requestState.requested.annotation,
       projection: requestState.requested.projection,
+      tooltip: requestState.requested.tooltip
+        ? [...requestState.requested.tooltip]
+        : requestState.requested.tooltip,
     },
     present: {
       annotation: requestState.present.annotation,
       projection: requestState.present.projection,
+      tooltip: requestState.present.tooltip,
     },
     normalize: {
       annotation: requestState.normalize.annotation,
       projection: requestState.normalize.projection,
+      tooltip: requestState.normalize.tooltip,
     },
   };
+}
+
+function resolveTooltip(
+  requested: readonly string[] | undefined,
+  effectiveAnnotation: string,
+  availableAnnotations: readonly string[],
+): { value: string[]; matches: boolean } {
+  if (requested === undefined) {
+    return { value: [], matches: false };
+  }
+
+  const available = new Set(availableAnnotations);
+  const filtered: string[] = [];
+  const seen = new Set<string>();
+  let dropped = false;
+  for (const name of requested) {
+    if (name === effectiveAnnotation) {
+      dropped = true;
+      continue;
+    }
+    if (!available.has(name)) {
+      dropped = true;
+      continue;
+    }
+    if (seen.has(name)) {
+      dropped = true;
+      continue;
+    }
+    seen.add(name);
+    filtered.push(name);
+  }
+
+  return { value: filtered, matches: !dropped && filtered.length === requested.length };
 }
 
 export function resolveExploreView(
@@ -92,14 +183,19 @@ export function resolveExploreView(
   const projectionIsValid =
     requestedProjection !== undefined && availableProjections.includes(requestedProjection);
 
+  const effectiveAnnotation = annotationIsValid ? requestedAnnotation : availableAnnotations[0];
+  const tooltip = resolveTooltip(requested.tooltip, effectiveAnnotation, availableAnnotations);
+
   return {
     effective: {
-      annotation: annotationIsValid ? requestedAnnotation : availableAnnotations[0],
+      annotation: effectiveAnnotation,
       projection: projectionIsValid ? requestedProjection : availableProjections[0],
+      tooltip: tooltip.value,
     },
     matchesRequested: {
       annotation: annotationIsValid,
       projection: projectionIsValid,
+      tooltip: tooltip.matches,
     },
   };
 }
@@ -115,7 +211,18 @@ export function getResolvedExploreViewNormalization(
     projection:
       requestState.normalize.projection ||
       (requestState.present.projection && !resolved.matchesRequested.projection),
+    tooltip:
+      requestState.normalize.tooltip ||
+      (requestState.present.tooltip && !resolved.matchesRequested.tooltip),
   };
+}
+
+function setTooltipParam(searchParams: URLSearchParams, tooltip: readonly string[]) {
+  if (tooltip.length === 0) {
+    searchParams.delete('tooltip');
+    return;
+  }
+  searchParams.set('tooltip', tooltip.join(','));
 }
 
 export function buildSearchParamsWithExploreView(
@@ -135,6 +242,7 @@ export function buildSearchParamsWithExploreView(
   if (options.mode === 'user') {
     next.set('annotation', effective.annotation);
     next.set('projection', effective.projection);
+    setTooltipParam(next, effective.tooltip);
     return next;
   }
 
@@ -144,6 +252,10 @@ export function buildSearchParamsWithExploreView(
 
   if (options.normalize.projection) {
     next.set('projection', effective.projection);
+  }
+
+  if (options.normalize.tooltip) {
+    setTooltipParam(next, effective.tooltip);
   }
 
   return next;
@@ -167,7 +279,7 @@ export function getExploreViewSearchParamsUpdate(
     return next.toString() === searchParams.toString() ? null : { next, replace: false };
   }
 
-  if (!change.normalize.annotation && !change.normalize.projection) {
+  if (!change.normalize.annotation && !change.normalize.projection && !change.normalize.tooltip) {
     return null;
   }
 

--- a/app/src/explore/view-controller.test.ts
+++ b/app/src/explore/view-controller.test.ts
@@ -21,6 +21,7 @@ function createMockElements() {
   const plotElement = {
     selectedProjectionIndex: 0,
     selectedAnnotation: 'ec',
+    tooltipAnnotations: [] as string[],
     getCurrentData: () => ({
       annotations: { ec: {}, pfam: {}, go: {} },
       projections: [{ name: 'UMAP' }, { name: 'PCA' }, { name: 't-SNE' }],
@@ -31,6 +32,7 @@ function createMockElements() {
   const controlBar = {
     selectedProjection: 'UMAP',
     selectedAnnotation: 'ec',
+    tooltipAnnotations: [] as string[],
     applyProjectionSelection: vi.fn((projection: string) => {
       controlBar.selectedProjection = projection;
       // Simulate the real control-bar updating the plot
@@ -43,19 +45,28 @@ function createMockElements() {
       controlBar.selectedAnnotation = annotation;
       plotElement.selectedAnnotation = annotation;
     }),
+    applyTooltipAnnotationsSelection: vi.fn((tooltip: string[]) => {
+      controlBar.tooltipAnnotations = [...tooltip];
+      plotElement.tooltipAnnotations = [...tooltip];
+    }),
   };
 
   return { plotElement, controlBar };
 }
 
-function makeRequest(annotation?: string, projection?: string): ExploreViewRequestState {
+function makeRequest(
+  annotation?: string,
+  projection?: string,
+  tooltip?: string[],
+): ExploreViewRequestState {
   return {
-    requested: { annotation, projection },
+    requested: { annotation, projection, tooltip },
     present: {
       annotation: annotation !== undefined,
       projection: projection !== undefined,
+      tooltip: tooltip !== undefined,
     },
-    normalize: { annotation: false, projection: false },
+    normalize: { annotation: false, projection: false, tooltip: false },
   };
 }
 
@@ -73,7 +84,7 @@ describe('createViewController', () => {
     const { viewController } = setup();
     const view = viewController.getCurrentEffectiveView();
 
-    expect(view).toEqual({ annotation: 'ec', projection: 'UMAP' });
+    expect(view).toEqual({ annotation: 'ec', projection: 'UMAP', tooltip: [] });
   });
 
   it('returns null when no data is available', () => {
@@ -95,7 +106,7 @@ describe('createViewController', () => {
     const request = makeRequest('pfam', 'PCA');
     const result = viewController.applyViewSelection(request, 'url');
 
-    expect(result).toEqual({ annotation: 'pfam', projection: 'PCA' });
+    expect(result).toEqual({ annotation: 'pfam', projection: 'PCA', tooltip: [] });
     expect(controlBar.applyProjectionSelection).toHaveBeenCalledWith('PCA');
     expect(controlBar.applyAnnotationSelection).toHaveBeenCalledWith('pfam');
   });
@@ -105,7 +116,7 @@ describe('createViewController', () => {
     const request = makeRequest('NONEXISTENT', 'UNKNOWN');
     const result = viewController.applyViewSelection(request, 'url');
 
-    expect(result).toEqual({ annotation: 'ec', projection: 'UMAP' });
+    expect(result).toEqual({ annotation: 'ec', projection: 'UMAP', tooltip: [] });
   });
 
   it('returns null from applyViewSelection when dataset has no options', () => {
@@ -131,7 +142,7 @@ describe('createViewController', () => {
     viewController.applyViewSelection(makeRequest('pfam', 'PCA'), 'user');
 
     expect(changes).toHaveLength(1);
-    expect(changes[0].effective).toEqual({ annotation: 'pfam', projection: 'PCA' });
+    expect(changes[0].effective).toEqual({ annotation: 'pfam', projection: 'PCA', tooltip: [] });
     expect(changes[0].source).toBe('user');
   });
 
@@ -163,7 +174,7 @@ describe('createViewController', () => {
     viewController.setRequestedView(makeRequest('pfam', 'PCA'));
 
     const resolved = viewController.resolveLatestView();
-    expect(resolved).toEqual({ annotation: 'pfam', projection: 'PCA' });
+    expect(resolved).toEqual({ annotation: 'pfam', projection: 'PCA', tooltip: [] });
   });
 
   it('resolveLatestView falls back for invalid requests', () => {
@@ -171,7 +182,7 @@ describe('createViewController', () => {
     viewController.setRequestedView(makeRequest('NONEXISTENT', 'UNKNOWN'));
 
     const resolved = viewController.resolveLatestView();
-    expect(resolved).toEqual({ annotation: 'ec', projection: 'UMAP' });
+    expect(resolved).toEqual({ annotation: 'ec', projection: 'UMAP', tooltip: [] });
   });
 
   it('applyLatestViewForDatasetLoad uses dataset-load source', () => {

--- a/app/src/explore/view-controller.ts
+++ b/app/src/explore/view-controller.ts
@@ -31,6 +31,7 @@ export interface ViewController {
   setRequestedView(viewRequest: ExploreViewRequestState): void;
   handleUserAnnotationChange(): void;
   handleUserProjectionChange(): void;
+  handleUserTooltipAnnotationsChange(): void;
   subscribeToViewChanges(callback: (change: ExploreViewChange) => void): () => void;
   dispose(): void;
 }
@@ -95,9 +96,21 @@ export function createViewController({
           ? controlBar.selectedAnnotation
           : availableAnnotations[0];
 
+    const rawTooltip = plotElement.tooltipAnnotations ?? controlBar.tooltipAnnotations ?? [];
+    const tooltipSeen = new Set<string>();
+    const tooltip: string[] = [];
+    for (const name of rawTooltip) {
+      if (name === annotation) continue;
+      if (!availableAnnotations.includes(name)) continue;
+      if (tooltipSeen.has(name)) continue;
+      tooltipSeen.add(name);
+      tooltip.push(name);
+    }
+
     return {
       annotation,
       projection,
+      tooltip,
     };
   };
 
@@ -107,6 +120,18 @@ export function createViewController({
 
   const selectAnnotation = (annotation: string) => {
     controlBar.applyAnnotationSelection(annotation);
+  };
+
+  const selectTooltipAnnotations = (tooltipAnnotations: string[]) => {
+    controlBar.applyTooltipAnnotationsSelection?.(tooltipAnnotations);
+  };
+
+  const arraysEqual = (a: readonly string[], b: readonly string[]) => {
+    if (a.length !== b.length) return false;
+    for (let i = 0; i < a.length; i++) {
+      if (a[i] !== b[i]) return false;
+    }
+    return true;
   };
 
   const resolveLatestView = (dataOverride?: VisualizationData) => {
@@ -143,6 +168,7 @@ export function createViewController({
     const effective = resolved.effective;
     const projectionChanged = currentView?.projection !== effective.projection;
     const annotationChanged = currentView?.annotation !== effective.annotation;
+    const tooltipChanged = !arraysEqual(currentView?.tooltip ?? [], effective.tooltip);
 
     activeViewChangeSource = source;
     if (projectionChanged) {
@@ -150,6 +176,9 @@ export function createViewController({
     }
     if (annotationChanged) {
       selectAnnotation(effective.annotation);
+    }
+    if (tooltipChanged) {
+      selectTooltipAnnotations(effective.tooltip);
     }
     scheduleActiveViewChangeSourceReset(source);
 
@@ -178,6 +207,7 @@ export function createViewController({
       normalize: {
         annotation: false,
         projection: false,
+        tooltip: false,
       },
     });
   };
@@ -198,6 +228,9 @@ export function createViewController({
       emitCurrentUserViewChange();
     },
     handleUserProjectionChange() {
+      emitCurrentUserViewChange();
+    },
+    handleUserTooltipAnnotationsChange() {
       emitCurrentUserViewChange();
     },
     subscribeToViewChanges(callback: (change: ExploreViewChange) => void) {

--- a/app/src/explore/view-state.ts
+++ b/app/src/explore/view-state.ts
@@ -1,11 +1,18 @@
 export interface RequestedExploreView {
   annotation?: string;
   projection?: string;
+  /**
+   * Extra annotations the user has opted into the hover tooltip.
+   * `undefined` means the URL didn't request a value; `[]` means it
+   * requested an explicitly empty set.
+   */
+  tooltip?: string[];
 }
 
 export interface ExploreViewNormalization {
   annotation: boolean;
   projection: boolean;
+  tooltip: boolean;
 }
 
 export interface ExploreViewRequestState {
@@ -13,6 +20,7 @@ export interface ExploreViewRequestState {
   present: {
     annotation: boolean;
     projection: boolean;
+    tooltip: boolean;
   };
   normalize: ExploreViewNormalization;
 }
@@ -20,6 +28,7 @@ export interface ExploreViewRequestState {
 export interface EffectiveExploreView {
   annotation: string;
   projection: string;
+  tooltip: string[];
 }
 
 export interface ResolvedExploreView {
@@ -27,6 +36,7 @@ export interface ResolvedExploreView {
   matchesRequested: {
     annotation: boolean;
     projection: boolean;
+    tooltip: boolean;
   };
 }
 

--- a/app/tests/multi-annotation-tooltip.spec.ts
+++ b/app/tests/multi-annotation-tooltip.spec.ts
@@ -14,11 +14,9 @@ async function openAnnotationDropdown(page: Page): Promise<void> {
 }
 
 async function getRowForAnnotation(page: Page, annotation: string) {
-  return page
-    .locator('protspace-control-bar protspace-annotation-select .dropdown-item')
-    .filter({
-      has: page.locator('.dropdown-item-label', { hasText: new RegExp(`^${annotation}$`) }),
-    });
+  return page.locator('protspace-control-bar protspace-annotation-select .dropdown-item').filter({
+    has: page.locator('.dropdown-item-label', { hasText: new RegExp(`^${annotation}$`) }),
+  });
 }
 
 test.describe('Multi-annotation hover tooltip', () => {

--- a/app/tests/multi-annotation-tooltip.spec.ts
+++ b/app/tests/multi-annotation-tooltip.spec.ts
@@ -1,0 +1,103 @@
+import { expect, test, type Page } from '@playwright/test';
+import {
+  dismissTourIfPresent,
+  waitForExploreDataLoad,
+  waitForExploreInteractionReady,
+} from './helpers/explore';
+
+async function openAnnotationDropdown(page: Page): Promise<void> {
+  await waitForExploreInteractionReady(page);
+  const trigger = page.locator(
+    'protspace-control-bar protspace-annotation-select .dropdown-trigger',
+  );
+  await trigger.click();
+}
+
+async function getRowForAnnotation(page: Page, annotation: string) {
+  return page
+    .locator('protspace-control-bar protspace-annotation-select .dropdown-item')
+    .filter({
+      has: page.locator('.dropdown-item-label', { hasText: new RegExp(`^${annotation}$`) }),
+    });
+}
+
+test.describe('Multi-annotation hover tooltip', () => {
+  test('marks the primary annotation with a dot and hides its (i) toggle', async ({ page }) => {
+    await page.goto('/explore?annotation=ec');
+    await dismissTourIfPresent(page);
+    await waitForExploreDataLoad(page);
+
+    await openAnnotationDropdown(page);
+
+    const primaryRow = await getRowForAnnotation(page, 'ec');
+    await expect(primaryRow.locator('.primary-dot')).toHaveCount(1);
+    await expect(primaryRow.locator('.tooltip-toggle-btn')).toHaveCount(0);
+  });
+
+  test('toggling the (i) icon adds the annotation to the URL tooltip param', async ({ page }) => {
+    await page.goto('/explore?annotation=ec');
+    await dismissTourIfPresent(page);
+    await waitForExploreDataLoad(page);
+
+    await openAnnotationDropdown(page);
+
+    const annotations = await page.evaluate(() => {
+      const cb = document.querySelector('protspace-control-bar') as
+        | (Element & { annotations?: string[] })
+        | null;
+      return cb?.annotations ?? [];
+    });
+    const otherAnnotation = annotations.find((name) => name !== 'ec');
+    if (!otherAnnotation) {
+      test.skip(true, 'demo dataset has only a single annotation');
+      return;
+    }
+
+    const otherRow = await getRowForAnnotation(page, otherAnnotation);
+    await otherRow.locator('.tooltip-toggle-btn').click();
+
+    await expect(page).toHaveURL(new RegExp(`tooltip=${otherAnnotation}`));
+
+    const tooltipState = await page.evaluate(() => {
+      const cb = document.querySelector('protspace-control-bar') as
+        | (Element & { tooltipAnnotations?: string[] })
+        | null;
+      const plot = document.querySelector('protspace-scatterplot') as
+        | (Element & { tooltipAnnotations?: string[] })
+        | null;
+      return {
+        controlBar: cb?.tooltipAnnotations ?? null,
+        plot: plot?.tooltipAnnotations ?? null,
+      };
+    });
+
+    expect(tooltipState.controlBar).toEqual([otherAnnotation]);
+    expect(tooltipState.plot).toEqual([otherAnnotation]);
+  });
+
+  test('toggling an extra back off removes the tooltip URL param', async ({ page }) => {
+    await page.goto('/explore?annotation=ec');
+    await dismissTourIfPresent(page);
+    await waitForExploreDataLoad(page);
+
+    await openAnnotationDropdown(page);
+    const available = await page.evaluate(() => {
+      const cb = document.querySelector('protspace-control-bar') as
+        | (Element & { annotations?: string[] })
+        | null;
+      return cb?.annotations ?? [];
+    });
+    const otherAnnotation = available.find((name) => name !== 'ec');
+    if (!otherAnnotation) {
+      test.skip(true, 'demo dataset has only a single annotation');
+      return;
+    }
+
+    const row = await getRowForAnnotation(page, otherAnnotation);
+    await row.locator('.tooltip-toggle-btn').click();
+    await expect(page).toHaveURL(new RegExp(`tooltip=${otherAnnotation}`));
+    await row.locator('.tooltip-toggle-btn').click();
+
+    await expect(page).not.toHaveURL(/tooltip=/);
+  });
+});

--- a/app/tests/numeric-binning.spec.ts
+++ b/app/tests/numeric-binning.spec.ts
@@ -741,15 +741,14 @@ async function readTooltipSummary(page: Page): Promise<{
       | null;
     const root = tooltip?.shadowRoot;
     const rawValueRow = Array.from(root?.querySelectorAll('.tooltip-content > div') ?? []).find(
-      (node) => node.textContent?.includes('Raw value:'),
+      (node) => node.textContent?.includes('Value:'),
     ) as HTMLElement | undefined;
 
     return {
       labels: Array.from(root?.querySelectorAll('.tooltip-annotation-label') ?? []).map(
         (node) => node.textContent?.trim() ?? '',
       ),
-      rawValue:
-        rawValueRow?.textContent?.replace(/\s+/g, ' ').replace('Raw value:', '').trim() ?? null,
+      rawValue: rawValueRow?.textContent?.replace(/\s+/g, ' ').replace('Value:', '').trim() ?? null,
     };
   });
 }

--- a/app/tests/playwright.config.ts
+++ b/app/tests/playwright.config.ts
@@ -119,6 +119,14 @@ export default defineConfig({
       },
       testMatch: /isolation-dataset-swap\.spec\.ts/,
     },
+    {
+      name: 'multi-annotation-tooltip',
+      use: {
+        ...devices['Desktop Chrome'],
+        viewport: { width: 1280, height: 720 },
+      },
+      testMatch: /multi-annotation-tooltip\.spec\.ts/,
+    },
   ],
 
   outputDir: '../test-results/',

--- a/packages/core/src/components/control-bar/annotation-select.component.test.ts
+++ b/packages/core/src/components/control-bar/annotation-select.component.test.ts
@@ -1,0 +1,148 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import './annotation-select';
+
+type AnnotationSelectElement = HTMLElement & {
+  annotations: string[];
+  selectedAnnotation: string;
+  tooltipAnnotations: string[];
+  updateComplete: Promise<unknown>;
+};
+
+async function setup(initial: Partial<AnnotationSelectElement> = {}) {
+  const el = document.createElement('protspace-annotation-select') as AnnotationSelectElement;
+  el.annotations = initial.annotations ?? ['gene_name', 'pfam', 'species'];
+  el.selectedAnnotation = initial.selectedAnnotation ?? 'pfam';
+  el.tooltipAnnotations = initial.tooltipAnnotations ?? [];
+  document.body.appendChild(el);
+  await el.updateComplete;
+  return el;
+}
+
+async function openDropdown(el: AnnotationSelectElement): Promise<void> {
+  const trigger = el.shadowRoot!.querySelector('.dropdown-trigger') as HTMLButtonElement;
+  trigger.click();
+  await el.updateComplete;
+}
+
+function getRowFor(el: AnnotationSelectElement, annotation: string): HTMLElement {
+  const items = Array.from(el.shadowRoot!.querySelectorAll('.dropdown-item')) as HTMLElement[];
+  const row = items.find(
+    (item) => item.querySelector('.dropdown-item-label')?.textContent?.trim() === annotation,
+  );
+  if (!row) {
+    throw new Error(`row for annotation "${annotation}" not found`);
+  }
+  return row;
+}
+
+describe('protspace-annotation-select tooltip extras', () => {
+  beforeEach(() => {
+    document.body.innerHTML = '';
+  });
+
+  afterEach(() => {
+    document.body.innerHTML = '';
+  });
+
+  it('renders a primary indicator only on the selected row', async () => {
+    const el = await setup();
+    await openDropdown(el);
+
+    const primary = getRowFor(el, 'pfam');
+    const other = getRowFor(el, 'gene_name');
+
+    expect(primary.querySelector('.primary-dot')).not.toBeNull();
+    expect(other.querySelector('.primary-dot')).toBeNull();
+  });
+
+  it('hides the tooltip toggle on the primary row and shows it on other rows', async () => {
+    const el = await setup();
+    await openDropdown(el);
+
+    const primary = getRowFor(el, 'pfam');
+    const other = getRowFor(el, 'gene_name');
+
+    expect(primary.querySelector('.tooltip-toggle-btn')).toBeNull();
+    expect(other.querySelector('.tooltip-toggle-btn')).not.toBeNull();
+  });
+
+  it('reflects active state on the toggle for annotations in tooltipAnnotations', async () => {
+    const el = await setup({ tooltipAnnotations: ['gene_name'] });
+    await openDropdown(el);
+
+    const activeBtn = getRowFor(el, 'gene_name').querySelector(
+      '.tooltip-toggle-btn',
+    ) as HTMLButtonElement;
+    const inactiveBtn = getRowFor(el, 'species').querySelector(
+      '.tooltip-toggle-btn',
+    ) as HTMLButtonElement;
+
+    expect(activeBtn.classList.contains('is-active')).toBe(true);
+    expect(activeBtn.getAttribute('aria-pressed')).toBe('true');
+    expect(inactiveBtn.classList.contains('is-active')).toBe(false);
+    expect(inactiveBtn.getAttribute('aria-pressed')).toBe('false');
+  });
+
+  it('dispatches tooltip-annotation-toggle when the toggle is clicked, without selecting', async () => {
+    const el = await setup();
+    await openDropdown(el);
+
+    const toggleEvents: CustomEvent[] = [];
+    const selectEvents: CustomEvent[] = [];
+    el.addEventListener('tooltip-annotation-toggle', (e) => toggleEvents.push(e as CustomEvent));
+    el.addEventListener('annotation-select', (e) => selectEvents.push(e as CustomEvent));
+
+    const btn = getRowFor(el, 'gene_name').querySelector(
+      '.tooltip-toggle-btn',
+    ) as HTMLButtonElement;
+    btn.click();
+    await el.updateComplete;
+
+    expect(toggleEvents).toHaveLength(1);
+    expect(toggleEvents[0].detail).toEqual({
+      annotation: 'gene_name',
+      active: true,
+      tooltipAnnotations: ['gene_name'],
+    });
+    expect(selectEvents).toHaveLength(0);
+    expect(el.tooltipAnnotations).toEqual(['gene_name']);
+  });
+
+  it('removes an annotation from tooltipAnnotations on a second toggle click', async () => {
+    const el = await setup({ tooltipAnnotations: ['gene_name'] });
+    await openDropdown(el);
+
+    const events: CustomEvent[] = [];
+    el.addEventListener('tooltip-annotation-toggle', (e) => events.push(e as CustomEvent));
+
+    const btn = getRowFor(el, 'gene_name').querySelector(
+      '.tooltip-toggle-btn',
+    ) as HTMLButtonElement;
+    btn.click();
+    await el.updateComplete;
+
+    expect(events[0].detail).toEqual({
+      annotation: 'gene_name',
+      active: false,
+      tooltipAnnotations: [],
+    });
+    expect(el.tooltipAnnotations).toEqual([]);
+  });
+
+  it('clicking the row label selects the annotation as primary', async () => {
+    const el = await setup();
+    await openDropdown(el);
+
+    const selectSpy = vi.fn();
+    el.addEventListener('annotation-select', selectSpy);
+
+    (getRowFor(el, 'gene_name').querySelector('.dropdown-item-label') as HTMLElement).click();
+    await el.updateComplete;
+
+    expect(selectSpy).toHaveBeenCalledTimes(1);
+    expect((selectSpy.mock.calls[0][0] as CustomEvent).detail).toEqual({ annotation: 'gene_name' });
+  });
+});

--- a/packages/core/src/components/control-bar/annotation-select.styles.ts
+++ b/packages/core/src/components/control-bar/annotation-select.styles.ts
@@ -102,6 +102,72 @@ export const annotationSelectStyles = [
       width: 100%;
       box-sizing: border-box;
       margin: 0;
+      display: flex;
+      align-items: center;
+      gap: var(--spacing-sm);
+    }
+
+    .primary-indicator {
+      flex: 0 0 0.85rem;
+      width: 0.85rem;
+      height: 0.85rem;
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+    }
+
+    .primary-dot {
+      display: block;
+      width: 0.55rem;
+      height: 0.55rem;
+      border-radius: 50%;
+      background: var(--primary);
+    }
+
+    .dropdown-item-label {
+      flex: 1 1 auto;
+      min-width: 0;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+
+    .tooltip-toggle-slot {
+      flex: 0 0 auto;
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      width: 1.5rem;
+      height: 1.5rem;
+    }
+
+    .tooltip-toggle-btn {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      width: 1.5rem;
+      height: 1.5rem;
+      padding: 0;
+      background: none;
+      border: none;
+      border-radius: 0.25rem;
+      color: var(--muted);
+      cursor: pointer;
+      transition: var(--transition);
+    }
+
+    .tooltip-toggle-btn:hover {
+      color: var(--primary);
+      background: var(--primary-alpha-10);
+    }
+
+    .tooltip-toggle-btn:focus-visible {
+      outline: none;
+      box-shadow: 0 0 0 2px var(--focus-ring-bg);
+    }
+
+    .tooltip-toggle-btn.is-active {
+      color: var(--primary);
     }
 
     .no-results {

--- a/packages/core/src/components/control-bar/annotation-select.styles.ts
+++ b/packages/core/src/components/control-bar/annotation-select.styles.ts
@@ -30,13 +30,16 @@ export const annotationSelectStyles = [
 
     /* Ensure dropdown-trigger padding matches (inherited from dropdownMixin) */
 
-    /* Override dropdown menu to match projection dropdown exactly */
+    /* Popover sits absolutely positioned, so it can be wider than the
+       trigger without affecting layout. Stay at least as wide as the
+       trigger, grow with content, cap so very long annotation names
+       wrap instead of pushing the menu off-screen. */
     .dropdown-menu {
       overflow-y: auto;
       overflow-x: hidden;
-      /* Match trigger width more closely */
-      width: 100%;
-      max-width: 20rem;
+      min-width: max(100%, 22rem);
+      width: max-content;
+      max-width: 28rem;
     }
 
     .annotation-search-container {

--- a/packages/core/src/components/control-bar/annotation-select.ts
+++ b/packages/core/src/components/control-bar/annotation-select.ts
@@ -14,6 +14,7 @@ class ProtspaceAnnotationSelect extends LitElement {
 
   @property({ type: Array }) annotations: string[] = [];
   @property({ type: String, attribute: 'selected-annotation' }) selectedAnnotation: string = '';
+  @property({ type: Array }) tooltipAnnotations: string[] = [];
   @property({ type: String }) placeholder: string = 'Select annotation';
 
   @state() private open: boolean = false;
@@ -126,6 +127,26 @@ class ProtspaceAnnotationSelect extends LitElement {
     );
   }
 
+  private toggleTooltipAnnotation(annotation: string, event: Event) {
+    event.stopPropagation();
+    event.preventDefault();
+    if (annotation === this.selectedAnnotation) {
+      return;
+    }
+    const isActive = this.tooltipAnnotations.includes(annotation);
+    const next = isActive
+      ? this.tooltipAnnotations.filter((name) => name !== annotation)
+      : [...this.tooltipAnnotations, annotation];
+    this.tooltipAnnotations = next;
+    this.dispatchEvent(
+      new CustomEvent('tooltip-annotation-toggle', {
+        detail: { annotation, active: !isActive, tooltipAnnotations: next },
+        bubbles: true,
+        composed: true,
+      }),
+    );
+  }
+
   /**
    * Categorize annotations using the shared utility.
    */
@@ -219,6 +240,7 @@ class ProtspaceAnnotationSelect extends LitElement {
                                 const itemIndex = currentIndex++;
                                 const isHighlighted = itemIndex === this.highlightIndex;
                                 const isSelected = annotation === this.selectedAnnotation;
+                                const isInTooltip = this.tooltipAnnotations.includes(annotation);
                                 return html`
                                   <div
                                     class="dropdown-item ${isHighlighted
@@ -229,7 +251,66 @@ class ProtspaceAnnotationSelect extends LitElement {
                                       this.highlightIndex = itemIndex;
                                     }}
                                   >
-                                    ${annotation}
+                                    <span
+                                      class="primary-indicator"
+                                      aria-hidden="true"
+                                      data-active=${isSelected ? 'true' : 'false'}
+                                    >
+                                      ${isSelected ? html`<span class="primary-dot"></span>` : ''}
+                                    </span>
+                                    <span class="dropdown-item-label">${annotation}</span>
+                                    <span class="tooltip-toggle-slot">
+                                      ${isSelected
+                                        ? ''
+                                        : html`<button
+                                            type="button"
+                                            class="tooltip-toggle-btn ${isInTooltip
+                                              ? 'is-active'
+                                              : ''}"
+                                            title=${isInTooltip
+                                              ? 'Hide from hover tooltip'
+                                              : 'Show in hover tooltip'}
+                                            aria-label=${isInTooltip
+                                              ? `Hide ${annotation} from hover tooltip`
+                                              : `Show ${annotation} in hover tooltip`}
+                                            aria-pressed=${isInTooltip ? 'true' : 'false'}
+                                            @click=${(e: Event) =>
+                                              this.toggleTooltipAnnotation(annotation, e)}
+                                            @mousedown=${(e: Event) => e.stopPropagation()}
+                                          >
+                                            <svg
+                                              viewBox="0 0 24 24"
+                                              width="16"
+                                              height="16"
+                                              aria-hidden="true"
+                                            >
+                                              <circle
+                                                cx="12"
+                                                cy="12"
+                                                r="9"
+                                                fill=${isInTooltip ? 'currentColor' : 'none'}
+                                                stroke="currentColor"
+                                                stroke-width="2"
+                                              />
+                                              <path
+                                                d="M12 10v6"
+                                                stroke=${isInTooltip
+                                                  ? 'var(--surface, #fff)'
+                                                  : 'currentColor'}
+                                                stroke-width="2"
+                                                stroke-linecap="round"
+                                              />
+                                              <circle
+                                                cx="12"
+                                                cy="7.5"
+                                                r="1.25"
+                                                fill=${isInTooltip
+                                                  ? 'var(--surface, #fff)'
+                                                  : 'currentColor'}
+                                              />
+                                            </svg>
+                                          </button>`}
+                                    </span>
                                   </div>
                                 `;
                               })}

--- a/packages/core/src/components/control-bar/annotation-select.ts
+++ b/packages/core/src/components/control-bar/annotation-select.ts
@@ -278,37 +278,43 @@ class ProtspaceAnnotationSelect extends LitElement {
                                               this.toggleTooltipAnnotation(annotation, e)}
                                             @mousedown=${(e: Event) => e.stopPropagation()}
                                           >
-                                            <svg
-                                              viewBox="0 0 24 24"
-                                              width="16"
-                                              height="16"
-                                              aria-hidden="true"
-                                            >
-                                              <circle
-                                                cx="12"
-                                                cy="12"
-                                                r="9"
-                                                fill=${isInTooltip ? 'currentColor' : 'none'}
-                                                stroke="currentColor"
-                                                stroke-width="2"
-                                              />
-                                              <path
-                                                d="M12 10v6"
-                                                stroke=${isInTooltip
-                                                  ? 'var(--surface, #fff)'
-                                                  : 'currentColor'}
-                                                stroke-width="2"
-                                                stroke-linecap="round"
-                                              />
-                                              <circle
-                                                cx="12"
-                                                cy="7.5"
-                                                r="1.25"
-                                                fill=${isInTooltip
-                                                  ? 'var(--surface, #fff)'
-                                                  : 'currentColor'}
-                                              />
-                                            </svg>
+                                            ${isInTooltip
+                                              ? html`<svg
+                                                  viewBox="0 0 24 24"
+                                                  width="16"
+                                                  height="16"
+                                                  fill="none"
+                                                  stroke="currentColor"
+                                                  stroke-width="2"
+                                                  stroke-linecap="round"
+                                                  stroke-linejoin="round"
+                                                  aria-hidden="true"
+                                                >
+                                                  <path
+                                                    d="M1.5 12s4-7.5 10.5-7.5S22.5 12 22.5 12 18.5 19.5 12 19.5 1.5 12 1.5 12z"
+                                                  />
+                                                  <circle cx="12" cy="12" r="3" />
+                                                </svg>`
+                                              : html`<svg
+                                                  viewBox="0 0 24 24"
+                                                  width="16"
+                                                  height="16"
+                                                  fill="none"
+                                                  stroke="currentColor"
+                                                  stroke-width="2"
+                                                  stroke-linecap="round"
+                                                  stroke-linejoin="round"
+                                                  aria-hidden="true"
+                                                >
+                                                  <path d="M3 3l18 18" />
+                                                  <path d="M10.585 10.587a2 2 0 0 0 2.83 2.828" />
+                                                  <path
+                                                    d="M16.681 16.673A8.717 8.717 0 0 1 12 18C6 18 2 12 2 12a13.16 13.16 0 0 1 3.176-3.836"
+                                                  />
+                                                  <path
+                                                    d="M9.88 5.18A8.717 8.717 0 0 1 12 5c6 0 10 7 10 7a13.198 13.198 0 0 1-1.668 2.06"
+                                                  />
+                                                </svg>`}
                                           </button>`}
                                     </span>
                                   </div>

--- a/packages/core/src/components/control-bar/control-bar.ts
+++ b/packages/core/src/components/control-bar/control-bar.ts
@@ -42,6 +42,7 @@ export class ProtspaceControlBar extends LitElement {
   selectedProjection: string = '';
   @property({ type: String, attribute: 'selected-annotation' })
   selectedAnnotation: string = '';
+  @property({ type: Array }) tooltipAnnotations: string[] = [];
   @property({ type: String, attribute: 'projection-plane' })
   projectionPlane: 'xy' | 'xz' | 'yz' = 'xy';
   @property({ type: Boolean, attribute: 'selection-mode' })
@@ -295,6 +296,14 @@ export class ProtspaceControlBar extends LitElement {
       }
     }
 
+    // The new primary is implicitly in the tooltip; drop it from the extras
+    // so the dropdown does not also show an active toggle for it.
+    if (this.tooltipAnnotations.includes(annotation)) {
+      this.applyTooltipAnnotationsSelection(
+        this.tooltipAnnotations.filter((name) => name !== annotation),
+      );
+    }
+
     const customEvent = new CustomEvent('annotation-change', {
       detail: { annotation },
       bubbles: true,
@@ -305,6 +314,37 @@ export class ProtspaceControlBar extends LitElement {
 
   private handleAnnotationSelected(event: CustomEvent<{ annotation: string }>) {
     this.applyAnnotationSelection(event.detail.annotation);
+  }
+
+  applyTooltipAnnotationsSelection(tooltipAnnotations: string[]) {
+    const sanitized = Array.from(
+      new Set(tooltipAnnotations.filter((name) => name !== this.selectedAnnotation)),
+    );
+    this.tooltipAnnotations = sanitized;
+
+    if (this.autoSync && this._scatterplotElement) {
+      if ('tooltipAnnotations' in this._scatterplotElement) {
+        (this._scatterplotElement as ScatterplotElementLike).tooltipAnnotations = [...sanitized];
+      }
+    }
+
+    this.dispatchEvent(
+      new CustomEvent('tooltip-annotations-change', {
+        detail: { tooltipAnnotations: [...sanitized] },
+        bubbles: true,
+        composed: true,
+      }),
+    );
+  }
+
+  private handleTooltipAnnotationToggle(
+    event: CustomEvent<{
+      annotation: string;
+      active: boolean;
+      tooltipAnnotations: string[];
+    }>,
+  ) {
+    this.applyTooltipAnnotationsSelection(event.detail.tooltipAnnotations);
   }
 
   private handleToggleSelectionMode() {
@@ -603,7 +643,9 @@ export class ProtspaceControlBar extends LitElement {
               id="annotation-select"
               .annotations=${this.annotations}
               .selectedAnnotation=${this.selectedAnnotation}
+              .tooltipAnnotations=${this.tooltipAnnotations}
               @annotation-select=${this.handleAnnotationSelected}
+              @tooltip-annotation-toggle=${this.handleTooltipAnnotationToggle}
             ></protspace-annotation-select>
           </div>
         </div>

--- a/packages/core/src/components/control-bar/types.ts
+++ b/packages/core/src/components/control-bar/types.ts
@@ -51,6 +51,7 @@ export interface ScatterplotElementLike extends Element {
   // State properties
   selectedProjectionIndex?: number;
   selectedAnnotation?: string;
+  tooltipAnnotations?: string[];
   selectionMode?: boolean;
   selectionTool?: 'rectangle' | 'lasso';
   selectedProteinIds?: string[];

--- a/packages/core/src/components/scatter-plot/protein-tooltip.styles.ts
+++ b/packages/core/src/components/scatter-plot/protein-tooltip.styles.ts
@@ -141,6 +141,20 @@ export const proteinTooltipStyles = css`
     font-variant-numeric: tabular-nums;
   }
 
+  .tooltip-annotation-raw-label {
+    flex-shrink: 0;
+    color: #64748b;
+    font-weight: normal;
+  }
+
+  .tooltip-annotation-raw-value {
+    flex-shrink: 0;
+    white-space: nowrap;
+    color: #64748b;
+    font-weight: normal;
+    font-variant-numeric: tabular-nums;
+  }
+
   .tooltip-annotation-evidence {
     flex-shrink: 0;
     white-space: nowrap;

--- a/packages/core/src/components/scatter-plot/protein-tooltip.ts
+++ b/packages/core/src/components/scatter-plot/protein-tooltip.ts
@@ -1,8 +1,8 @@
-import { LitElement, html } from 'lit';
+import { LitElement, html, type TemplateResult } from 'lit';
 import { property } from 'lit/decorators.js';
 import { customElement } from '../../utils/safe-custom-element';
 import { toDisplayValue, toInternalValue } from '@protspace/utils';
-import type { NumericAnnotationType, TooltipView } from '@protspace/utils';
+import type { AnnotationBlock, NumericAnnotationType, TooltipView } from '@protspace/utils';
 import { proteinTooltipStyles } from './protein-tooltip.styles';
 import {
   getAnnotationHeaderType,
@@ -17,17 +17,17 @@ const ANNOTATION_HEADER_LABELS: Record<'bitscore' | 'evidence', string> = {
 };
 
 const SUPERSCRIPT_DIGITS: Record<string, string> = {
-  '0': '\u2070',
-  '1': '\u00B9',
-  '2': '\u00B2',
-  '3': '\u00B3',
-  '4': '\u2074',
-  '5': '\u2075',
-  '6': '\u2076',
-  '7': '\u2077',
-  '8': '\u2078',
-  '9': '\u2079',
-  '-': '\u207B',
+  '0': '⁰',
+  '1': '¹',
+  '2': '²',
+  '3': '³',
+  '4': '⁴',
+  '5': '⁵',
+  '6': '⁶',
+  '7': '⁷',
+  '8': '⁸',
+  '9': '⁹',
+  '-': '⁻',
 };
 
 const RAW_FLOAT_VALUE_FORMATTER = new Intl.NumberFormat('en-US', {
@@ -65,13 +65,53 @@ function formatScore(value: number): string {
   // Strip the leading '+' from the exponent (e.g., e+2 → e2)
   const cleanExp = (exponent ?? '').replace(/^\+/, '');
   const superExp = cleanExp.replace(/[0-9\-]/g, (ch) => SUPERSCRIPT_DIGITS[ch] ?? ch);
-  return `${mantissa}\u00D710${superExp}`;
+  return `${mantissa}×10${superExp}`;
+}
+
+function renderAnnotationBlock(block: AnnotationBlock): TemplateResult {
+  const headerType = getAnnotationHeaderType(block.scores, block.evidence);
+  const numericType: NumericAnnotationType = block.numericType;
+  return html`
+    <div class="tooltip-annotations">
+      <div class="tooltip-annotation-header">
+        <span>${block.key}</span>
+        ${headerType ? html`<span>${ANNOTATION_HEADER_LABELS[headerType]}</span>` : ''}
+      </div>
+      ${block.numericValue !== null
+        ? html`<div class="tooltip-annotation tooltip-annotation-raw">
+            <span class="label">Raw value:</span>
+            <span class="tooltip-annotation-score"
+              >${formatRawNumericTooltipValue(block.numericValue, numericType)}</span
+            >
+          </div>`
+        : ''}
+      ${block.displayValues.map((value, idx) => {
+        const scores = block.scores[idx];
+        const evidence = block.evidence[idx];
+        const MAX_VISIBLE_SCORES = 3;
+        let scoreText = '';
+        if (Array.isArray(scores) && scores.length > 0) {
+          const visible = scores.slice(0, MAX_VISIBLE_SCORES).map(formatScore);
+          scoreText =
+            scores.length > MAX_VISIBLE_SCORES ? visible.join(', ') + ', …' : visible.join(', ');
+        }
+        const displayValue = toDisplayValue(toInternalValue(value));
+        return html`<div class="tooltip-annotation">
+          <span class="tooltip-annotation-label" title="${displayValue}">${displayValue}</span
+          >${scoreText
+            ? html`<span class="tooltip-annotation-score">${scoreText}</span>`
+            : evidence
+              ? html`<span class="tooltip-annotation-evidence">${evidence}</span>`
+              : ''}
+        </div>`;
+      })}
+    </div>
+  `;
 }
 
 @customElement('protspace-protein-tooltip')
 class ProtspaceProteinTooltip extends LitElement {
   @property({ type: Object }) view: TooltipView | null = null;
-  @property({ type: String }) selectedAnnotation = '';
 
   static styles = proteinTooltipStyles;
 
@@ -84,12 +124,6 @@ class ProtspaceProteinTooltip extends LitElement {
     const geneName = getGeneName(view.geneName);
     const proteinName = getProteinName(view.proteinName);
     const uniprotKbId = getUniprotKbId(view.uniprotKbId);
-    const tooltipAnnotationValues = view.displayValues;
-    const rawNumericValue = view.numericValue;
-    const rawNumericType: NumericAnnotationType = view.numericType;
-    const tooltipAnnotationScores = view.scores;
-    const tooltipAnnotationEvidence = view.evidence;
-    const headerType = getAnnotationHeaderType(tooltipAnnotationScores, tooltipAnnotationEvidence);
 
     return html`
       <div class="tooltip">
@@ -113,40 +147,7 @@ class ProtspaceProteinTooltip extends LitElement {
                 <span class="label">Gene:</span> ${geneName}
               </div>`
             : ''}
-          ${rawNumericValue !== null
-            ? html`<div class="tooltip-gene-name">
-                <span class="label">Raw value:</span>
-                ${formatRawNumericTooltipValue(rawNumericValue, rawNumericType)}
-              </div>`
-            : ''}
-          <div class="tooltip-annotations">
-            <div class="tooltip-annotation-header">
-              <span>${this.selectedAnnotation}</span>
-              ${headerType ? html`<span>${ANNOTATION_HEADER_LABELS[headerType]}</span>` : ''}
-            </div>
-            ${tooltipAnnotationValues.map((value, idx) => {
-              const scores = tooltipAnnotationScores[idx];
-              const evidence = tooltipAnnotationEvidence[idx];
-              const MAX_VISIBLE_SCORES = 3;
-              let scoreText = '';
-              if (Array.isArray(scores) && scores.length > 0) {
-                const visible = scores.slice(0, MAX_VISIBLE_SCORES).map(formatScore);
-                scoreText =
-                  scores.length > MAX_VISIBLE_SCORES
-                    ? visible.join(', ') + ', \u2026'
-                    : visible.join(', ');
-              }
-              const displayValue = toDisplayValue(toInternalValue(value));
-              return html`<div class="tooltip-annotation">
-                <span class="tooltip-annotation-label" title="${displayValue}">${displayValue}</span
-                >${scoreText
-                  ? html`<span class="tooltip-annotation-score">${scoreText}</span>`
-                  : evidence
-                    ? html`<span class="tooltip-annotation-evidence">${evidence}</span>`
-                    : ''}
-              </div>`;
-            })}
-          </div>
+          ${view.blocks.map((block) => renderAnnotationBlock(block))}
         </div>
       </div>
     `;

--- a/packages/core/src/components/scatter-plot/protein-tooltip.ts
+++ b/packages/core/src/components/scatter-plot/protein-tooltip.ts
@@ -79,8 +79,8 @@ function renderAnnotationBlock(block: AnnotationBlock): TemplateResult {
       </div>
       ${block.numericValue !== null
         ? html`<div class="tooltip-annotation tooltip-annotation-raw">
-            <span class="label">Raw value:</span>
-            <span class="tooltip-annotation-score"
+            <span class="tooltip-annotation-raw-label">Value:</span>
+            <span class="tooltip-annotation-raw-value"
               >${formatRawNumericTooltipValue(block.numericValue, numericType)}</span
             >
           </div>`

--- a/packages/core/src/components/scatter-plot/scatter-plot.ts
+++ b/packages/core/src/components/scatter-plot/scatter-plot.ts
@@ -63,6 +63,7 @@ export class ProtspaceScatterplot extends LitElement {
   @property({ type: Number }) selectedProjectionIndex = 0;
   @property({ type: String }) projectionPlane: 'xy' | 'xz' | 'yz' = 'xy';
   @property({ type: String }) selectedAnnotation = 'family';
+  @property({ type: Array }) tooltipAnnotations: string[] = [];
   @property({ type: Array }) highlightedProteinIds: string[] = [];
   @property({ type: Array }) selectedProteinIds: string[] = [];
   @property({ type: Boolean }) selectionMode = false;
@@ -1853,7 +1854,12 @@ export class ProtspaceScatterplot extends LitElement {
   private _handleMouseOver(event: MouseEvent, point: PlotDataPoint) {
     if (!this.data) return;
     const { x, y } = this._getLocalPointerPosition(event);
-    const view = buildTooltipView(this.data, point.originalIndex, this.selectedAnnotation);
+    const view = buildTooltipView(
+      this.data,
+      point.originalIndex,
+      this.selectedAnnotation,
+      this.tooltipAnnotations,
+    );
     this._tooltipData = { x, y, view };
 
     if (this._hoveredProteinId !== point.id) {
@@ -1872,7 +1878,12 @@ export class ProtspaceScatterplot extends LitElement {
 
   private _handleClick(event: MouseEvent, point: PlotDataPoint) {
     const view = this.data
-      ? buildTooltipView(this.data, point.originalIndex, this.selectedAnnotation)
+      ? buildTooltipView(
+          this.data,
+          point.originalIndex,
+          this.selectedAnnotation,
+          this.tooltipAnnotations,
+        )
       : null;
     this.dispatchEvent(
       new CustomEvent('protein-click', {
@@ -2134,7 +2145,6 @@ export class ProtspaceScatterplot extends LitElement {
                 class="visible"
                 style="${this._getTooltipStyle()}"
                 .view=${this._tooltipData.view}
-                .selectedAnnotation=${this.selectedAnnotation}
               >
               </protspace-protein-tooltip>
             `

--- a/packages/core/src/components/scatter-plot/scatter-plot.ts
+++ b/packages/core/src/components/scatter-plot/scatter-plot.ts
@@ -86,6 +86,7 @@ export class ProtspaceScatterplot extends LitElement {
     y: number;
     view: TooltipView;
   } | null = null;
+  @state() private _tooltipHeight: number | null = null;
   @state() private _mergedConfig = DEFAULT_CONFIG;
   @state() private _transform = d3.zoomIdentity;
   @state() private _isolationHistory: string[][] = [];
@@ -560,6 +561,23 @@ export class ProtspaceScatterplot extends LitElement {
     if (!onlySelectionChanged) {
       this._renderPlot();
       this._updateSelectionOverlays();
+    }
+
+    this._measureTooltipHeight();
+  }
+
+  private _measureTooltipHeight() {
+    if (!this._tooltipData) {
+      if (this._tooltipHeight !== null) {
+        this._tooltipHeight = null;
+      }
+      return;
+    }
+    const el = this.renderRoot.querySelector('protspace-protein-tooltip') as HTMLElement | null;
+    if (!el) return;
+    const height = el.offsetHeight;
+    if (height > 0 && height !== this._tooltipHeight) {
+      this._tooltipHeight = height;
     }
   }
 
@@ -2067,7 +2085,7 @@ export class ProtspaceScatterplot extends LitElement {
     const config = this._mergedConfig;
     const padding = 15;
     const tooltipMaxWidth = 350;
-    const tooltipApproxHeight = 160;
+    const tooltipHeight = this._tooltipHeight ?? 160;
 
     let left = x + 15;
     let top = y - 60;
@@ -2089,11 +2107,13 @@ export class ProtspaceScatterplot extends LitElement {
       left = tooltipMaxWidth + padding;
     }
 
-    // Vertical adjustment: keep within vertical bounds
+    // Vertical adjustment: clamp to viewport using the measured height when
+    // available, so tall multi-annotation tooltips do not run off the bottom.
+    if (top + tooltipHeight > config.height - padding) {
+      top = config.height - tooltipHeight - padding;
+    }
     if (top < padding) {
       top = padding;
-    } else if (top + tooltipApproxHeight > config.height) {
-      top = config.height - tooltipApproxHeight - padding;
     }
 
     return `left: ${left}px; top: ${top}px;${transform ? ` transform: ${transform};` : ''}`;

--- a/packages/core/src/components/scatter-plot/scatter-plot.ts
+++ b/packages/core/src/components/scatter-plot/scatter-plot.ts
@@ -26,6 +26,7 @@ import { createStyleGetters } from './style-getters';
 import { MAX_POINTS_DIRECT_RENDER, WebGLRenderer } from './webgl';
 import { QuadtreeIndex } from './quadtree-index';
 import { getDuplicateStackKey } from './duplicate-stack-helpers';
+import { estimateTooltipHeight } from './tooltip-height-estimate';
 import {
   WebglRenderPerfRunner,
   type PerfDatasetInfo,
@@ -171,6 +172,11 @@ export class ProtspaceScatterplot extends LitElement {
   private _spiderfyPressByPointerId = new Map<number, { x: number; y: number; t: number }>();
 
   private _webglRenderPerf = new WebglRenderPerfRunner(this);
+
+  // Monotonically-increasing token used to invalidate a pending async tooltip-height
+  // measurement when a newer hover or a tooltip-clear supersedes it before the child
+  // LitElement has finished rendering.
+  private _tooltipMeasureToken = 0;
 
   // Track data reference to detect projection-only changes (same data object, different projection index).
   private _lastDataRef: VisualizationData | null = null;
@@ -576,17 +582,37 @@ export class ProtspaceScatterplot extends LitElement {
 
   private _measureTooltipHeight() {
     if (!this._tooltipData) {
+      this._tooltipMeasureToken++; // invalidate any in-flight async measurement
       if (this._tooltipHeight !== null) {
         this._tooltipHeight = null;
       }
       return;
     }
-    const el = this.renderRoot.querySelector('protspace-protein-tooltip') as HTMLElement | null;
+    const el = this.renderRoot.querySelector('protspace-protein-tooltip') as
+      | (HTMLElement & { updateComplete?: Promise<unknown> })
+      | null;
     if (!el) return;
-    const height = el.offsetHeight;
-    if (height > 0 && height !== this._tooltipHeight) {
-      this._tooltipHeight = height;
-    }
+
+    // The <protspace-protein-tooltip> child LitElement renders its updated content
+    // one microtask AFTER this parent's updated() runs. Reading offsetHeight here
+    // would return the previous (or empty, on first hover) content height. Instead
+    // we wait for the child's own render cycle to complete before measuring.
+    const token = ++this._tooltipMeasureToken;
+    const childReady: Promise<unknown> = el.updateComplete ?? Promise.resolve();
+    void childReady.then(
+      () => {
+        // Guard against: (a) a newer hover that bumped the token while we were
+        // waiting, or (b) the tooltip being cleared while we were waiting.
+        if (token !== this._tooltipMeasureToken || !this._tooltipData) return;
+        const height = el.offsetHeight;
+        if (height > 0 && height !== this._tooltipHeight) {
+          this._tooltipHeight = height;
+        }
+      },
+      // The child's updateComplete rejects only if its render throws; swallow it
+      // so this measurement never surfaces an unhandled promise rejection.
+      () => {},
+    );
   }
 
   firstUpdated() {
@@ -2086,6 +2112,17 @@ export class ProtspaceScatterplot extends LitElement {
     }
   }
 
+  /**
+   * Content-scaled fallback height derived from the tooltip view model.
+   * Used when the async DOM measurement has not yet resolved (first hover or
+   * hover that changed data). Delegates to the pure `estimateTooltipHeight`
+   * helper so the logic is unit-testable without a DOM.
+   */
+  private _estimateTooltipHeight(): number {
+    if (!this._tooltipData) return 160;
+    return estimateTooltipHeight(this._tooltipData.view);
+  }
+
   private _getTooltipStyle() {
     if (!this._tooltipData) return '';
 
@@ -2093,7 +2130,7 @@ export class ProtspaceScatterplot extends LitElement {
     const config = this._mergedConfig;
     const padding = 15;
     const tooltipMaxWidth = 350;
-    const tooltipHeight = this._tooltipHeight ?? 160;
+    const tooltipHeight = this._tooltipHeight ?? this._estimateTooltipHeight();
 
     let left = x + 15;
     let top = y - 60;

--- a/packages/core/src/components/scatter-plot/scatter-plot.ts
+++ b/packages/core/src/components/scatter-plot/scatter-plot.ts
@@ -563,7 +563,15 @@ export class ProtspaceScatterplot extends LitElement {
       this._updateSelectionOverlays();
     }
 
-    this._measureTooltipHeight();
+    // Only measure tooltip height when the tooltip data itself changes. The rendered
+    // height is derived purely from _tooltipData.view, so there is no reason to
+    // read offsetHeight (which forces a synchronous layout reflow) on unrelated
+    // updates such as zoom/pan (_transform), selection overlays, or the self-triggered
+    // _tooltipHeight update. Clearing _tooltipData to null IS a _tooltipData change,
+    // so the null-reset path in _measureTooltipHeight still fires correctly.
+    if (changedProperties.has('_tooltipData')) {
+      this._measureTooltipHeight();
+    }
   }
 
   private _measureTooltipHeight() {

--- a/packages/core/src/components/scatter-plot/tooltip-height-estimate.test.ts
+++ b/packages/core/src/components/scatter-plot/tooltip-height-estimate.test.ts
@@ -1,0 +1,158 @@
+import { describe, it, expect } from 'vitest';
+import type { TooltipView } from '@protspace/utils';
+import { estimateTooltipHeight } from './tooltip-height-estimate';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeBlock(
+  overrides: Partial<{
+    key: string;
+    displayValues: string[];
+    numericValue: number | null;
+    numericType: 'float' | 'int';
+    scores: (number[] | null)[];
+    evidence: (string | null)[];
+  }> = {},
+): TooltipView['blocks'][number] {
+  return {
+    key: 'annotation',
+    displayValues: ['ValueA'],
+    numericValue: null,
+    numericType: 'float',
+    scores: [],
+    evidence: [],
+    ...overrides,
+  };
+}
+
+function makeView(
+  overrides: Partial<{
+    proteinId: string;
+    geneName: string[];
+    proteinName: string[];
+    uniprotKbId: string[];
+    blocks: TooltipView['blocks'];
+  }> = {},
+): TooltipView {
+  return {
+    proteinId: 'P12345',
+    geneName: [],
+    proteinName: [],
+    uniprotKbId: [],
+    blocks: [],
+    ...overrides,
+  };
+}
+
+// A block that is large enough on its own to push the total above the 160 floor.
+// 1 block: BLOCK_SEPARATOR(17) + BLOCK_HEADER_ROW(16) + 4×ANNOTATION_ROW(64) = 97
+// + HEADER_HEIGHT(38) + CONTENT_PADDING_V(24) = 159 — just below floor!
+// Use 5 displayValues: 17+16+5*16=113; +38+24=175 — safely above 160.
+function bigBlock(): TooltipView['blocks'][number] {
+  return makeBlock({ displayValues: ['A', 'B', 'C', 'D', 'E'] });
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('estimateTooltipHeight', () => {
+  it('returns the minimum floor (160) for a minimal view with no blocks or names', () => {
+    const view = makeView();
+    expect(estimateTooltipHeight(view)).toBe(160);
+  });
+
+  it('is always >= 160 regardless of content', () => {
+    const heights = [
+      estimateTooltipHeight(makeView()),
+      estimateTooltipHeight(makeView({ geneName: ['TP53'] })),
+      estimateTooltipHeight(makeView({ blocks: [makeBlock()] })),
+    ];
+    for (const h of heights) {
+      expect(h).toBeGreaterThanOrEqual(160);
+    }
+  });
+
+  it('increases height when proteinName is present (both above floor)', () => {
+    // Anchor both views at one big block so raw totals are above 160
+    const withoutName = estimateTooltipHeight(makeView({ proteinName: [], blocks: [bigBlock()] }));
+    const withName = estimateTooltipHeight(
+      makeView({ proteinName: ['Tumor protein p53'], blocks: [bigBlock()] }),
+    );
+    expect(withName).toBeGreaterThan(withoutName);
+  });
+
+  it('increases height when geneName is present (both above floor)', () => {
+    const without = estimateTooltipHeight(makeView({ geneName: [], blocks: [bigBlock()] }));
+    const with_ = estimateTooltipHeight(makeView({ geneName: ['TP53'], blocks: [bigBlock()] }));
+    expect(with_).toBeGreaterThan(without);
+  });
+
+  it('increases height monotonically as more annotation blocks are added', () => {
+    // bigBlock() alone pushes first non-zero-block case above 160
+    const h1 = estimateTooltipHeight(makeView({ blocks: [bigBlock()] }));
+    const h2 = estimateTooltipHeight(makeView({ blocks: [bigBlock(), bigBlock()] }));
+    const h3 = estimateTooltipHeight(makeView({ blocks: [bigBlock(), bigBlock(), bigBlock()] }));
+    expect(h1).toBeGreaterThan(160); // ensure we are above the floor
+    expect(h2).toBeGreaterThan(h1);
+    expect(h3).toBeGreaterThan(h2);
+  });
+
+  it('increases height when a block has more displayValues rows (both above floor)', () => {
+    // Each block is in a view with extra blocks so we stay above 160
+    const blockOneRow = makeBlock({ displayValues: ['A'] });
+    const blockFiveRows = makeBlock({ displayValues: ['A', 'B', 'C', 'D', 'E'] });
+    const h1 = estimateTooltipHeight(makeView({ blocks: [bigBlock(), blockOneRow] }));
+    const h5 = estimateTooltipHeight(makeView({ blocks: [bigBlock(), blockFiveRows] }));
+    expect(h5).toBeGreaterThan(h1);
+  });
+
+  it('adds a row when a block has a numericValue (both above floor)', () => {
+    const blockNoNumeric = makeBlock({ numericValue: null, displayValues: ['Bin A'] });
+    const blockWithNumeric = makeBlock({ numericValue: 3.14, displayValues: ['Bin A'] });
+    // Pair each variant with a bigBlock so both totals exceed 160
+    const hNoNumeric = estimateTooltipHeight(makeView({ blocks: [bigBlock(), blockNoNumeric] }));
+    const hWithNumeric = estimateTooltipHeight(
+      makeView({ blocks: [bigBlock(), blockWithNumeric] }),
+    );
+    expect(hWithNumeric).toBeGreaterThan(hNoNumeric);
+  });
+
+  it('produces a plausible height for a typical single-annotation tooltip', () => {
+    // Header-only protein, 1 annotation block with 3 values
+    const view = makeView({
+      proteinName: ['Tumor protein p53'],
+      geneName: ['TP53'],
+      blocks: [makeBlock({ displayValues: ['Oncogene', 'Tumor suppressor', 'Kinase'] })],
+    });
+    const h = estimateTooltipHeight(view);
+    // Should be well above the floor and below an unreasonably large value
+    expect(h).toBeGreaterThan(160);
+    expect(h).toBeLessThan(500);
+  });
+
+  it('produces a plausible height for a tall multi-annotation tooltip (5 blocks, many rows)', () => {
+    const tallBlock = makeBlock({
+      displayValues: ['Val1', 'Val2', 'Val3', 'Val4', 'Val5'],
+      numericValue: 42,
+    });
+    const view = makeView({
+      proteinName: ['Some long protein name'],
+      geneName: ['GENE1'],
+      blocks: [tallBlock, tallBlock, tallBlock, tallBlock, tallBlock],
+    });
+    const h = estimateTooltipHeight(view);
+    // 5 blocks × (17 sep + 16 header + 16 numericRow + 5×16 rows) = 5 × 129 = 645
+    // + header 38 + content padding 24 + proteinName 20 + geneName 20 = 102
+    // total ≈ 747, well above floor
+    expect(h).toBeGreaterThan(600);
+  });
+
+  it('two identical views produce equal heights', () => {
+    const view1 = makeView({ geneName: ['TP53'], blocks: [bigBlock()] });
+    const view2 = makeView({ geneName: ['TP53'], blocks: [bigBlock()] });
+    expect(estimateTooltipHeight(view1)).toBe(estimateTooltipHeight(view2));
+  });
+});

--- a/packages/core/src/components/scatter-plot/tooltip-height-estimate.ts
+++ b/packages/core/src/components/scatter-plot/tooltip-height-estimate.ts
@@ -1,0 +1,82 @@
+import type { TooltipView } from '@protspace/utils';
+import { filterAnnotationValues } from './protein-tooltip-helpers';
+
+/**
+ * CSS-calibrated constants for estimating the rendered height of
+ * <protspace-protein-tooltip> from its data model alone.
+ *
+ * All values are in CSS pixels at the default 16px root font size.
+ *
+ * Header section (.tooltip-header)
+ *   padding: 0.625rem top + 0.625rem bottom = 10 + 10 = 20 px
+ *   font-size: 0.75rem → 12 px, line-height default 1.2 → ~15 px
+ *   border-bottom: 1 px
+ *   Total: 20 + 15 + 1 = 36 px  → rounded up to 38 for safety
+ *
+ * Content wrapper (.tooltip-content)
+ *   padding: 0.75rem top + 0.75rem bottom = 12 + 12 = 24 px
+ *
+ * Protein-name row (.tooltip-protein-name)
+ *   font-size: 0.8125rem (13 px), line-height 1.4 → ~18 px
+ *   margin-bottom: 0.125rem = 2 px
+ *   Total: ~20 px
+ *
+ * Gene-name row (.tooltip-gene-name)
+ *   font-size: 0.75rem (12 px), line-height default → ~15 px
+ *   margin-bottom: 0.25rem = 4 px
+ *   Total: ~19 px   → rounded to 20 for safety
+ *
+ * Per annotation block (.tooltip-annotations)
+ *   top separator area: margin-top 0.5rem (8) + padding-top 0.5rem (8) + border-top 1 = 17 px
+ *   block header row (.tooltip-annotation-header):
+ *     font-size: 0.625rem (10 px), margin-bottom 0.125rem (2 px) → ~16 px
+ *   "Value:" row (.tooltip-annotation with raw class):
+ *     font-size: 0.75rem (12 px) → ~16 px (reuses the annotation row height)
+ *   each displayValues row (.tooltip-annotation):
+ *     font-size: 0.75rem (12 px), gap between rows 0.25rem (4 px) → ~16 px per row
+ *
+ * Minimum height floor: 160 px (the previous hard-coded fallback).
+ */
+
+const HEADER_HEIGHT = 38; // header padding + content + border-bottom
+const CONTENT_PADDING_V = 24; // .tooltip-content top + bottom padding
+const PROTEIN_NAME_ROW = 20; // .tooltip-protein-name row
+const GENE_NAME_ROW = 20; // .tooltip-gene-name row
+const BLOCK_SEPARATOR = 17; // margin-top + padding-top + border-top for .tooltip-annotations
+const BLOCK_HEADER_ROW = 16; // .tooltip-annotation-header height
+const ANNOTATION_ROW = 16; // each .tooltip-annotation row (value or displayValues entry)
+const MINIMUM_HEIGHT = 160; // floor — short tooltips unaffected
+
+/**
+ * Estimate the rendered pixel height of a tooltip from its view model.
+ *
+ * The estimate intentionally biases slightly toward over-estimating because:
+ * - A larger estimate clamps the tooltip further up, keeping it on-screen.
+ * - Under-estimating risks the tooltip running off the bottom of the viewport.
+ *
+ * This is a pure function suitable for unit testing; no DOM access required.
+ */
+export function estimateTooltipHeight(view: TooltipView): number {
+  let height = HEADER_HEIGHT + CONTENT_PADDING_V;
+
+  const hasProteinName = filterAnnotationValues(view.proteinName) !== null;
+  const hasGeneName = filterAnnotationValues(view.geneName) !== null;
+
+  if (hasProteinName) height += PROTEIN_NAME_ROW;
+  if (hasGeneName) height += GENE_NAME_ROW;
+
+  for (const block of view.blocks) {
+    height += BLOCK_SEPARATOR;
+    height += BLOCK_HEADER_ROW;
+
+    // "Value:" row is rendered when numericValue is not null
+    if (block.numericValue !== null) {
+      height += ANNOTATION_ROW;
+    }
+
+    // One row per displayValues entry
+    height += block.displayValues.length * ANNOTATION_ROW;
+  }
+
+  return Math.max(MINIMUM_HEIGHT, height);
+}

--- a/packages/utils/src/visualization/plot-data-accessors.test.ts
+++ b/packages/utils/src/visualization/plot-data-accessors.test.ts
@@ -172,7 +172,9 @@ describe('plot-data-accessors', () => {
       expect(view.geneName).toEqual(['BRCA1']);
       expect(view.proteinName).toEqual(['BRCA1 protein']);
       expect(view.uniprotKbId).toEqual(['P00001']);
-      expect(view.displayValues).toEqual(['human']);
+      expect(view.blocks).toHaveLength(1);
+      expect(view.blocks[0].key).toBe('species');
+      expect(view.blocks[0].displayValues).toEqual(['human']);
     });
 
     it('falls back to "Gene name" / "Protein name" keys when snake_case keys are absent', () => {
@@ -245,13 +247,9 @@ describe('plot-data-accessors', () => {
       expect(view.proteinName).toEqual(['BRCA1 protein']);
     });
 
-    it('returns empty selected-annotation fields when selectedAnnotation is null', () => {
+    it('returns no annotation blocks when primaryAnnotation is null and no extras provided', () => {
       const view = buildTooltipView(baseData(), 0, null);
-      expect(view.displayValues).toEqual([]);
-      expect(view.numericValue).toBeNull();
-      expect(view.numericType).toBe('float');
-      expect(view.scores).toEqual([]);
-      expect(view.evidence).toEqual([]);
+      expect(view.blocks).toEqual([]);
     });
 
     it('returns empty header arrays when the named annotations are absent', () => {
@@ -260,6 +258,34 @@ describe('plot-data-accessors', () => {
       // No protein_name / uniprot_kb_id in baseData
       expect(view.proteinName).toEqual([]);
       expect(view.uniprotKbId).toEqual([]);
+    });
+
+    it('returns extra annotation blocks after the primary, in given order', () => {
+      const view = buildTooltipView(baseData(), 0, 'species', ['gene_name']);
+      expect(view.blocks.map((b) => b.key)).toEqual(['species', 'gene_name']);
+      expect(view.blocks[0].displayValues).toEqual(['human']);
+      expect(view.blocks[1].displayValues).toEqual(['BRCA1']);
+    });
+
+    it('deduplicates extras against the primary', () => {
+      const view = buildTooltipView(baseData(), 0, 'species', ['species', 'gene_name']);
+      expect(view.blocks.map((b) => b.key)).toEqual(['species', 'gene_name']);
+    });
+
+    it('deduplicates repeated extras', () => {
+      const view = buildTooltipView(baseData(), 0, 'species', ['gene_name', 'gene_name']);
+      expect(view.blocks.map((b) => b.key)).toEqual(['species', 'gene_name']);
+    });
+
+    it('drops extras whose annotation is missing from the dataset', () => {
+      const view = buildTooltipView(baseData(), 0, 'species', ['nonexistent', 'gene_name']);
+      expect(view.blocks.map((b) => b.key)).toEqual(['species', 'gene_name']);
+    });
+
+    it('returns only extra blocks when primary is null', () => {
+      const view = buildTooltipView(baseData(), 0, null, ['gene_name']);
+      expect(view.blocks.map((b) => b.key)).toEqual(['gene_name']);
+      expect(view.blocks[0].displayValues).toEqual(['BRCA1']);
     });
   });
 });

--- a/packages/utils/src/visualization/plot-data-accessors.ts
+++ b/packages/utils/src/visualization/plot-data-accessors.ts
@@ -77,17 +77,24 @@ export function getProteinEvidence(
 
 /**
  * Tooltip view — assembled once per hover, never per-protein.
+ * `blocks` is ordered: the primary annotation is first (when provided),
+ * followed by any extra annotations the user has opted into.
  */
-export interface TooltipView {
-  proteinId: string;
-  geneName: string[];
-  proteinName: string[];
-  uniprotKbId: string[];
+export interface AnnotationBlock {
+  key: string;
   displayValues: string[];
   numericValue: number | null;
   numericType: NumericAnnotationType;
   scores: (number[] | null)[];
   evidence: (string | null)[];
+}
+
+export interface TooltipView {
+  proteinId: string;
+  geneName: string[];
+  proteinName: string[];
+  uniprotKbId: string[];
+  blocks: AnnotationBlock[];
 }
 
 function getHeaderValues(
@@ -105,10 +112,26 @@ function getHeaderValues(
   return [];
 }
 
+function buildAnnotationBlock(
+  data: VisualizationData,
+  proteinIdx: number,
+  key: string,
+): AnnotationBlock {
+  return {
+    key,
+    displayValues: getProteinDisplayValues(data, proteinIdx, key),
+    numericValue: getProteinNumericValue(data, proteinIdx, key),
+    numericType: getProteinNumericType(data, key),
+    scores: getProteinScores(data, proteinIdx, key),
+    evidence: getProteinEvidence(data, proteinIdx, key),
+  };
+}
+
 export function buildTooltipView(
   data: VisualizationData,
   proteinIdx: number,
-  selectedAnnotation: string | null,
+  primaryAnnotation: string | null,
+  extraAnnotations: readonly string[] = [],
 ): TooltipView {
   const proteinId = data.protein_ids[proteinIdx] ?? '';
   const geneName = getHeaderValues(data, proteinIdx, 'gene_name', 'Gene name');
@@ -117,18 +140,17 @@ export function buildTooltipView(
     ? getProteinAnnotationValues(data, proteinIdx, 'uniprot_kb_id')
     : [];
 
-  if (!selectedAnnotation) {
-    return {
-      proteinId,
-      geneName,
-      proteinName,
-      uniprotKbId,
-      displayValues: [],
-      numericValue: null,
-      numericType: 'float',
-      scores: [],
-      evidence: [],
-    };
+  const blocks: AnnotationBlock[] = [];
+  const seen = new Set<string>();
+  if (primaryAnnotation && data.annotations[primaryAnnotation]) {
+    blocks.push(buildAnnotationBlock(data, proteinIdx, primaryAnnotation));
+    seen.add(primaryAnnotation);
+  }
+  for (const key of extraAnnotations) {
+    if (seen.has(key)) continue;
+    if (!data.annotations[key]) continue;
+    blocks.push(buildAnnotationBlock(data, proteinIdx, key));
+    seen.add(key);
   }
 
   return {
@@ -136,10 +158,6 @@ export function buildTooltipView(
     geneName,
     proteinName,
     uniprotKbId,
-    displayValues: getProteinDisplayValues(data, proteinIdx, selectedAnnotation),
-    numericValue: getProteinNumericValue(data, proteinIdx, selectedAnnotation),
-    numericType: getProteinNumericType(data, selectedAnnotation),
-    scores: getProteinScores(data, proteinIdx, selectedAnnotation),
-    evidence: getProteinEvidence(data, proteinIdx, selectedAnnotation),
+    blocks,
   };
 }


### PR DESCRIPTION
## Summary
Closes #234.

Lets users opt extra annotation features into the hover tooltip alongside the primary (legend-defining) annotation.

### Dropdown UI (`protspace-annotation-select`)
- Filled **primary indicator dot** on the currently selected row.
- Small **(i) toggle button** on every non-primary row. Click flips that annotation in/out of the hover tooltip; native `title` provides the help text ("Show in hover tooltip" / "Hide from hover tooltip"). `aria-pressed` reflects state.
- Toggle dispatches `tooltip-annotation-toggle` (separate from `annotation-select`); the row label still selects the primary.

### Hover tooltip
- `TooltipView` now carries an ordered `blocks[]` array. Each `AnnotationBlock` has its own `key`, `displayValues`, `numericValue`/`numericType`, `scores`, `evidence`.
- The primary annotation renders first, then any extras in dropdown-add order — each gets the full treatment (header, scores/evidence column, raw numeric row).

### State + persistence
- New `?tooltip=foo,bar` URL param (comma-separated). Parser dedupes, drops the primary, drops names not in the dataset, marks anything off for normalization on next URL write.
- Dataset-scoped localStorage (`protspace:tooltip-annotations:<hash>`) seeded on dataset load when the URL does not pin a value; kept in sync afterwards via the existing view-change subscription.
- Promoting an extra annotation to primary drops it from the extras (no double-render).

### Test coverage
- 11 new url-state tests, 5 localStorage-store tests, 6 component tests for the dropdown UI, multi-annotation tests for `buildTooltipView`.
- New Playwright spec `multi-annotation-tooltip.spec.ts` (3 tests) covers the dropdown indicator/toggle, URL writes on toggle, and round-trip removal — all pass locally.
- Existing `818 + 73 + 243` unit/component tests still pass.

## Test plan
- [x] Primary annotation visually distinguished in the dropdown (radio-dot)
- [x] (i) icon toggles tooltip inclusion without changing the primary annotation
- [x] Hover tooltip shows extra blocks for opted-in annotations in stable order
- [x] State persists across reloads (URL + dataset-scoped localStorage)
- [x] Keyboard nav unchanged; `aria-pressed` + `title` on (i) for a11y
- [x] Type-check, knip, unit/component tests, docs build (via pre-commit)
- [x] Local Playwright e2e spec for the new dropdown + URL plumbing

🤖 Generated with [Claude Code](https://claude.com/claude-code)