### PR TITLE
refactor: control bar cleanup and filtering improvements

### DIFF
--- a/packages/core/src/components/control-bar/control-bar-helpers.test.ts
+++ b/packages/core/src/components/control-bar/control-bar-helpers.test.ts
@@ -1,8 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import {
   EXPORT_DEFAULTS,
-  isProjection3D,
-  getProjectionPlane,
   shouldDisableSelection,
   getSelectionDisabledMessage,
   toggleProteinSelection,
@@ -89,48 +87,6 @@ describe('control-bar-helpers', () => {
           EXPORT_DEFAULTS.MAX_LEGEND_FONT_SIZE_PX / EXPORT_DEFAULTS.BASE_FONT_SIZE;
         expect(scaleFactor).toBe(5.0); // 120 / 24 = 5.0
       });
-    });
-  });
-
-  describe('isProjection3D', () => {
-    const projectionsMeta = [
-      { name: 'projection2D', metadata: { dimension: 2 as const } },
-      { name: 'projection3D', metadata: { dimension: 3 as const } },
-      { name: 'projectionNoMeta' },
-    ];
-
-    it('returns true for 3D projection', () => {
-      expect(isProjection3D('projection3D', projectionsMeta)).toBe(true);
-    });
-
-    it('returns false for 2D projection', () => {
-      expect(isProjection3D('projection2D', projectionsMeta)).toBe(false);
-    });
-
-    it('returns false for projection without metadata', () => {
-      expect(isProjection3D('projectionNoMeta', projectionsMeta)).toBe(false);
-    });
-
-    it('returns false for non-existent projection', () => {
-      expect(isProjection3D('nonExistent', projectionsMeta)).toBe(false);
-    });
-
-    it('returns false for empty projections array', () => {
-      expect(isProjection3D('projection3D', [])).toBe(false);
-    });
-  });
-
-  describe('getProjectionPlane', () => {
-    it('returns current plane for 3D projection', () => {
-      expect(getProjectionPlane(true, 'xz')).toBe('xz');
-      expect(getProjectionPlane(true, 'yz')).toBe('yz');
-      expect(getProjectionPlane(true, 'xy')).toBe('xy');
-    });
-
-    it('returns xy for 2D projection regardless of current plane', () => {
-      expect(getProjectionPlane(false, 'xz')).toBe('xy');
-      expect(getProjectionPlane(false, 'yz')).toBe('xy');
-      expect(getProjectionPlane(false, 'xy')).toBe('xy');
     });
   });
 

--- a/packages/core/src/components/control-bar/control-bar-helpers.ts
+++ b/packages/core/src/components/control-bar/control-bar-helpers.ts
@@ -20,27 +20,6 @@ export const EXPORT_DEFAULTS = {
 };
 
 /**
- * Check if projection is 3D based on metadata
- */
-export function isProjection3D(
-  projectionName: string,
-  projectionsMeta: Array<{ name: string; metadata?: { dimension?: 2 | 3 } }>,
-): boolean {
-  const meta = projectionsMeta.find((p) => p.name === projectionName);
-  return meta?.metadata?.dimension === 3;
-}
-
-/**
- * Get appropriate plane for projection
- */
-export function getProjectionPlane(
-  is3D: boolean,
-  currentPlane: 'xy' | 'xz' | 'yz',
-): 'xy' | 'xz' | 'yz' {
-  return is3D ? currentPlane : 'xy';
-}
-
-/**
  * Validate selection mode based on data size
  */
 export function shouldDisableSelection(dataSize: number): boolean {

--- a/packages/core/src/components/control-bar/control-bar.ts
+++ b/packages/core/src/components/control-bar/control-bar.ts
@@ -12,8 +12,6 @@ import type {
 import { handleDropdownEscape, isAnyDropdownOpen } from '../../utils/dropdown-helpers';
 import {
   EXPORT_DEFAULTS,
-  isProjection3D,
-  getProjectionPlane,
   toggleProteinSelection,
   mergeProteinSelections,
 } from './control-bar-helpers';
@@ -42,8 +40,6 @@ export class ProtspaceControlBar extends LitElement {
   selectedProjection: string = '';
   @property({ type: String, attribute: 'selected-annotation' })
   selectedAnnotation: string = '';
-  @property({ type: String, attribute: 'projection-plane' })
-  projectionPlane: 'xy' | 'xz' | 'yz' = 'xy';
   @property({ type: Boolean, attribute: 'selection-mode' })
   selectionMode: boolean = false;
   @property({ type: String, attribute: 'selection-tool' })
@@ -141,13 +137,6 @@ export class ProtspaceControlBar extends LitElement {
       if (projectionIndex !== -1 && 'selectedProjectionIndex' in this._scatterplotElement) {
         (this._scatterplotElement as ScatterplotElementLike).selectedProjectionIndex =
           projectionIndex;
-
-        const is3D = isProjection3D(this.selectedProjection, this.projectionsMeta);
-        const nextPlane = getProjectionPlane(is3D, this.projectionPlane);
-        if ('projectionPlane' in this._scatterplotElement) {
-          (this._scatterplotElement as ScatterplotElementLike).projectionPlane = nextPlane;
-        }
-        this.projectionPlane = nextPlane;
       }
     }
 
@@ -264,25 +253,6 @@ export class ProtspaceControlBar extends LitElement {
         highlighted.scrollIntoView({ block: 'nearest', behavior: 'smooth' });
       }
     });
-  }
-
-  private handlePlaneChange(event: Event) {
-    const target = event.target as HTMLSelectElement;
-    const plane = target.value as 'xy' | 'xz' | 'yz';
-    if (
-      this.autoSync &&
-      this._scatterplotElement &&
-      'projectionPlane' in this._scatterplotElement
-    ) {
-      (this._scatterplotElement as ScatterplotElementLike).projectionPlane = plane;
-      this.projectionPlane = plane;
-    }
-    const customEvent = new CustomEvent('projection-plane-change', {
-      detail: { plane },
-      bubbles: true,
-      composed: true,
-    });
-    this.dispatchEvent(customEvent);
   }
 
   applyAnnotationSelection(annotation: string) {
@@ -576,25 +546,6 @@ export class ProtspaceControlBar extends LitElement {
                 : ''}
             </div>
           </div>
-
-          ${(() => {
-            return isProjection3D(this.selectedProjection, this.projectionsMeta)
-              ? html`
-                  <div class="control-group">
-                    <label for="plane-select">Plane:</label>
-                    <select
-                      id="plane-select"
-                      .value=${this.projectionPlane}
-                      @change=${this.handlePlaneChange}
-                    >
-                      <option value="xy">XY</option>
-                      <option value="xz">XZ</option>
-                      <option value="yz">YZ</option>
-                    </select>
-                  </div>
-                `
-              : null;
-          })()}
 
           <!-- Annotation selection -->
           <div class="control-group">

--- a/packages/core/src/components/control-bar/types.ts
+++ b/packages/core/src/components/control-bar/types.ts
@@ -54,7 +54,6 @@ export interface ScatterplotElementLike extends Element {
   selectionMode?: boolean;
   selectionTool?: 'rectangle' | 'lasso';
   selectedProteinIds?: string[];
-  projectionPlane?: 'xy' | 'xz' | 'yz';
   data?: ProtspaceData;
   filteredProteinIds?: string[];
   filtersActive?: boolean;

--- a/packages/core/src/components/scatter-plot/scatter-plot.ts
+++ b/packages/core/src/components/scatter-plot/scatter-plot.ts
@@ -60,7 +60,6 @@ export class ProtspaceScatterplot extends LitElement {
   // Properties
   @property({ type: Object }) data: VisualizationData | null = null;
   @property({ type: Number }) selectedProjectionIndex = 0;
-  @property({ type: String }) projectionPlane: 'xy' | 'xz' | 'yz' = 'xy';
   @property({ type: String }) selectedAnnotation = 'family';
   @property({ type: Array }) highlightedProteinIds: string[] = [];
   @property({ type: Array }) selectedProteinIds: string[] = [];
@@ -432,15 +431,13 @@ export class ProtspaceScatterplot extends LitElement {
       !changedProperties.has('data') &&
       !changedProperties.has('filteredProteinIds') &&
       !changedProperties.has('filtersActive') &&
-      !changedProperties.has('selectedProjectionIndex') &&
-      !changedProperties.has('projectionPlane');
+      !changedProperties.has('selectedProjectionIndex');
 
     if (
       changedProperties.has('data') ||
       changedProperties.has('filteredProteinIds') ||
       changedProperties.has('filtersActive') ||
-      changedProperties.has('selectedProjectionIndex') ||
-      changedProperties.has('projectionPlane')
+      changedProperties.has('selectedProjectionIndex')
     ) {
       this._processData();
       this._scheduleQuadtreeRebuild();
@@ -604,7 +601,6 @@ export class ProtspaceScatterplot extends LitElement {
         this.selectedProjectionIndex,
         this._isolationMode,
         this._isolationHistory,
-        this.projectionPlane,
       );
     }
 
@@ -779,18 +775,8 @@ export class ProtspaceScatterplot extends LitElement {
         | [number, number]
         | [number, number, number];
 
-      let xVal = coords[0];
-      let yVal = coords[1];
-
-      if (coords.length === 3) {
-        point.z = coords[2];
-        if (this.projectionPlane === 'xz') {
-          yVal = coords[2];
-        } else if (this.projectionPlane === 'yz') {
-          xVal = coords[1];
-          yVal = coords[2];
-        }
-      }
+      const xVal = coords[0];
+      const yVal = coords[1];
 
       point.x = xVal;
       point.y = yVal;

--- a/packages/core/src/components/scatter-plot/scatter-plot.ts
+++ b/packages/core/src/components/scatter-plot/scatter-plot.ts
@@ -585,7 +585,7 @@ export class ProtspaceScatterplot extends LitElement {
 
     if (onlyProjectionChanged) {
       // Fast path: update coordinates in-place from the new projection data.
-      // No new object allocation — just overwrite x/y/z on existing PlotDataPoints.
+      // No new object allocation — just overwrite x/y on existing PlotDataPoints.
       this._updatePlotDataCoordinates(dataToUse);
     } else {
       // Release old data references before allocating the new dataset.

--- a/packages/utils/src/types.ts
+++ b/packages/utils/src/types.ts
@@ -63,7 +63,6 @@ export interface PlotDataPoint {
   id: string;
   x: number;
   y: number;
-  z?: number;
   originalIndex: number;
 }
 

--- a/packages/utils/src/visualization/data-processor.test.ts
+++ b/packages/utils/src/visualization/data-processor.test.ts
@@ -24,7 +24,7 @@ describe('DataProcessor.processVisualizationData', () => {
     expect(result[1]).toEqual({ id: 'p1', x: 3, y: 4, originalIndex: 1 });
   });
 
-  it('preserves z coordinate for 3D projections', () => {
+  it('drops the z coordinate for 3D projections (rendered as 2D)', () => {
     const data: VisualizationData = {
       protein_ids: ['p0'],
       projections: [{ name: 't', data: [[1, 2, 3]] }],
@@ -32,29 +32,8 @@ describe('DataProcessor.processVisualizationData', () => {
       annotation_data: {},
     };
     const result = DataProcessor.processVisualizationData(data, 0);
-    expect(result[0]).toEqual({ id: 'p0', x: 1, y: 2, z: 3, originalIndex: 0 });
-  });
-
-  it('maps coordinates to xz plane when projectionPlane is "xz"', () => {
-    const data: VisualizationData = {
-      protein_ids: ['p0'],
-      projections: [{ name: 't', data: [[10, 20, 30]] }],
-      annotations: {},
-      annotation_data: {},
-    };
-    const result = DataProcessor.processVisualizationData(data, 0, false, undefined, 'xz');
-    expect(result[0]).toEqual({ id: 'p0', x: 10, y: 30, z: 30, originalIndex: 0 });
-  });
-
-  it('maps coordinates to yz plane when projectionPlane is "yz"', () => {
-    const data: VisualizationData = {
-      protein_ids: ['p0'],
-      projections: [{ name: 't', data: [[10, 20, 30]] }],
-      annotations: {},
-      annotation_data: {},
-    };
-    const result = DataProcessor.processVisualizationData(data, 0, false, undefined, 'yz');
-    expect(result[0]).toEqual({ id: 'p0', x: 20, y: 30, z: 30, originalIndex: 0 });
+    expect(result[0]).toEqual({ id: 'p0', x: 1, y: 2, originalIndex: 0 });
+    expect(result[0]).not.toHaveProperty('z');
   });
 
   it('returns empty array when projection index is out of range', () => {

--- a/packages/utils/src/visualization/data-processor.ts
+++ b/packages/utils/src/visualization/data-processor.ts
@@ -7,7 +7,6 @@ export class DataProcessor {
     projectionIndex: number,
     isolationMode: boolean = false,
     isolationHistory?: string[][],
-    projectionPlane: 'xy' | 'xz' | 'yz' = 'xy',
   ): PlotDataPoint[] {
     if (!data.projections[projectionIndex]) return [];
 
@@ -16,18 +15,7 @@ export class DataProcessor {
         | [number, number]
         | [number, number, number];
 
-      let xVal = coordinates[0];
-      let yVal = coordinates[1];
-      if (coordinates.length === 3) {
-        if (projectionPlane === 'xz') {
-          yVal = coordinates[2];
-        } else if (projectionPlane === 'yz') {
-          xVal = coordinates[1];
-          yVal = coordinates[2];
-        }
-        return { id, x: xVal, y: yVal, z: coordinates[2], originalIndex: index };
-      }
-      return { id, x: xVal, y: yVal, originalIndex: index };
+      return { id, x: coordinates[0], y: coordinates[1], originalIndex: index };
     });
 
     if (isolationMode && isolationHistory && isolationHistory.length > 0) {


### PR DESCRIPTION
Closes #196

Removes the 3D projection "Plane" (XY/XZ/YZ) dropdown and all `projectionPlane` plumbing from the web frontend. 3D Parquet files continue to load, `z` is silently discarded and only `x` / `y` are rendered. The Python `protspace` CLI is unaffected.

Changes:

1. **control-bar:** remove plane selector UI, `handlePlaneChange`, `projection-plane-change` event, the `projectionPlane` property, the cross-element assignment that pushed plane onto the scatter-plot, and `projectionPlane?` from `ScatterplotElementLike`.
2. **scatter-plot:** remove `projectionPlane` property, xz/yz coord remap, `point.z` write, and `projectionPlane` from change-detection gates. `DataProcessor.processVisualizationData` is now called with four args.
3. **data-processor:** remove the `projectionPlane` parameter and the xz/yz branch. `PlotDataPoint` loses its optional `z?` field. Tests updated: xz/yz mapping tests removed, "preserves z" test replaced with "drops the z coordinate for 3D projections."
4. **control-bar helpers:** delete the now-unused `isProjection3D` and `getProjectionPlane` helpers and their tests.
5. **scatter-plot (chore):** drop stale "x/y/z" from the `_updatePlotDataCoordinates` fast-path comment, it now correctly says "x/y" after `PlotDataPoint.z` was removed in commit 3.