### PR TITLE
perf(573K SwissProt): cut peak memory 3.5× and speedup data loading

### DIFF
--- a/app/src/perf/webgl-perf-suite.ts
+++ b/app/src/perf/webgl-perf-suite.ts
@@ -16,6 +16,21 @@ type PerfSuiteGlobalState = typeof globalThis & {
   __protspaceWebglPerfSuiteConsumed?: boolean;
 };
 
+type HeapSample = {
+  usedBytes: number | null;
+  totalBytes: number | null;
+  limitBytes: number | null;
+};
+
+type LoadMetrics = {
+  datasetId: string;
+  loadDurationMs: number;
+  heapBefore: HeapSample;
+  heapAfterLoad: HeapSample;
+  heapSteady: HeapSample;
+  peakUsedDuringLoadBytes: number | null;
+};
+
 const PERF_OVERLAY_ID = 'webgl-perf-suite-overlay';
 const PERF_OVERLAY_STYLE_ID = 'webgl-perf-suite-overlay-style';
 
@@ -34,6 +49,19 @@ async function waitUntil(
     await sleep(intervalMs);
   }
   throw new Error('perf: timeout');
+}
+
+function readHeap(): HeapSample {
+  const mem = (
+    performance as unknown as {
+      memory?: { usedJSHeapSize?: number; totalJSHeapSize?: number; jsHeapSizeLimit?: number };
+    }
+  ).memory;
+  return {
+    usedBytes: typeof mem?.usedJSHeapSize === 'number' ? mem.usedJSHeapSize : null,
+    totalBytes: typeof mem?.totalJSHeapSize === 'number' ? mem.totalJSHeapSize : null,
+    limitBytes: typeof mem?.jsHeapSizeLimit === 'number' ? mem.jsHeapSizeLimit : null,
+  };
 }
 
 async function readDatasetList(): Promise<string[]> {
@@ -60,6 +88,18 @@ async function readDatasetList(): Promise<string[]> {
   } catch {
     return fallback;
   }
+}
+
+async function resolveDatasetList(params: URLSearchParams): Promise<string[]> {
+  const raw = params.get('webglPerfDatasets');
+  if (raw && raw.length > 0) {
+    const ids = raw
+      .split(',')
+      .map((s) => s.trim())
+      .filter((s) => s.length > 0);
+    if (ids.length > 0) return ids;
+  }
+  return readDatasetList();
 }
 
 function downloadJson(filename: string, payload: unknown) {
@@ -156,7 +196,7 @@ function hidePerfOverlay() {
   document.getElementById(PERF_OVERLAY_ID)?.remove();
 }
 
-async function loadDataset(args: Args, datasetId: string, timeoutMs: number): Promise<void> {
+async function loadDataset(args: Args, datasetId: string, timeoutMs: number): Promise<LoadMetrics> {
   const url = `/data/${datasetId}.parquetbundle`;
 
   const dataChange = new Promise<void>((resolve) => {
@@ -184,12 +224,52 @@ async function loadDataset(args: Args, datasetId: string, timeoutMs: number): Pr
     type: 'application/octet-stream',
   });
 
+  // Settle briefly then capture baseline heap
+  await sleep(50);
+  const heapBefore = readHeap();
+
+  // Best-effort polling loop to track peak heap during load
+  let polling = true;
+  let peakUsedDuringLoadBytes: number | null = null;
+
+  const pollLoop = (async () => {
+    while (polling) {
+      const sample = readHeap();
+      if (sample.usedBytes !== null) {
+        if (peakUsedDuringLoadBytes === null || sample.usedBytes > peakUsedDuringLoadBytes) {
+          peakUsedDuringLoadBytes = sample.usedBytes;
+        }
+      }
+      await sleep(50);
+    }
+  })();
+
+  const t0 = performance.now();
   await args.dataLoader.loadFromFile(file);
   await loaderDone;
   await dataChange;
 
   await waitUntil(() => !!args.plotElement.data?.protein_ids?.length, timeoutMs);
   await waitUntil(() => !document.getElementById('progressive-loading'), timeoutMs);
+
+  const loadDurationMs = performance.now() - t0;
+
+  // Stop poller and wait for it to finish
+  polling = false;
+  await pollLoop;
+
+  const heapAfterLoad = readHeap();
+  await sleep(300);
+  const heapSteady = readHeap();
+
+  return {
+    datasetId,
+    loadDurationMs,
+    heapBefore,
+    heapAfterLoad,
+    heapSteady,
+    peakUsedDuringLoadBytes,
+  };
 }
 
 export async function maybeRunWebglPerfSuite(args: Args): Promise<boolean> {
@@ -209,13 +289,13 @@ export async function maybeRunWebglPerfSuite(args: Args): Promise<boolean> {
 
   let success = false;
   try {
-    const datasets = await readDatasetList();
+    const datasets = await resolveDatasetList(params);
     const timeoutMs = 12 * 60_000;
     const createdAt = new Date().toISOString();
     const results: unknown[] = [];
 
     for (const datasetId of datasets) {
-      await loadDataset(args, datasetId, timeoutMs);
+      const loadMetrics = await loadDataset(args, datasetId, timeoutMs);
 
       const result = await args.plotElement.runWebGLRenderPerfMeasurements(iterations, {
         download: false,
@@ -224,7 +304,7 @@ export async function maybeRunWebglPerfSuite(args: Args): Promise<boolean> {
       if (!result) {
         throw new Error(`perf: no result for dataset ${datasetId}`);
       }
-      results.push(result);
+      results.push({ ...(result as Record<string, unknown>), load: loadMetrics });
     }
 
     const suite: PerfSuiteResult = {

--- a/packages/core/src/components/control-bar/search-suggestions.test.ts
+++ b/packages/core/src/components/control-bar/search-suggestions.test.ts
@@ -1,0 +1,164 @@
+import { describe, it, expect } from 'vitest';
+import { computeSearchSuggestions, MAX_SEARCH_SUGGESTIONS } from './search-suggestions';
+
+describe('computeSearchSuggestions', () => {
+  describe('empty query + focused', () => {
+    it('returns unselected IDs capped at default limit', () => {
+      const ids = Array.from({ length: 200 }, (_, i) => `P${String(i).padStart(5, '0')}`);
+      const result = computeSearchSuggestions(ids, [], '', true);
+      expect(result).toHaveLength(MAX_SEARCH_SUGGESTIONS);
+      expect(result).toEqual(ids.slice(0, MAX_SEARCH_SUGGESTIONS));
+    });
+
+    it('returns first limit unselected IDs in order', () => {
+      const ids = ['A1', 'A2', 'A3', 'A4', 'A5'];
+      const result = computeSearchSuggestions(ids, [], '', true, 3);
+      expect(result).toEqual(['A1', 'A2', 'A3']);
+    });
+
+    it('skips selected IDs and fills up to limit from remaining', () => {
+      const ids = ['A1', 'A2', 'A3', 'A4', 'A5'];
+      const result = computeSearchSuggestions(ids, ['A1', 'A3'], '', true, 3);
+      expect(result).toEqual(['A2', 'A4', 'A5']);
+    });
+  });
+
+  describe('empty query + NOT focused', () => {
+    it('returns empty array', () => {
+      const ids = ['P12345', 'P23456', 'P34567'];
+      const result = computeSearchSuggestions(ids, [], '', false);
+      expect(result).toEqual([]);
+    });
+
+    it('returns empty array even when IDs exist', () => {
+      const ids = Array.from({ length: 100 }, (_, i) => `P${i}`);
+      const result = computeSearchSuggestions(ids, [], '', false);
+      expect(result).toEqual([]);
+    });
+  });
+
+  describe('non-empty prefix query', () => {
+    it('returns only IDs starting with the query (case-insensitive), excluding selected, capped', () => {
+      const ids = ['P12345', 'P23456', 'P34567', 'Q12345', 'Q23456'];
+      const result = computeSearchSuggestions(ids, [], 'p', true);
+      expect(result).toEqual(['P12345', 'P23456', 'P34567']);
+    });
+
+    it('caps results at limit when there are many matches', () => {
+      const ids = Array.from({ length: 200 }, (_, i) => `P${String(i).padStart(5, '0')}`);
+      const result = computeSearchSuggestions(ids, [], 'p', true);
+      expect(result).toHaveLength(MAX_SEARCH_SUGGESTIONS);
+    });
+
+    it('returns all matches when fewer than limit', () => {
+      const ids = ['P12345', 'P23456', 'Q99999'];
+      const result = computeSearchSuggestions(ids, [], 'p', true);
+      expect(result).toEqual(['P12345', 'P23456']);
+    });
+  });
+
+  describe('case-insensitivity', () => {
+    it('matches lowercase query against uppercase IDs', () => {
+      const ids = ['P12345', 'P23456', 'Q12345'];
+      const result = computeSearchSuggestions(ids, [], 'p12', true);
+      expect(result).toEqual(['P12345']);
+    });
+
+    it('matches uppercase query against lowercase IDs', () => {
+      const ids = ['p12345', 'p23456', 'q12345'];
+      const result = computeSearchSuggestions(ids, [], 'P12', true);
+      expect(result).toEqual(['p12345']);
+    });
+
+    it('matches mixed case query', () => {
+      const ids = ['P12345', 'P23456'];
+      const result = computeSearchSuggestions(ids, [], 'p12', true);
+      expect(result).toEqual(['P12345']);
+    });
+  });
+
+  describe('excludes already-selected IDs', () => {
+    it('excludes selected IDs provided as an array', () => {
+      const ids = ['P12345', 'P23456', 'P34567'];
+      const result = computeSearchSuggestions(ids, ['P12345', 'P23456'], 'p', true);
+      expect(result).toEqual(['P34567']);
+    });
+
+    it('excludes selected IDs provided as a Set', () => {
+      const ids = ['P12345', 'P23456', 'P34567'];
+      const selected = new Set(['P12345', 'P23456']);
+      const result = computeSearchSuggestions(ids, selected, 'p', true);
+      expect(result).toEqual(['P34567']);
+    });
+
+    it('excludes selected IDs with empty query and focused', () => {
+      const ids = ['A1', 'A2', 'A3'];
+      const result = computeSearchSuggestions(ids, ['A1'], '', true);
+      expect(result).toEqual(['A2', 'A3']);
+    });
+  });
+
+  describe('fewer-than-limit matches', () => {
+    it('returns all matches when total is below limit', () => {
+      const ids = ['P12345', 'Q23456', 'R34567'];
+      const result = computeSearchSuggestions(ids, [], 'p', true);
+      expect(result).toEqual(['P12345']);
+    });
+
+    it('returns all unselected when focused and fewer than limit', () => {
+      const ids = ['A1', 'A2', 'A3'];
+      const result = computeSearchSuggestions(ids, [], '', true);
+      expect(result).toEqual(['A1', 'A2', 'A3']);
+    });
+  });
+
+  describe('custom limit param', () => {
+    it('respects a custom limit of 1', () => {
+      const ids = ['P12345', 'P23456', 'P34567'];
+      const result = computeSearchSuggestions(ids, [], 'p', true, 1);
+      expect(result).toEqual(['P12345']);
+    });
+
+    it('respects a custom limit larger than available matches', () => {
+      const ids = ['P12345', 'P23456'];
+      const result = computeSearchSuggestions(ids, [], 'p', true, 100);
+      expect(result).toEqual(['P12345', 'P23456']);
+    });
+
+    it('respects a custom limit of 10', () => {
+      const ids = Array.from({ length: 50 }, (_, i) => `P${i}`);
+      const result = computeSearchSuggestions(ids, [], 'p', true, 10);
+      expect(result).toHaveLength(10);
+      expect(result).toEqual(ids.slice(0, 10));
+    });
+  });
+
+  describe('large input (early-exit proof)', () => {
+    it('returns exactly limit IDs for 100K-entry array with empty+focused', () => {
+      const ids = Array.from({ length: 100_000 }, (_, i) => `P${String(i).padStart(6, '0')}`);
+      const result = computeSearchSuggestions(ids, [], '', true);
+      expect(result).toHaveLength(MAX_SEARCH_SUGGESTIONS);
+      expect(result).toEqual(ids.slice(0, MAX_SEARCH_SUGGESTIONS));
+    });
+
+    it('returns exactly limit IDs for 100K-entry array with query match', () => {
+      const ids = Array.from({ length: 100_000 }, (_, i) => `P${String(i).padStart(6, '0')}`);
+      const result = computeSearchSuggestions(ids, [], 'p', true);
+      expect(result).toHaveLength(MAX_SEARCH_SUGGESTIONS);
+    });
+  });
+
+  describe('prefix-only (startsWith), NOT substring', () => {
+    it('matches prefix but not infix', () => {
+      const ids = ['ABC', 'XABC'];
+      const result = computeSearchSuggestions(ids, [], 'abc', true);
+      expect(result).toEqual(['ABC']);
+    });
+
+    it('does not match mid-string occurrence', () => {
+      const ids = ['ABC123', 'XYZ123', 'ABC456'];
+      const result = computeSearchSuggestions(ids, [], '123', true);
+      expect(result).toEqual([]);
+    });
+  });
+});

--- a/packages/core/src/components/control-bar/search-suggestions.ts
+++ b/packages/core/src/components/control-bar/search-suggestions.ts
@@ -1,0 +1,31 @@
+/** Hard cap on rendered search suggestions — prevents a 573K-node DOM explosion. */
+export const MAX_SEARCH_SUGGESTIONS = 50;
+
+/**
+ * Compute capped autocomplete suggestions with an early-exit scan.
+ * - Empty query + focused: first `limit` available IDs not already selected.
+ * - Empty query + not focused: none.
+ * - Non-empty query: first `limit` available IDs that (case-insensitively) start with the
+ *   query and are not already selected.
+ * Stops scanning as soon as `limit` matches are found (sub-ms even at 573K).
+ */
+export function computeSearchSuggestions(
+  availableIds: readonly string[],
+  selectedIds: Iterable<string>,
+  query: string,
+  isInputFocused: boolean,
+  limit: number = MAX_SEARCH_SUGGESTIONS,
+): string[] {
+  const q = query.trim().toLowerCase();
+  if (!q && !isInputFocused) return [];
+  const selectedSet = selectedIds instanceof Set ? selectedIds : new Set(selectedIds);
+  const out: string[] = [];
+  for (let i = 0; i < availableIds.length; i++) {
+    if (out.length >= limit) break;
+    const id = availableIds[i];
+    if (selectedSet.has(id)) continue;
+    if (q && !id.toLowerCase().startsWith(q)) continue;
+    out.push(id);
+  }
+  return out;
+}

--- a/packages/core/src/components/control-bar/search.ts
+++ b/packages/core/src/components/control-bar/search.ts
@@ -3,6 +3,9 @@ import { property, state } from 'lit/decorators.js';
 import { customElement } from '../../utils/safe-custom-element';
 import { searchStyles } from './search.styles';
 import { isMacOrIos } from '@protspace/utils';
+import { computeSearchSuggestions } from './search-suggestions';
+
+const SEARCH_DEBOUNCE_MS = 120;
 
 /**
  * Protein search component with autocomplete suggestions and multi-select state (no chips UI)
@@ -18,6 +21,8 @@ class ProtspaceProteinSearch extends LitElement {
   @state() private searchSuggestions: string[] = [];
   @state() private highlightedSuggestionIndex: number = -1;
   @state() private isInputFocused: boolean = false;
+
+  private _suggestionDebounceId: ReturnType<typeof setTimeout> | null = null;
 
   render() {
     return html`
@@ -78,6 +83,7 @@ class ProtspaceProteinSearch extends LitElement {
     window.addEventListener('keydown', this._handleBodyKeydown);
     // Listen for parent-initiated close
     this.addEventListener('close-search', () => {
+      this._clearSuggestionDebounce();
       this.searchSuggestions = [];
       this.highlightedSuggestionIndex = -1;
       this.searchQuery = '';
@@ -93,6 +99,7 @@ class ProtspaceProteinSearch extends LitElement {
   disconnectedCallback(): void {
     super.disconnectedCallback();
     window.removeEventListener('keydown', this._handleBodyKeydown);
+    this._clearSuggestionDebounce();
   }
 
   private _handleBodyKeydown = (event: KeyboardEvent) => {
@@ -122,10 +129,17 @@ class ProtspaceProteinSearch extends LitElement {
   private _onSearchInput(event: Event) {
     const target = event.target as HTMLInputElement;
     this.searchQuery = target.value;
-    this._updateSuggestions();
+    this._clearSuggestionDebounce();
+    this._suggestionDebounceId = setTimeout(() => {
+      this._suggestionDebounceId = null;
+      this._updateSuggestions();
+    }, SEARCH_DEBOUNCE_MS);
   }
 
   private _onSearchKeydown(event: KeyboardEvent) {
+    if (event.key === 'Enter' || event.key === 'ArrowDown' || event.key === 'ArrowUp') {
+      this._flushSuggestions();
+    }
     if (event.key === 'Enter') {
       event.preventDefault();
       if (
@@ -154,6 +168,7 @@ class ProtspaceProteinSearch extends LitElement {
     } else if (event.key === 'Escape') {
       event.preventDefault();
       event.stopPropagation();
+      this._clearSuggestionDebounce();
       this.searchSuggestions = [];
       this.highlightedSuggestionIndex = -1;
       this.searchQuery = '';
@@ -162,6 +177,7 @@ class ProtspaceProteinSearch extends LitElement {
 
   private _onInputFocus() {
     this.isInputFocused = true;
+    this._clearSuggestionDebounce();
     this._updateSuggestions();
     // Notify parent to close other dropdowns
     this.dispatchEvent(
@@ -174,6 +190,7 @@ class ProtspaceProteinSearch extends LitElement {
 
   private _onInputBlur() {
     this.isInputFocused = false;
+    this._clearSuggestionDebounce();
     // Delay clearing suggestions to allow mousedown to fire on suggestions
     setTimeout(() => {
       this.searchSuggestions = [];
@@ -181,28 +198,25 @@ class ProtspaceProteinSearch extends LitElement {
     }, 200);
   }
 
-  private _updateSuggestions() {
-    const q = this.searchQuery.trim().toLowerCase();
-
-    if (!q) {
-      // If no query but input is focused, show all available proteins (not already selected)
-      if (this.isInputFocused) {
-        const selectedSet = new Set(this.selectedProteinIds);
-        this.searchSuggestions = this.availableProteinIds.filter((id) => !selectedSet.has(id));
-        this.highlightedSuggestionIndex = this.searchSuggestions.length > 0 ? 0 : -1;
-      } else {
-        this.searchSuggestions = [];
-        this.highlightedSuggestionIndex = -1;
-      }
-      return;
+  private _clearSuggestionDebounce() {
+    if (this._suggestionDebounceId !== null) {
+      clearTimeout(this._suggestionDebounceId);
+      this._suggestionDebounceId = null;
     }
+  }
 
-    const selectedSet = new Set(this.selectedProteinIds);
+  private _flushSuggestions() {
+    this._clearSuggestionDebounce();
+    this._updateSuggestions();
+  }
 
-    this.searchSuggestions = this.availableProteinIds.filter(
-      (id) => !selectedSet.has(id) && id.toLowerCase().startsWith(q),
+  private _updateSuggestions() {
+    this.searchSuggestions = computeSearchSuggestions(
+      this.availableProteinIds,
+      this.selectedProteinIds,
+      this.searchQuery,
+      this.isInputFocused,
     );
-
     this.highlightedSuggestionIndex = this.searchSuggestions.length > 0 ? 0 : -1;
   }
 
@@ -218,6 +232,7 @@ class ProtspaceProteinSearch extends LitElement {
         validId = exact;
       } else {
         // ID not found in available proteins - ignore
+        this._clearSuggestionDebounce();
         this.searchQuery = '';
         this.searchSuggestions = [];
         this.highlightedSuggestionIndex = -1;
@@ -227,6 +242,7 @@ class ProtspaceProteinSearch extends LitElement {
 
     // Check if already selected
     if (this.selectedProteinIds.includes(validId)) {
+      this._clearSuggestionDebounce();
       this.searchQuery = '';
       this.searchSuggestions = [];
       this.highlightedSuggestionIndex = -1;
@@ -234,6 +250,7 @@ class ProtspaceProteinSearch extends LitElement {
     }
 
     // Clear search state
+    this._clearSuggestionDebounce();
     this.searchQuery = '';
     this.searchSuggestions = [];
     this.highlightedSuggestionIndex = -1;
@@ -281,6 +298,7 @@ class ProtspaceProteinSearch extends LitElement {
       );
     }
 
+    this._clearSuggestionDebounce();
     this.searchQuery = '';
     this.searchSuggestions = [];
     this.highlightedSuggestionIndex = -1;

--- a/packages/core/src/components/data-loader/data-loader.ts
+++ b/packages/core/src/components/data-loader/data-loader.ts
@@ -15,6 +15,11 @@ import {
   assertValidParquetMagic,
   validateRowsBasic,
 } from './utils/validation';
+import {
+  decodeBundleInWorker,
+  isWorkerDecodeSupported,
+  type WorkerDecodeResult,
+} from './decode-worker-client';
 
 /** Whether data was loaded by user action or automatically (e.g. page reload) */
 export type DataLoadSource = 'user' | 'auto';
@@ -195,15 +200,31 @@ export class DataLoader extends LitElement {
 
       // Branch-specific steps
       if (file.name.endsWith('.parquetbundle') || isParquetBundle(arrayBuffer)) {
-        // For bundles: extract -> validate -> convert
-        this.addSteps(3);
-        const extraction = await extractRowsFromParquetBundle(arrayBuffer);
+        // For bundles: decode+convert in worker (or main-thread fallback)
+        this.addSteps(1);
+        let visualizationData: VisualizationData;
+        let settings: BundleSettings | null;
+        if (isWorkerDecodeSupported()) {
+          try {
+            const result: WorkerDecodeResult = await decodeBundleInWorker(arrayBuffer);
+            visualizationData = result.data;
+            settings = result.settings;
+          } catch (workerError) {
+            // Fallback: main-thread decode (worker unsupported / runtime failure).
+            console.warn('Worker decode failed, falling back to main thread:', workerError);
+            const extraction = await extractRowsFromParquetBundle(arrayBuffer);
+            validateRowsBasic(extraction.projections);
+            visualizationData = await convertParquetToVisualizationDataOptimized(extraction);
+            settings = extraction.settings;
+          }
+        } else {
+          const extraction = await extractRowsFromParquetBundle(arrayBuffer);
+          validateRowsBasic(extraction.projections);
+          visualizationData = await convertParquetToVisualizationDataOptimized(extraction);
+          settings = extraction.settings;
+        }
         this.completeStep();
-        validateRowsBasic(extraction.projections);
-        this.completeStep();
-        const visualizationData = await convertParquetToVisualizationDataOptimized(extraction);
-        this.completeStep();
-        this.dispatchDataLoaded(visualizationData, extraction.settings, source, file);
+        this.dispatchDataLoaded(visualizationData, settings, source, file);
       } else {
         // For regular parquet: validate magic -> parse -> validate rows -> convert
         this.addSteps(4);

--- a/packages/core/src/components/data-loader/decode-worker-client.test.ts
+++ b/packages/core/src/components/data-loader/decode-worker-client.test.ts
@@ -1,0 +1,167 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+// Mock the inline worker module — vitest (node env) cannot resolve '?worker&inline'.
+// The mock factory returns a class so `new DecodeWorker()` works as a constructor.
+vi.mock('./decode.worker?worker&inline', () => {
+  class FakeWorker {
+    onmessage: ((e: MessageEvent) => void) | null = null;
+    onerror: ((e: ErrorEvent) => void) | null = null;
+    postMessage(_msg: unknown): void {
+      // default no-op; tests override the instance directly
+    }
+    terminate(): void {
+      // no-op
+    }
+  }
+  return { default: FakeWorker };
+});
+
+import { isWorkerDecodeSupported, decodeBundleInWorker } from './decode-worker-client';
+
+describe('isWorkerDecodeSupported', () => {
+  it('returns false when Worker is undefined in the test environment', () => {
+    // vitest runs in node — no Worker global by default
+    const result = isWorkerDecodeSupported();
+    // We only assert the function returns a boolean; the actual value depends on env
+    expect(typeof result).toBe('boolean');
+  });
+
+  it('returns true when Worker is defined on globalThis', () => {
+    const original = (globalThis as Record<string, unknown>)['Worker'];
+    (globalThis as Record<string, unknown>)['Worker'] = class MockWorker {};
+    expect(isWorkerDecodeSupported()).toBe(true);
+    if (original === undefined) {
+      delete (globalThis as Record<string, unknown>)['Worker'];
+    } else {
+      (globalThis as Record<string, unknown>)['Worker'] = original;
+    }
+  });
+
+  it('returns false when Worker is deleted from globalThis', () => {
+    const original = (globalThis as Record<string, unknown>)['Worker'];
+    delete (globalThis as Record<string, unknown>)['Worker'];
+    expect(isWorkerDecodeSupported()).toBe(false);
+    if (original !== undefined) {
+      (globalThis as Record<string, unknown>)['Worker'] = original;
+    }
+  });
+});
+
+describe('decodeBundleInWorker', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('rejects when DecodeWorker constructor throws', async () => {
+    // Override the mock so the constructor throws
+    const mod = await import('./decode.worker?worker&inline');
+    const OriginalClass = mod.default;
+    vi.spyOn(mod, 'default').mockImplementationOnce(() => {
+      throw new Error('Worker spawn failed');
+    });
+
+    const buf = new ArrayBuffer(8);
+    await expect(decodeBundleInWorker(buf)).rejects.toThrow('Worker spawn failed');
+
+    vi.spyOn(mod, 'default').mockRestore?.();
+    // Restore
+    mod.default = OriginalClass;
+  });
+
+  it('rejects when worker posts ok:false', async () => {
+    const mod = await import('./decode.worker?worker&inline');
+    // Replace the class with one that auto-fires an error response
+    const OrigClass = mod.default;
+    mod.default = class FakeFailWorker {
+      onmessage: ((e: MessageEvent) => void) | null = null;
+      onerror: ((e: ErrorEvent) => void) | null = null;
+      terminate(): void {
+        /* no-op */
+      }
+      postMessage(_msg: unknown): void {
+        const self = this;
+        setTimeout(() => {
+          if (self.onmessage) {
+            self.onmessage(
+              new MessageEvent('message', {
+                data: { type: 'decode-result', ok: false, error: 'decode failed in worker' },
+              }),
+            );
+          }
+        }, 0);
+      }
+    } as unknown as typeof mod.default;
+
+    const buf = new ArrayBuffer(8);
+    await expect(decodeBundleInWorker(buf)).rejects.toThrow('decode failed in worker');
+    mod.default = OrigClass;
+  });
+
+  it('resolves with data and settings when worker posts ok:true', async () => {
+    const fakeData = {
+      protein_ids: ['P12345'],
+      projections: [],
+      annotation_data: {},
+      annotations: {},
+      dimension: 2,
+    };
+
+    const mod = await import('./decode.worker?worker&inline');
+    const OrigClass = mod.default;
+    mod.default = class FakeOkWorker {
+      onmessage: ((e: MessageEvent) => void) | null = null;
+      onerror: ((e: ErrorEvent) => void) | null = null;
+      terminate(): void {
+        /* no-op */
+      }
+      postMessage(_msg: unknown): void {
+        const self = this;
+        setTimeout(() => {
+          if (self.onmessage) {
+            self.onmessage(
+              new MessageEvent('message', {
+                data: { type: 'decode-result', ok: true, data: fakeData, settings: null },
+              }),
+            );
+          }
+        }, 0);
+      }
+    } as unknown as typeof mod.default;
+
+    const buf = new ArrayBuffer(8);
+    const result = await decodeBundleInWorker(buf);
+    expect(result.data).toBe(fakeData);
+    expect(result.settings).toBeNull();
+    mod.default = OrigClass;
+  });
+
+  it('rejects when worker fires onerror', async () => {
+    const mod = await import('./decode.worker?worker&inline');
+    const OrigClass = mod.default;
+    mod.default = class FakeErrWorker {
+      onmessage: ((e: MessageEvent) => void) | null = null;
+      onerror: ((e: ErrorEvent) => void) | null = null;
+      terminate(): void {
+        /* no-op */
+      }
+      postMessage(_msg: unknown): void {
+        const self = this;
+        setTimeout(() => {
+          if (self.onerror) {
+            // Use a plain object shaped like ErrorEvent (node env lacks ErrorEvent constructor)
+            const fakeEvent = { message: 'Script error' } as ErrorEvent;
+            self.onerror(fakeEvent);
+          }
+        }, 0);
+      }
+    } as unknown as typeof mod.default;
+
+    const buf = new ArrayBuffer(8);
+    await expect(decodeBundleInWorker(buf)).rejects.toThrow('decode worker error: Script error');
+    mod.default = OrigClass;
+  });
+});

--- a/packages/core/src/components/data-loader/decode-worker-client.ts
+++ b/packages/core/src/components/data-loader/decode-worker-client.ts
@@ -1,0 +1,55 @@
+import DecodeWorker from './decode.worker?worker&inline';
+import type { VisualizationData, BundleSettings } from '@protspace/utils';
+
+export interface WorkerDecodeResult {
+  data: VisualizationData;
+  settings: BundleSettings | null;
+}
+
+export function isWorkerDecodeSupported(): boolean {
+  return typeof Worker !== 'undefined';
+}
+
+/**
+ * Decode+convert a parquetbundle in a worker. The input `arrayBuffer` is cloned into
+ * the worker via structured-clone (postMessage without transfer list), so the caller's
+ * buffer remains valid for the main-thread fallback if the worker path fails.
+ *
+ * The result Float32/Int32 typed arrays are transferred back zero-copy.
+ * Rejects on worker spawn or runtime error (caller falls back to the main-thread path).
+ *
+ * NOTE: Transfer-in is intentionally omitted here to keep the fallback safe. It can be
+ * added as a future optimisation once the worker path is confirmed stable in production.
+ */
+export function decodeBundleInWorker(arrayBuffer: ArrayBuffer): Promise<WorkerDecodeResult> {
+  return new Promise((resolve, reject) => {
+    let worker: Worker;
+    try {
+      worker = new DecodeWorker();
+    } catch (err) {
+      reject(err instanceof Error ? err : new Error(String(err)));
+      return;
+    }
+    const cleanup = () => worker.terminate();
+    worker.onmessage = (event: MessageEvent) => {
+      const d = event.data as {
+        ok: boolean;
+        data?: VisualizationData;
+        settings?: BundleSettings | null;
+        error?: string;
+      };
+      cleanup();
+      if (d?.ok) {
+        resolve({ data: d.data as VisualizationData, settings: d.settings ?? null });
+      } else {
+        reject(new Error(d?.error || 'worker decode failed'));
+      }
+    };
+    worker.onerror = (event: ErrorEvent) => {
+      cleanup();
+      reject(new Error(`decode worker error: ${event.message || 'unknown'}`));
+    };
+    // Clone-in (no transfer list): keeps arrayBuffer valid for fallback if worker fails.
+    worker.postMessage({ type: 'decode-bundle', arrayBuffer });
+  });
+}

--- a/packages/core/src/components/data-loader/decode.worker.ts
+++ b/packages/core/src/components/data-loader/decode.worker.ts
@@ -1,0 +1,52 @@
+import { extractRowsFromParquetBundle } from './utils/bundle';
+import { convertParquetToVisualizationDataOptimized } from './utils/conversion';
+import { validateRowsBasic } from './utils/validation';
+import type { VisualizationData, BundleSettings } from '@protspace/utils';
+
+interface DecodeRequest {
+  type: 'decode-bundle';
+  arrayBuffer: ArrayBuffer;
+}
+
+const ctx = self as unknown as {
+  onmessage: ((e: MessageEvent<DecodeRequest>) => void) | null;
+  postMessage(message: unknown, transfer: Transferable[]): void;
+};
+
+/**
+ * Collect transferable ArrayBuffers from the result (Float32 coords + Int32 annotation columns)
+ * so they move zero-copy. Everything else (strings, metadata, number[][]) is structured-cloned.
+ */
+function collectTransferables(data: VisualizationData): Transferable[] {
+  const transfer: Transferable[] = [];
+  for (const projection of data.projections) {
+    if (projection.data instanceof Float32Array) transfer.push(projection.data.buffer);
+  }
+  for (const value of Object.values(data.annotation_data)) {
+    if (value instanceof Int32Array) transfer.push(value.buffer);
+  }
+  return transfer;
+}
+
+ctx.onmessage = async (event: MessageEvent<DecodeRequest>) => {
+  const { arrayBuffer } = event.data;
+  try {
+    const extraction = await extractRowsFromParquetBundle(arrayBuffer);
+    validateRowsBasic(extraction.projections);
+    const data = await convertParquetToVisualizationDataOptimized(extraction);
+    const settings: BundleSettings | null = extraction.settings;
+    ctx.postMessage(
+      { type: 'decode-result', ok: true, data, settings },
+      collectTransferables(data),
+    );
+  } catch (error) {
+    ctx.postMessage(
+      {
+        type: 'decode-result',
+        ok: false,
+        error: error instanceof Error ? error.message : String(error),
+      },
+      [],
+    );
+  }
+};

--- a/packages/core/src/components/data-loader/utils/bundle-roundtrip.test.ts
+++ b/packages/core/src/components/data-loader/utils/bundle-roundtrip.test.ts
@@ -125,11 +125,8 @@ describe('round-trip with real data files', () => {
       projections: [
         {
           name: 'UMAP',
-          data: [
-            [0, 0],
-            [1, 1],
-            [2, 2],
-          ] as Array<[number, number]>,
+          data: Float32Array.of(0, 0, 1, 1, 2, 2),
+          dimension: 2 as const,
         },
       ],
       annotations: {
@@ -179,10 +176,8 @@ describe('round-trip with real data files', () => {
       projections: [
         {
           name: 'UMAP',
-          data: [
-            [0, 0],
-            [1, 1],
-          ] as Array<[number, number]>,
+          data: Float32Array.of(0, 0, 1, 1),
+          dimension: 2 as const,
         },
       ],
       annotations: {
@@ -346,11 +341,8 @@ describe('numeric annotation round-trip', () => {
       projections: [
         {
           name: 'UMAP',
-          data: [
-            [0, 0],
-            [1, 1],
-            [2, 2],
-          ] as Array<[number, number]>,
+          data: Float32Array.of(0, 0, 1, 1, 2, 2),
+          dimension: 2 as const,
         },
       ],
       annotations: {

--- a/packages/core/src/components/data-loader/utils/bundle.ts
+++ b/packages/core/src/components/data-loader/utils/bundle.ts
@@ -49,12 +49,12 @@ export async function extractRowsFromParquetBundle(
   const hasSettingsPart = delimiterPositions.length === 3;
 
   // Extract the three required parts
-  const part1 = uint8Array.subarray(0, delimiterPositions[0]).slice().buffer;
-  const part2 = uint8Array
+  let part1: ArrayBuffer | null = uint8Array.subarray(0, delimiterPositions[0]).slice().buffer;
+  let part2: ArrayBuffer | null = uint8Array
     .subarray(delimiterPositions[0] + BUNDLE_DELIMITER_BYTES.length, delimiterPositions[1])
     .slice().buffer;
 
-  let part3: ArrayBuffer;
+  let part3: ArrayBuffer | null;
   let part4: ArrayBuffer | null = null;
 
   if (hasSettingsPart) {
@@ -75,12 +75,17 @@ export async function extractRowsFromParquetBundle(
   assertValidParquetMagic(part2);
   assertValidParquetMagic(part3);
 
-  // Parse the three required parts
-  const [selectedAnnotationsData, projectionsMetadataData, projectionsData] = await Promise.all([
-    parquetReadObjects({ file: part1 }),
-    parquetReadObjects({ file: part2 }),
-    parquetReadObjects({ file: part3 }),
-  ]);
+  // Decode sequentially and release each sliced buffer immediately after its decode completes.
+  // hyparquet is CPU-bound on the single JS thread — Promise.all gives no real parallelism, only
+  // interleaved async continuations that keep all three buffers + decode scratch live simultaneously.
+  // Sequential decode ensures only one part's buffer is live at a time, cutting the transient
+  // load-peak (critical for large datasets such as SwissProt 573 K where peak heap reached ~2.3 GB).
+  const selectedAnnotationsData = await parquetReadObjects({ file: part1 });
+  part1 = null;
+  const projectionsMetadataData = await parquetReadObjects({ file: part2 });
+  part2 = null;
+  const projectionsData = await parquetReadObjects({ file: part3! });
+  part3 = null;
 
   // Parse settings if present
   let settings: BundleSettings | null = null;

--- a/packages/core/src/components/data-loader/utils/conversion-numeric.test.ts
+++ b/packages/core/src/components/data-loader/utils/conversion-numeric.test.ts
@@ -638,6 +638,45 @@ describe('annotation_data storage shape', () => {
     expect(evidence).toBeDefined();
     expect(evidence![p1]).toEqual([null, 'ECO:0000269', null]);
   });
+
+  it('memoizes repeated cells without cross-contaminating per-protein output', async () => {
+    // Many proteins share the SAME multi-valued scored+evidence cell (cache hits),
+    // interleaved with a distinct plain cell — guards the parse memoization.
+    const shared = 'Active|1.5e-10;Bind|ECO:0000269';
+    const rows = Array.from({ length: 10000 }, (_, i) => ({
+      projection_name: 'UMAP',
+      identifier: `P${i + 1}`,
+      x: i,
+      y: i,
+      site: i % 4 === 0 ? 'Solo' : shared,
+    }));
+
+    const result = await convertParquetToVisualizationDataOptimized(rows, [
+      { projection_name: 'UMAP', dimensions: 2 },
+    ]);
+
+    const siteData = result.annotation_data.site as readonly (readonly number[])[];
+    const values = result.annotations.site.values;
+    const scores = result.annotation_scores?.site;
+    const evidence = result.annotation_evidence?.site;
+    expect(scores).toBeDefined();
+    expect(evidence).toBeDefined();
+
+    // Every shared-cell protein resolves to ['Active','Bind'] with the right score/evidence,
+    // and the distinct 'Solo' proteins are unaffected (no cross-contamination).
+    const pShared = result.protein_ids.indexOf('P2'); // i=1 -> shared
+    const pSolo = result.protein_ids.indexOf('P1'); // i=0 -> 'Solo'
+    expect(siteData[pShared].map((ix) => values[ix])).toEqual(['Active', 'Bind']);
+    expect(scores![pShared]).toEqual([[1.5e-10], null]);
+    expect(evidence![pShared]).toEqual([null, 'ECO:0000269']);
+    expect(siteData[pSolo].map((ix) => values[ix])).toEqual(['Solo']);
+    expect(scores![pSolo]).toEqual([null]);
+    expect(evidence![pSolo]).toEqual([null]);
+
+    // Frequency-based ordering is unaffected by memoization: 'Active' and 'Bind'
+    // each occur 7500 times (3/4 of 10000), 'Solo' 2500 — so Solo sorts last.
+    expect(values.indexOf('Solo')).toBeGreaterThan(values.indexOf('Active'));
+  });
 });
 
 import { generateColorsAndShapes } from './conversion';

--- a/packages/core/src/components/data-loader/utils/conversion-numeric.test.ts
+++ b/packages/core/src/components/data-loader/utils/conversion-numeric.test.ts
@@ -602,6 +602,42 @@ describe('annotation_data storage shape', () => {
     expect(pfamData[p2Idx]).toHaveLength(1);
     expect(values[pfamData[p2Idx][0]]).toBe('PF03');
   });
+
+  it('round-trips heterogeneous per-value scores and evidence through the optimized path', async () => {
+    // Each protein's cell mixes a scored value, an evidence-coded value, and a
+    // plain value — exercises the single-parse cache reconstruction in Pass 2.
+    const rows = Array.from({ length: 10000 }, (_, i) => ({
+      projection_name: 'UMAP',
+      identifier: `P${i + 1}`,
+      x: i,
+      y: i,
+      // value 0: scored, value 1: evidence code, value 2: plain
+      site: 'Active|1.5e-10;Bind|ECO:0000269;Other',
+    }));
+
+    const result = await convertParquetToVisualizationDataOptimized(rows, [
+      { projection_name: 'UMAP', dimensions: 2 },
+    ]);
+
+    expect(Array.isArray(result.annotation_data.site)).toBe(true);
+    const siteData = result.annotation_data.site as readonly (readonly number[])[];
+    const values = result.annotations.site.values;
+
+    const p1 = result.protein_ids.indexOf('P1');
+    // Three labels resolved
+    expect(siteData[p1]).toHaveLength(3);
+    expect(siteData[p1].map((i) => values[i])).toEqual(['Active', 'Bind', 'Other']);
+
+    // Scores: value 0 has [1.5e-10], values 1 and 2 are null
+    const scores = result.annotation_scores?.site;
+    expect(scores).toBeDefined();
+    expect(scores![p1]).toEqual([[1.5e-10], null, null]);
+
+    // Evidence: value 1 has 'ECO:0000269', values 0 and 2 are null
+    const evidence = result.annotation_evidence?.site;
+    expect(evidence).toBeDefined();
+    expect(evidence![p1]).toEqual([null, 'ECO:0000269', null]);
+  });
 });
 
 import { generateColorsAndShapes } from './conversion';

--- a/packages/core/src/components/data-loader/utils/conversion.ts
+++ b/packages/core/src/components/data-loader/utils/conversion.ts
@@ -437,19 +437,36 @@ function convertBundleFormatData(
   const projections = [] as VisualizationData['projections'];
   for (const [projectionName, projectionRows] of projectionGroups.entries()) {
     const coordMap = buildCoordinateMap(projectionRows, proteinIdCol);
-    const projectionData = uniqueProteinIds.map((proteinId) => coordMap.get(proteinId) || [0, 0]);
-    const has3D = projectionData.some((p) => p.length === 3);
+    let has3D = false;
+    for (const v of coordMap.values()) {
+      if (v.length === 3) {
+        has3D = true;
+        break;
+      }
+    }
+    const dimension: 2 | 3 = has3D ? 3 : 2;
+    const data = new Float32Array(uniqueProteinIds.length * dimension);
+    for (let i = 0; i < uniqueProteinIds.length; i++) {
+      const c = coordMap.get(uniqueProteinIds[i]);
+      const base = i * dimension;
+      if (c) {
+        data[base] = c[0];
+        data[base + 1] = c[1];
+        if (dimension === 3) data[base + 2] = c.length === 3 ? c[2] : 0;
+      }
+    }
 
     // Merge dimension with existing metadata from projectionsMetadata
     const existingMetadata = metadataMap.get(projectionName) || {};
     const metadata = {
       ...existingMetadata,
-      dimension: (has3D ? 3 : 2) as 2 | 3,
+      dimension,
     };
 
     projections.push({
       name: formatProjectionName(projectionName),
-      data: projectionData as Array<[number, number] | [number, number, number]>,
+      data,
+      dimension,
       metadata,
     });
   }
@@ -601,24 +618,36 @@ async function convertBundleFormatDataOptimized(
   const projections = [] as VisualizationData['projections'];
   for (const [projectionName, projectionRows] of projectionGroups.entries()) {
     const coordMap = buildCoordinateMap(projectionRows, proteinIdCol);
-    const projectionData: Array<[number, number] | [number, number, number]> = new Array(
-      uniqueProteinIds.length,
-    );
-    for (let i = 0; i < uniqueProteinIds.length; i++) {
-      projectionData[i] = coordMap.get(uniqueProteinIds[i]) || [0, 0];
+    let has3D = false;
+    for (const v of coordMap.values()) {
+      if (v.length === 3) {
+        has3D = true;
+        break;
+      }
     }
-    const has3D = projectionData.some((p) => p.length === 3);
+    const dimension: 2 | 3 = has3D ? 3 : 2;
+    const data = new Float32Array(uniqueProteinIds.length * dimension);
+    for (let i = 0; i < uniqueProteinIds.length; i++) {
+      const c = coordMap.get(uniqueProteinIds[i]);
+      const base = i * dimension;
+      if (c) {
+        data[base] = c[0];
+        data[base + 1] = c[1];
+        if (dimension === 3) data[base + 2] = c.length === 3 ? c[2] : 0;
+      }
+    }
 
     // Merge dimension with existing metadata from projectionsMetadata
     const existingMetadata = metadataMap.get(projectionName) || {};
     const metadata = {
       ...existingMetadata,
-      dimension: (has3D ? 3 : 2) as 2 | 3,
+      dimension,
     };
 
     projections.push({
       name: formatProjectionName(projectionName),
-      data: projectionData,
+      data,
+      dimension,
       metadata,
     });
     // yield
@@ -693,21 +722,33 @@ async function convertBundleFormatDataOptimizedSeparated(
   const projections = [] as VisualizationData['projections'];
   for (const [projectionName, projRows] of projectionGroups.entries()) {
     const coordMap = buildCoordinateMap(projRows, projectionIdCol);
-    const projectionData: Array<[number, number] | [number, number, number]> = new Array(
-      uniqueProteinIds.length,
-    );
-    for (let i = 0; i < uniqueProteinIds.length; i++) {
-      projectionData[i] = coordMap.get(uniqueProteinIds[i]) || [0, 0];
+    let has3D = false;
+    for (const v of coordMap.values()) {
+      if (v.length === 3) {
+        has3D = true;
+        break;
+      }
     }
-    const has3D = projectionData.some((p) => p.length === 3);
+    const dimension: 2 | 3 = has3D ? 3 : 2;
+    const data = new Float32Array(uniqueProteinIds.length * dimension);
+    for (let i = 0; i < uniqueProteinIds.length; i++) {
+      const c = coordMap.get(uniqueProteinIds[i]);
+      const base = i * dimension;
+      if (c) {
+        data[base] = c[0];
+        data[base + 1] = c[1];
+        if (dimension === 3) data[base + 2] = c.length === 3 ? c[2] : 0;
+      }
+    }
     const existingMetadata = metadataMap.get(projectionName) || {};
     const metadata = {
       ...existingMetadata,
-      dimension: (has3D ? 3 : 2) as 2 | 3,
+      dimension,
     };
     projections.push({
       name: formatProjectionName(projectionName),
-      data: projectionData,
+      data,
+      dimension,
       metadata,
     });
     await fastYield();
@@ -761,17 +802,22 @@ function convertLegacyFormatData(rows: Rows, columnNames: string[]): Visualizati
   const protein_ids = rows.map((row) => (row[proteinIdCol] ? String(row[proteinIdCol]) : ''));
 
   const projections = projectionPairs.map((pair) => {
-    const projectionData: [number, number][] = rows.map((row, idx) => {
+    const dimension: 2 | 3 = 2;
+    const data = new Float32Array(rows.length * dimension);
+    for (let i = 0; i < rows.length; i++) {
+      const row = rows[i];
       const x = Number(row[pair.xCol]);
       const y = Number(row[pair.yCol]);
       if (Number.isNaN(x) || Number.isNaN(y)) {
-        console.warn(`Invalid coordinates at row ${idx} for projection ${pair.name}`, { x, y });
+        console.warn(`Invalid coordinates at row ${i} for projection ${pair.name}`, { x, y });
       }
-      return [x, y];
-    });
+      data[i * dimension] = x;
+      data[i * dimension + 1] = y;
+    }
     return {
       name: pair.name,
-      data: projectionData,
+      data,
+      dimension,
     } as VisualizationData['projections'][number];
   });
 

--- a/packages/core/src/components/data-loader/utils/conversion.ts
+++ b/packages/core/src/components/data-loader/utils/conversion.ts
@@ -1078,25 +1078,54 @@ async function extractAnnotationsByProtein(
       continue;
     }
 
-    // === Pass 1: Collect unique values, frequency counts, detect scores/evidence ===
+    // === Pass 1: split + parse every cell EXACTLY ONCE. Collect unique-value
+    //     frequencies, detect scores/evidence, track the max arity, and CACHE
+    //     the parse output per protein so Pass 2 is a pure index-mapping pass.
+    //     Previously Pass 2 re-split + re-parsed every cell — ~2x the parse work
+    //     across ~22 columns at 573K. Caching halves it; output is byte-identical.
+    //     The caches are block-scoped and reclaimed between columns.
     const valueCountMap = new Map<string, number>();
     let columnHasScores = false;
     let columnHasEvidence = false;
     let maxValuesPerProtein = 0;
 
+    // `labelsByProtein[p] === undefined` ⇒ protein had no values for this column.
+    // scores/evidence caches stay sparse: a protein's slot is only set when at
+    // least one of its values carried a score / evidence code. When set, the
+    // cached array length equals labelsByProtein[p].length.
+    const labelsByProtein = new Array<string[] | undefined>(numProteins);
+    const scoresByProtein = new Array<(number[] | null)[] | undefined>(numProteins);
+    const evidenceByProtein = new Array<(string | null)[] | undefined>(numProteins);
+
     for (let i = 0; i < numProteins; i += chunkSize) {
       const end = Math.min(i + chunkSize, numProteins);
       for (let p = i; p < end; p++) {
         const rawValues = splitCategoricalAnnotationValues(rowByProteinIdx[p]?.[annotationCol]);
-        if (rawValues.length > maxValuesPerProtein) {
-          maxValuesPerProtein = rawValues.length;
-        }
-        for (const raw of rawValues) {
-          const parsed = parseAnnotationValue(raw);
+        const n = rawValues.length;
+        if (n > maxValuesPerProtein) maxValuesPerProtein = n;
+        if (n === 0) continue;
+
+        const labels = new Array<string>(n);
+        let scores: (number[] | null)[] | null = null;
+        let evidences: (string | null)[] | null = null;
+        for (let k = 0; k < n; k++) {
+          const parsed = parseAnnotationValue(rawValues[k]);
+          labels[k] = parsed.label;
           valueCountMap.set(parsed.label, (valueCountMap.get(parsed.label) || 0) + 1);
-          if (parsed.scores.length > 0) columnHasScores = true;
-          if (parsed.evidence) columnHasEvidence = true;
+          if (parsed.scores.length > 0) {
+            columnHasScores = true;
+            if (!scores) scores = new Array<number[] | null>(n).fill(null);
+            scores[k] = parsed.scores;
+          }
+          if (parsed.evidence) {
+            columnHasEvidence = true;
+            if (!evidences) evidences = new Array<string | null>(n).fill(null);
+            evidences[k] = parsed.evidence;
+          }
         }
+        labelsByProtein[p] = labels;
+        if (scores) scoresByProtein[p] = scores;
+        if (evidences) evidenceByProtein[p] = evidences;
       }
       await fastYield();
     }
@@ -1111,8 +1140,8 @@ async function extractAnnotationsByProtein(
 
     const { colors, shapes } = generateColorsAndShapes('kellys', uniqueValues.length);
 
-    // === Pass 2: Build output arrays. Use Int32Array for strict single-valued
-    //     columns to avoid the per-protein number[] allocation cliff. ===
+    // === Pass 2: map cached labels → dictionary indices. Use Int32Array for
+    //     strict single-valued columns to avoid the per-protein number[] cliff. ===
     const useTypedStorage = maxValuesPerProtein <= 1 && !columnHasScores && !columnHasEvidence;
 
     const annotationDataTyped = useTypedStorage ? new Int32Array(numProteins).fill(-1) : null;
@@ -1123,28 +1152,26 @@ async function extractAnnotationsByProtein(
     for (let i = 0; i < numProteins; i += chunkSize) {
       const end = Math.min(i + chunkSize, numProteins);
       for (let p = i; p < end; p++) {
-        const rawValues = splitCategoricalAnnotationValues(rowByProteinIdx[p]?.[annotationCol]);
-        if (rawValues.length === 0) continue;
+        const labels = labelsByProtein[p];
+        if (labels === undefined) continue;
 
         if (annotationDataTyped) {
           // Single-valued: write the one index directly into the typed array.
-          const parsed = parseAnnotationValue(rawValues[0]);
-          annotationDataTyped[p] = valueToIndex.get(parsed.label) ?? -1;
+          annotationDataTyped[p] = valueToIndex.get(labels[0]) ?? -1;
         } else {
-          const indices: number[] = [];
-          const scores: (number[] | null)[] | null = scoresArray ? [] : null;
-          const evidences: (string | null)[] | null = evidenceArray ? [] : null;
-
-          for (const raw of rawValues) {
-            const parsed = parseAnnotationValue(raw);
-            indices.push(valueToIndex.get(parsed.label) ?? -1);
-            if (scores) scores.push(parsed.scores.length > 0 ? parsed.scores : null);
-            if (evidences) evidences.push(parsed.evidence);
+          const indices = new Array<number>(labels.length);
+          for (let k = 0; k < labels.length; k++) {
+            indices[k] = valueToIndex.get(labels[k]) ?? -1;
           }
-
           annotationDataArray![p] = indices;
-          if (scoresArray && scores) scoresArray[p] = scores;
-          if (evidenceArray && evidences) evidenceArray[p] = evidences;
+          if (scoresArray) {
+            scoresArray[p] =
+              scoresByProtein[p] ?? new Array<number[] | null>(labels.length).fill(null);
+          }
+          if (evidenceArray) {
+            evidenceArray[p] =
+              evidenceByProtein[p] ?? new Array<string | null>(labels.length).fill(null);
+          }
         }
       }
       await fastYield();

--- a/packages/core/src/components/data-loader/utils/conversion.ts
+++ b/packages/core/src/components/data-loader/utils/conversion.ts
@@ -1078,54 +1078,82 @@ async function extractAnnotationsByProtein(
       continue;
     }
 
-    // === Pass 1: split + parse every cell EXACTLY ONCE. Collect unique-value
-    //     frequencies, detect scores/evidence, track the max arity, and CACHE
-    //     the parse output per protein so Pass 2 is a pure index-mapping pass.
-    //     Previously Pass 2 re-split + re-parsed every cell — ~2x the parse work
-    //     across ~22 columns at 573K. Caching halves it; output is byte-identical.
-    //     The caches are block-scoped and reclaimed between columns.
+    // === Pass 1: split + parse each DISTINCT cell value ONCE (memoized), then
+    //     reuse the parse across every protein that shares it. The annotation
+    //     columns are dictionary-encoded, so distinct cell values << protein
+    //     count for most columns (e.g. kingdom: 22 distinct over 573K rows) —
+    //     this turns the parse cost from O(proteins) into O(distinct cells).
+    //     Output is byte-identical: frequency counting, arity, and score/evidence
+    //     detection all stay PER-PROTEIN-OCCURRENCE below; only the split+parse
+    //     is shared. Caches are block-scoped and reclaimed between columns.
+    interface ParsedCell {
+      // null ⇒ empty cell (no values). Otherwise the parsed labels in cell order.
+      labels: string[] | null;
+      // Sparse: non-null only when at least one value carried a score / evidence
+      // code. When set, length === labels.length. SHARED by reference across
+      // proteins with identical cells — safe because the result is read-only and
+      // is deep-copied by structured-clone on worker transfer.
+      scores: (number[] | null)[] | null;
+      evidence: (string | null)[] | null;
+    }
+    const EMPTY_CELL: ParsedCell = { labels: null, scores: null, evidence: null };
+
     const valueCountMap = new Map<string, number>();
     let columnHasScores = false;
     let columnHasEvidence = false;
     let maxValuesPerProtein = 0;
 
-    // `labelsByProtein[p] === undefined` ⇒ protein had no values for this column.
-    // scores/evidence caches stay sparse: a protein's slot is only set when at
-    // least one of its values carried a score / evidence code. When set, the
-    // cached array length equals labelsByProtein[p].length.
-    const labelsByProtein = new Array<string[] | undefined>(numProteins);
-    const scoresByProtein = new Array<(number[] | null)[] | undefined>(numProteins);
-    const evidenceByProtein = new Array<(string | null)[] | undefined>(numProteins);
+    // Memoize split+parse keyed by the raw cell value (deterministic). parquet
+    // decodes these columns as strings, so the key is the cell string itself;
+    // distinct raw values are always parsed independently (never collapsed).
+    const parseCache = new Map<unknown, ParsedCell>();
+    const parseCell = (raw: unknown): ParsedCell => {
+      const cached = parseCache.get(raw);
+      if (cached !== undefined) return cached;
+      const rawValues = splitCategoricalAnnotationValues(raw);
+      const n = rawValues.length;
+      if (n === 0) {
+        parseCache.set(raw, EMPTY_CELL);
+        return EMPTY_CELL;
+      }
+      const labels = new Array<string>(n);
+      let scores: (number[] | null)[] | null = null;
+      let evidence: (string | null)[] | null = null;
+      for (let k = 0; k < n; k++) {
+        const parsed = parseAnnotationValue(rawValues[k]);
+        labels[k] = parsed.label;
+        if (parsed.scores.length > 0) {
+          if (!scores) scores = new Array<number[] | null>(n).fill(null);
+          scores[k] = parsed.scores;
+        }
+        if (parsed.evidence) {
+          if (!evidence) evidence = new Array<string | null>(n).fill(null);
+          evidence[k] = parsed.evidence;
+        }
+      }
+      const cell: ParsedCell = { labels, scores, evidence };
+      parseCache.set(raw, cell);
+      return cell;
+    };
+
+    // Per-protein parse (cache hit for repeated cells). Counting + flags + arity
+    // are accumulated PER PROTEIN so they match the non-memoized version exactly.
+    const parsedByProtein = new Array<ParsedCell>(numProteins);
 
     for (let i = 0; i < numProteins; i += chunkSize) {
       const end = Math.min(i + chunkSize, numProteins);
       for (let p = i; p < end; p++) {
-        const rawValues = splitCategoricalAnnotationValues(rowByProteinIdx[p]?.[annotationCol]);
-        const n = rawValues.length;
+        const cell = parseCell(rowByProteinIdx[p]?.[annotationCol]);
+        parsedByProtein[p] = cell;
+        const labels = cell.labels;
+        if (labels === null) continue;
+        const n = labels.length;
         if (n > maxValuesPerProtein) maxValuesPerProtein = n;
-        if (n === 0) continue;
-
-        const labels = new Array<string>(n);
-        let scores: (number[] | null)[] | null = null;
-        let evidences: (string | null)[] | null = null;
         for (let k = 0; k < n; k++) {
-          const parsed = parseAnnotationValue(rawValues[k]);
-          labels[k] = parsed.label;
-          valueCountMap.set(parsed.label, (valueCountMap.get(parsed.label) || 0) + 1);
-          if (parsed.scores.length > 0) {
-            columnHasScores = true;
-            if (!scores) scores = new Array<number[] | null>(n).fill(null);
-            scores[k] = parsed.scores;
-          }
-          if (parsed.evidence) {
-            columnHasEvidence = true;
-            if (!evidences) evidences = new Array<string | null>(n).fill(null);
-            evidences[k] = parsed.evidence;
-          }
+          valueCountMap.set(labels[k], (valueCountMap.get(labels[k]) || 0) + 1);
         }
-        labelsByProtein[p] = labels;
-        if (scores) scoresByProtein[p] = scores;
-        if (evidences) evidenceByProtein[p] = evidences;
+        if (cell.scores) columnHasScores = true;
+        if (cell.evidence) columnHasEvidence = true;
       }
       await fastYield();
     }
@@ -1152,25 +1180,25 @@ async function extractAnnotationsByProtein(
     for (let i = 0; i < numProteins; i += chunkSize) {
       const end = Math.min(i + chunkSize, numProteins);
       for (let p = i; p < end; p++) {
-        const labels = labelsByProtein[p];
-        if (labels === undefined) continue;
+        const cell = parsedByProtein[p];
+        const labels = cell.labels;
+        if (labels === null) continue;
 
         if (annotationDataTyped) {
           // Single-valued: write the one index directly into the typed array.
           annotationDataTyped[p] = valueToIndex.get(labels[0]) ?? -1;
         } else {
+          // Fresh index array per protein (NOT shared) to match prior behavior.
           const indices = new Array<number>(labels.length);
           for (let k = 0; k < labels.length; k++) {
             indices[k] = valueToIndex.get(labels[k]) ?? -1;
           }
           annotationDataArray![p] = indices;
           if (scoresArray) {
-            scoresArray[p] =
-              scoresByProtein[p] ?? new Array<number[] | null>(labels.length).fill(null);
+            scoresArray[p] = cell.scores ?? new Array<number[] | null>(labels.length).fill(null);
           }
           if (evidenceArray) {
-            evidenceArray[p] =
-              evidenceByProtein[p] ?? new Array<string | null>(labels.length).fill(null);
+            evidenceArray[p] = cell.evidence ?? new Array<string | null>(labels.length).fill(null);
           }
         }
       }

--- a/packages/core/src/components/legend/annotation-values.test.ts
+++ b/packages/core/src/components/legend/annotation-values.test.ts
@@ -1,0 +1,139 @@
+import { describe, it, expect } from 'vitest';
+import { buildAnnotationValueList } from './annotation-values';
+import { NA_VALUE } from './config';
+
+// ─── Int32Array (single-valued) fixtures ────────────────────────────────────
+
+/**
+ * Build an Int32Array where each element is the annotation index for that protein.
+ * -1 means "no annotation".
+ */
+function makeSingleValued(indices: number[]): Int32Array {
+  return new Int32Array(indices);
+}
+
+// ─── Multi-valued fixtures ───────────────────────────────────────────────────
+
+/**
+ * Build a multi-valued AnnotationData (readonly (readonly number[])[]) directly.
+ */
+function makeMultiValued(indexLists: number[][]): readonly (readonly number[])[] {
+  return indexLists.map((list) => list as readonly number[]);
+}
+
+// ─── Tests ───────────────────────────────────────────────────────────────────
+
+describe('buildAnnotationValueList', () => {
+  describe('empty (proteinCount 0)', () => {
+    it('returns [] for single-valued storage', () => {
+      const colData = makeSingleValued([]);
+      expect(buildAnnotationValueList(colData, [], 0)).toEqual([]);
+    });
+
+    it('returns [] for multi-valued storage', () => {
+      const colData = makeMultiValued([]);
+      expect(buildAnnotationValueList(colData, [], 0)).toEqual([]);
+    });
+  });
+
+  describe('single-valued (Int32Array) — all proteins annotated', () => {
+    it('produces one value per protein in order', () => {
+      const values = ['alpha', 'beta', 'gamma'];
+      // protein 0 → values[2], protein 1 → values[0], protein 2 → values[1]
+      const colData = makeSingleValued([2, 0, 1]);
+      const result = buildAnnotationValueList(colData, values, 3);
+      expect(result).toEqual(['gamma', 'alpha', 'beta']);
+    });
+
+    it('length equals proteinCount when all are annotated', () => {
+      const values = ['a', 'b'];
+      const colData = makeSingleValued([0, 1, 0, 1]);
+      const result = buildAnnotationValueList(colData, values, 4);
+      expect(result).toHaveLength(4);
+    });
+  });
+
+  describe('single-valued (Int32Array) — some proteins missing (compacted)', () => {
+    it('omits proteins with idx < 0', () => {
+      const values = ['cat', 'dog'];
+      // protein 0 → values[0], protein 1 → missing (-1), protein 2 → values[1]
+      const colData = makeSingleValued([0, -1, 1]);
+      const result = buildAnnotationValueList(colData, values, 3);
+      expect(result).toEqual(['cat', 'dog']);
+    });
+
+    it('length is less than proteinCount when some are missing', () => {
+      const values = ['x'];
+      const colData = makeSingleValued([-1, -1, 0, -1]);
+      const result = buildAnnotationValueList(colData, values, 4);
+      expect(result).toHaveLength(1);
+      expect(result).toEqual(['x']);
+    });
+
+    it('preserves order of annotated proteins', () => {
+      const values = ['first', 'second', 'third'];
+      // proteins 0,2,4 are annotated; 1,3 are missing
+      const colData = makeSingleValued([2, -1, 0, -1, 1]);
+      const result = buildAnnotationValueList(colData, values, 5);
+      expect(result).toEqual(['third', 'first', 'second']);
+    });
+
+    it('returns [] when all proteins have idx < 0', () => {
+      const values = ['a', 'b'];
+      const colData = makeSingleValued([-1, -1, -1]);
+      const result = buildAnnotationValueList(colData, values, 3);
+      expect(result).toEqual([]);
+    });
+  });
+
+  describe('multi-valued — expanded', () => {
+    it('a protein with 2 labels contributes 2 entries', () => {
+      const values = ['labelA', 'labelB', 'labelC'];
+      // protein 0 → [0, 1], protein 1 → [2]
+      const colData = makeMultiValued([[0, 1], [2]]);
+      const result = buildAnnotationValueList(colData, values, 2);
+      expect(result).toEqual(['labelA', 'labelB', 'labelC']);
+    });
+
+    it('total length equals sum of label counts', () => {
+      const values = ['v0', 'v1', 'v2', 'v3'];
+      // protein 0 → 3 labels, protein 1 → 0 labels, protein 2 → 1 label
+      const colData = makeMultiValued([[0, 1, 2], [], [3]]);
+      const result = buildAnnotationValueList(colData, values, 3);
+      expect(result).toHaveLength(4);
+      expect(result).toEqual(['v0', 'v1', 'v2', 'v3']);
+    });
+
+    it('proteins with empty index lists contribute 0 entries', () => {
+      const values = ['only'];
+      const colData = makeMultiValued([[], [], [0]]);
+      const result = buildAnnotationValueList(colData, values, 3);
+      expect(result).toEqual(['only']);
+    });
+  });
+
+  describe('toInternalValue applied (null → NA_VALUE)', () => {
+    it('maps null values to NA_VALUE in single-valued storage', () => {
+      // values[0] is null → should become NA_VALUE
+      const values: (string | null)[] = [null, 'real'];
+      const colData = makeSingleValued([0, 1]);
+      const result = buildAnnotationValueList(colData, values, 2);
+      expect(result[0]).toBe(NA_VALUE);
+      expect(result[1]).toBe('real');
+    });
+
+    it('maps null values to NA_VALUE in multi-valued storage', () => {
+      const values: (string | null)[] = [null, 'present'];
+      const colData = makeMultiValued([[0, 1]]);
+      const result = buildAnnotationValueList(colData, values, 1);
+      expect(result).toEqual([NA_VALUE, 'present']);
+    });
+
+    it('non-null string values pass through unchanged', () => {
+      const values: (string | null)[] = ['hello', 'world'];
+      const colData = makeSingleValued([0, 1]);
+      const result = buildAnnotationValueList(colData, values, 2);
+      expect(result).toEqual(['hello', 'world']);
+    });
+  });
+});

--- a/packages/core/src/components/legend/annotation-values.ts
+++ b/packages/core/src/components/legend/annotation-values.ts
@@ -1,0 +1,34 @@
+import type { AnnotationData } from '@protspace/utils';
+import { getFirstAnnotationIndex, getProteinAnnotationIndices } from '@protspace/utils';
+import { toInternalValue } from './config';
+
+/**
+ * Build the flat list of internal annotation values used by the legend frequency count.
+ *
+ * Replaces a `protein_ids.flatMap(...)` that allocated a throwaway `[]`/`[value]` array per
+ * protein. Output is IDENTICAL to that flatMap:
+ *  - Single-valued (Int32Array): one entry per protein that HAS an annotation (idx >= 0),
+ *    in protein order; proteins with no annotation are omitted (compacted).
+ *  - Multi-valued: one entry per (protein, label) pair, in order (expanded).
+ */
+export function buildAnnotationValueList(
+  colData: AnnotationData,
+  values: (string | null)[],
+  proteinCount: number,
+): string[] {
+  const out: string[] = [];
+  if (colData instanceof Int32Array) {
+    for (let i = 0; i < proteinCount; i++) {
+      const idx = getFirstAnnotationIndex(colData, i);
+      if (idx >= 0) out.push(toInternalValue(values[idx]));
+    }
+  } else {
+    for (let i = 0; i < proteinCount; i++) {
+      const indices = getProteinAnnotationIndices(colData, i);
+      for (let j = 0; j < indices.length; j++) {
+        out.push(toInternalValue(values[indices[j]]));
+      }
+    }
+  }
+  return out;
+}

--- a/packages/core/src/components/legend/legend-data-processor.ts
+++ b/packages/core/src/components/legend/legend-data-processor.ts
@@ -58,9 +58,15 @@ export class LegendDataProcessor {
     const filtered = new Set<number>();
     if (!isolationMode || !isolationHistory?.length || !proteinIds) return filtered;
 
+    // Build a Set per isolation layer once so membership is O(1). The previous
+    // `history.includes(id)` was a linear scan run for every protein, making this
+    // O(N × layerSize): on the 573K dataset an isolate triggered a ~18s main-thread
+    // freeze here. Mirrors the Set-based intersection in
+    // DataProcessor.processVisualizationData.
+    const layerSets = isolationHistory.map((layer) => new Set(layer));
+
     proteinIds.forEach((id, index) => {
-      const isIncluded = isolationHistory.every((history) => history.includes(id));
-      if (isIncluded) filtered.add(index);
+      if (layerSets.every((set) => set.has(id))) filtered.add(index);
     });
 
     return filtered;

--- a/packages/core/src/components/legend/legend.ts
+++ b/packages/core/src/components/legend/legend.ts
@@ -13,8 +13,6 @@ import {
   materializeNumericAnnotation,
   normalizeNumericPaletteId,
   resolveNumericAnnotationDisplaySettings,
-  getFirstAnnotationIndex,
-  getProteinAnnotationIndices,
   type NumericBinningStrategy,
   type NumericAnnotationDisplaySettingsMap,
 } from '@protspace/utils';
@@ -58,6 +56,7 @@ import {
   isolateItem,
   computeOtherConcreteValues,
 } from './legend-helpers';
+import { buildAnnotationValueList } from './annotation-values';
 
 // Dialogs
 import {
@@ -1065,22 +1064,7 @@ export class ProtspaceLegend extends LitElement {
   private _updateAnnotationValues(data: ScatterplotData, selectedAnnotation: string): void {
     const colData = data.annotation_data[selectedAnnotation];
     const values = data.annotations[selectedAnnotation].values;
-    let annotationValues: string[];
-    if (colData instanceof Int32Array) {
-      // Single-valued storage: use the allocation-free accessor.
-      annotationValues = data.protein_ids.flatMap((_: string, index: number) => {
-        const idx = getFirstAnnotationIndex(colData, index);
-        return idx < 0 ? [] : [toInternalValue(values[idx])];
-      });
-    } else {
-      annotationValues = data.protein_ids.flatMap((_: string, index: number) => {
-        const annotationIdxArray = getProteinAnnotationIndices(colData, index);
-        return annotationIdxArray.map((annotationIdx: number) =>
-          toInternalValue(values[annotationIdx]),
-        );
-      });
-    }
-    this.annotationValues = annotationValues;
+    this.annotationValues = buildAnnotationValueList(colData, values, data.protein_ids.length);
   }
 
   private _ensureSortModeDefaults(): void {

--- a/packages/core/src/components/scatter-plot/quadtree-index.test.ts
+++ b/packages/core/src/components/scatter-plot/quadtree-index.test.ts
@@ -1,19 +1,29 @@
 import { describe, it, expect } from 'vitest';
 import * as d3 from 'd3';
 import { QuadtreeIndex, pointInPolygon } from './quadtree-index';
-import type { PlotDataPoint } from '@protspace/utils';
+import type { PlotData } from '@protspace/utils';
 
-function makePoint(id: string, x: number, y: number): PlotDataPoint {
-  return { id, x, y, originalIndex: 0 };
+/** Build a minimal PlotData with identity originalIndices mapping. */
+function makePD(xs: number[], ys: number[], ids?: string[]): PlotData {
+  return {
+    length: xs.length,
+    xs: new Float32Array(xs),
+    ys: new Float32Array(ys),
+    zs: null,
+    originalIndices: null,
+    proteinIds: ids ?? xs.map((_, i) => `p${i}`),
+  };
 }
 
-function buildIndex(points: PlotDataPoint[]): QuadtreeIndex {
+function buildIndex(pd: PlotData): QuadtreeIndex {
   const idx = new QuadtreeIndex();
   idx.setScales({
     x: d3.scaleLinear().domain([0, 100]).range([0, 100]),
     y: d3.scaleLinear().domain([0, 100]).range([0, 100]),
   });
-  idx.rebuild(points);
+  // All slots are "visible"
+  const slots = Array.from({ length: pd.length }, (_, i) => i);
+  idx.rebuild(pd, slots);
   return idx;
 }
 
@@ -66,29 +76,71 @@ describe('pointInPolygon', () => {
   });
 });
 
+// ── findNearest ────────────────────────────────────────────────
+
+describe('QuadtreeIndex.findNearest', () => {
+  it('returns the slot of the nearest point within radius', () => {
+    const pd = makePD([10, 50, 90], [10, 50, 90]);
+    const idx = buildIndex(pd);
+    const slot = idx.findNearest(50, 50, 20);
+    expect(slot).toBe(1); // slot 1 is at (50,50)
+  });
+
+  it('returns -1 when no point is within radius', () => {
+    const pd = makePD([10], [10]);
+    const idx = buildIndex(pd);
+    expect(idx.findNearest(90, 90, 5)).toBe(-1);
+  });
+
+  it('returns -1 when tree is empty', () => {
+    const idx = new QuadtreeIndex();
+    expect(idx.findNearest(50, 50, 20)).toBe(-1);
+  });
+});
+
+// ── QuadtreeIndex.queryByPixels ────────────────────────────────
+
+describe('QuadtreeIndex.queryByPixels', () => {
+  it('returns slots of points inside the AABB', () => {
+    const pd = makePD([10, 50, 90], [10, 50, 90]);
+    const idx = buildIndex(pd);
+    const result = idx.queryByPixels(40, 40, 60, 60);
+    expect(result).toEqual([1]); // only slot 1 at (50,50)
+  });
+
+  it('returns empty array when no tree is built', () => {
+    const idx = new QuadtreeIndex();
+    expect(idx.queryByPixels(0, 0, 100, 100)).toEqual([]);
+  });
+
+  it('returns all slots with a large AABB', () => {
+    const pd = makePD([10, 50, 90], [10, 50, 90]);
+    const idx = buildIndex(pd);
+    const result = idx.queryByPixels(0, 0, 100, 100);
+    expect(result.sort((a, b) => a - b)).toEqual([0, 1, 2]);
+  });
+});
+
 // ── QuadtreeIndex.queryByPolygon ───────────────────────────────
 
 describe('QuadtreeIndex.queryByPolygon', () => {
-  it('selects points inside a triangle', () => {
-    const points = [
-      makePoint('inside', 5, 3),
-      makePoint('outside', 0, 10),
-      makePoint('also-inside', 5, 1),
-    ];
-    const idx = buildIndex(points);
+  it('returns slots of points inside a triangle', () => {
+    const pd = makePD([5, 0, 5], [3, 10, 1], ['inside', 'outside', 'also-inside']);
+    const idx = buildIndex(pd);
     const triangle: [number, number][] = [
       [0, 0],
       [10, 0],
       [5, 10],
     ];
     const result = idx.queryByPolygon(triangle);
-    const ids = result.map((p) => p.id).sort();
-    expect(ids).toEqual(['also-inside', 'inside']);
+    const slots = result.sort((a, b) => a - b);
+    // slot 0 = (5,3) inside, slot 1 = (0,10) outside, slot 2 = (5,1) inside
+    expect(slots).toEqual([0, 2]);
   });
 
   it('returns empty for polygon with < 3 vertices', () => {
-    const points = [makePoint('a', 5, 5)];
-    const idx = buildIndex(points);
+    const pd = makePD([5], [5]);
+    const idx = buildIndex(pd);
     expect(idx.queryByPolygon([[0, 0]])).toEqual([]);
     expect(
       idx.queryByPolygon([
@@ -109,11 +161,11 @@ describe('QuadtreeIndex.queryByPolygon', () => {
     expect(idx.queryByPolygon(square)).toEqual([]);
   });
 
-  it('selects all points with a large enclosing polygon', () => {
-    const points = Array.from({ length: 50 }, (_, i) =>
-      makePoint(`p${i}`, Math.random() * 80 + 10, Math.random() * 80 + 10),
-    );
-    const idx = buildIndex(points);
+  it('returns all slots with a large enclosing polygon', () => {
+    const xs = Array.from({ length: 50 }, () => Math.random() * 80 + 10);
+    const ys = Array.from({ length: 50 }, () => Math.random() * 80 + 10);
+    const pd = makePD(xs, ys);
+    const idx = buildIndex(pd);
     const bigSquare: [number, number][] = [
       [0, 0],
       [100, 0],
@@ -134,15 +186,48 @@ describe('QuadtreeIndex.queryByPolygon', () => {
       [40, 80],
       [0, 80],
     ];
-    const points = [
-      makePoint('bottom-left', 20, 20), // inside
-      makePoint('bottom-right', 50, 20), // inside (bottom arm)
-      makePoint('top-left', 20, 60), // inside (top arm)
-      makePoint('top-right', 50, 60), // outside (concave cutout)
-    ];
-    const idx = buildIndex(points);
+    const pd = makePD(
+      [20, 50, 20, 50],
+      [20, 20, 60, 60],
+      ['bottom-left', 'bottom-right', 'top-left', 'top-right'],
+    );
+    const idx = buildIndex(pd);
     const result = idx.queryByPolygon(lShape);
-    const ids = result.map((p) => p.id).sort();
+    const slots = result.sort((a, b) => a - b);
+    // slot 0 = (20,20) inside, slot 1 = (50,20) inside, slot 2 = (20,60) inside, slot 3 = (50,60) outside
+    expect(slots).toEqual([0, 1, 2]);
+    // Verify IDs via proteinIds
+    const ids = slots.map((s) => pd.proteinIds[s]).sort();
     expect(ids).toEqual(['bottom-left', 'bottom-right', 'top-left']);
+  });
+});
+
+// ── rebuild with explicit slots ────────────────────────────────
+
+describe('QuadtreeIndex.rebuild with slot subset', () => {
+  it('only indexes the provided slots', () => {
+    const pd = makePD([10, 50, 90], [10, 50, 90]);
+    const idx = new QuadtreeIndex();
+    idx.setScales({
+      x: d3.scaleLinear().domain([0, 100]).range([0, 100]),
+      y: d3.scaleLinear().domain([0, 100]).range([0, 100]),
+    });
+    // Only index slots 0 and 2 (exclude slot 1 at 50,50)
+    idx.rebuild(pd, [0, 2]);
+    const result = idx.queryByPixels(40, 40, 60, 60);
+    expect(result).toEqual([]); // slot 1 was not indexed
+    const all = idx.queryByPixels(0, 0, 100, 100);
+    expect(all.sort((a, b) => a - b)).toEqual([0, 2]);
+  });
+
+  it('sets qt to null when slots array is empty', () => {
+    const pd = makePD([10, 50], [10, 50]);
+    const idx = new QuadtreeIndex();
+    idx.setScales({
+      x: d3.scaleLinear().domain([0, 100]).range([0, 100]),
+      y: d3.scaleLinear().domain([0, 100]).range([0, 100]),
+    });
+    idx.rebuild(pd, []);
+    expect(idx.hasTree()).toBe(false);
   });
 });

--- a/packages/core/src/components/scatter-plot/quadtree-index.ts
+++ b/packages/core/src/components/scatter-plot/quadtree-index.ts
@@ -1,14 +1,14 @@
 import * as d3 from 'd3';
-import type { PlotDataPoint } from '@protspace/utils';
+import type { PlotData } from '@protspace/utils';
 
-type IndexedPoint = {
-  point: PlotDataPoint;
+type IndexedSlot = {
+  slot: number;
   px: number;
   py: number;
 };
 
 export class QuadtreeIndex {
-  private qt: d3.Quadtree<IndexedPoint> | null = null;
+  private qt: d3.Quadtree<IndexedSlot> | null = null;
   private scales: {
     x: d3.ScaleLinear<number, number>;
     y: d3.ScaleLinear<number, number>;
@@ -23,33 +23,35 @@ export class QuadtreeIndex {
     this.scales = scales;
   }
 
-  rebuild(plotData: PlotDataPoint[]) {
-    if (!this.scales || plotData.length === 0) {
+  rebuild(pd: PlotData, slots: ArrayLike<number>) {
+    if (!this.scales || slots.length === 0) {
       this.qt = null;
       return;
     }
 
     // Precompute screen-space coordinates once at rebuild time.
     // This makes query/hit-testing significantly cheaper, because we avoid calling
-    // scale functions for every candidate point during interactions.
+    // scale functions for every candidate slot during interactions.
     const sx = this.scales.x;
     const sy = this.scales.y;
-    const indexed: IndexedPoint[] = new Array(plotData.length);
-    for (let i = 0; i < plotData.length; i++) {
-      const p = plotData[i];
-      indexed[i] = { point: p, px: sx(p.x), py: sy(p.y) };
+    const n = slots.length;
+    const indexed: IndexedSlot[] = new Array(n);
+    for (let i = 0; i < n; i++) {
+      const slot = slots[i];
+      indexed[i] = { slot, px: sx(pd.xs[slot]), py: sy(pd.ys[slot]) };
     }
 
     this.qt = d3
-      .quadtree<IndexedPoint>()
+      .quadtree<IndexedSlot>()
       .x((d) => d.px)
       .y((d) => d.py)
       .addAll(indexed);
   }
 
-  findNearest(screenX: number, screenY: number, radius: number): PlotDataPoint | undefined {
-    if (!this.qt) return undefined;
-    return this.qt.find(screenX, screenY, radius)?.point;
+  findNearest(screenX: number, screenY: number, radius: number): number {
+    if (!this.qt) return -1;
+    const found = this.qt.find(screenX, screenY, radius);
+    return found ? found.slot : -1;
   }
 
   hasTree(): boolean {
@@ -60,21 +62,21 @@ export class QuadtreeIndex {
     this.qt = null;
   }
 
-  queryByPixels(minX: number, minY: number, maxX: number, maxY: number): PlotDataPoint[] {
+  queryByPixels(minX: number, minY: number, maxX: number, maxY: number): number[] {
     if (!this.qt) {
       return [];
     }
 
-    const results: PlotDataPoint[] = [];
+    const results: number[] = [];
     this.qt.visit((node, x0, y0, x1, y1) => {
       if (!node.length) {
-        let leaf: d3.QuadtreeLeaf<IndexedPoint> | undefined = node as d3.QuadtreeLeaf<IndexedPoint>;
+        let leaf: d3.QuadtreeLeaf<IndexedSlot> | undefined = node as d3.QuadtreeLeaf<IndexedSlot>;
         while (leaf) {
           const ip = leaf.data;
           if (ip.px >= minX && ip.px <= maxX && ip.py >= minY && ip.py <= maxY) {
-            results.push(ip.point);
+            results.push(ip.slot);
           }
-          leaf = leaf.next as d3.QuadtreeLeaf<IndexedPoint> | undefined;
+          leaf = leaf.next as d3.QuadtreeLeaf<IndexedSlot> | undefined;
         }
       }
       return x0 > maxX || x1 < minX || y0 > maxY || y1 < minY;
@@ -83,7 +85,7 @@ export class QuadtreeIndex {
     return results;
   }
 
-  queryByPolygon(vertices: ReadonlyArray<[number, number]>): PlotDataPoint[] {
+  queryByPolygon(vertices: ReadonlyArray<[number, number]>): number[] {
     if (!this.qt || vertices.length < 3) return [];
 
     // Compute AABB of polygon for fast quadtree pruning
@@ -98,12 +100,12 @@ export class QuadtreeIndex {
       if (y > maxY) maxY = y;
     }
 
-    const results: PlotDataPoint[] = [];
+    const results: number[] = [];
     this.qt.visit((node, x0, y0, x1, y1) => {
       // Prune quadtree nodes outside the polygon's bounding box
       if (x0 > maxX || x1 < minX || y0 > maxY || y1 < minY) return true;
       if (!node.length) {
-        let leaf: d3.QuadtreeLeaf<IndexedPoint> | undefined = node as d3.QuadtreeLeaf<IndexedPoint>;
+        let leaf: d3.QuadtreeLeaf<IndexedSlot> | undefined = node as d3.QuadtreeLeaf<IndexedSlot>;
         while (leaf) {
           const ip = leaf.data;
           if (
@@ -113,9 +115,9 @@ export class QuadtreeIndex {
             ip.py <= maxY &&
             pointInPolygon(ip.px, ip.py, vertices)
           ) {
-            results.push(ip.point);
+            results.push(ip.slot);
           }
-          leaf = leaf.next as d3.QuadtreeLeaf<IndexedPoint> | undefined;
+          leaf = leaf.next as d3.QuadtreeLeaf<IndexedSlot> | undefined;
         }
       }
       return false;

--- a/packages/core/src/components/scatter-plot/scatter-plot.isolation.test.ts
+++ b/packages/core/src/components/scatter-plot/scatter-plot.isolation.test.ts
@@ -10,6 +10,7 @@
  * global before the element module is imported.
  */
 import { vi, describe, it, expect, beforeEach } from 'vitest';
+import type { PlotData, VisualizationData } from '@protspace/utils';
 
 vi.hoisted(() => {
   if (!('ResizeObserver' in globalThis)) {
@@ -72,5 +73,115 @@ describe('scatter-plot clearIsolationState', () => {
     expect(events).toHaveLength(0);
     expect(sp.isIsolationMode()).toBe(false);
     expect(sp._isolationHistory).toEqual([]);
+  });
+});
+
+describe('scatter-plot getCurrentData (isolation slicing)', () => {
+  type SlicingInternals = HTMLElement & {
+    data: VisualizationData;
+    selectedProjectionIndex: number;
+    filtersActive: boolean;
+    filteredProteinIds: string[];
+    _isolationMode: boolean;
+    _isolationHistory: string[][];
+    _plotData: PlotData;
+    getCurrentData(): VisualizationData | null;
+  };
+
+  // 5 proteins; row coords encode the index so we can assert which rows survived.
+  function buildData(): VisualizationData {
+    return {
+      protein_ids: ['p0', 'p1', 'p2', 'p3', 'p4'],
+      projections: [
+        {
+          name: 'proj',
+          dimension: 2,
+          data: new Float32Array([0, 0, 10, 11, 20, 22, 30, 33, 40, 44]),
+        },
+      ],
+      annotations: {
+        cat: {
+          kind: 'categorical',
+          values: ['A', 'B'],
+          colors: ['#000000', '#ffffff'],
+          shapes: ['circle', 'square'],
+        },
+        num: { kind: 'numeric', values: [], colors: [], shapes: [] },
+      },
+      annotation_data: {
+        cat: new Int32Array([0, 1, 0, 1, 0]),
+      },
+      numeric_annotation_data: {
+        num: [100, 101, 102, 103, 104],
+      },
+    };
+  }
+
+  it('slices protein ids, categorical, numeric, and projection data to the isolated survivors', () => {
+    const el = document.createElement('protspace-scatterplot') as SlicingInternals;
+    const data = buildData();
+    el.data = data;
+    el.selectedProjectionIndex = 0;
+
+    // Isolate p1 and p3 (original indices 1 and 3). _plotData is the survivor view
+    // that getCurrentData() must reuse for slicing.
+    el._isolationMode = true;
+    el._isolationHistory = [['p1', 'p3']];
+    el._plotData = {
+      length: 2,
+      xs: new Float32Array([10, 30]),
+      ys: new Float32Array([11, 33]),
+      zs: null,
+      originalIndices: new Int32Array([1, 3]),
+      proteinIds: data.protein_ids,
+    };
+
+    const result = el.getCurrentData();
+    expect(result).not.toBeNull();
+    const r = result as VisualizationData;
+
+    expect(r.protein_ids).toEqual(['p1', 'p3']);
+    // categorical column sliced by survivor indices: cat[1]=1, cat[3]=1
+    expect(Array.from(r.annotation_data.cat as Int32Array)).toEqual([1, 1]);
+    // numeric column sliced: num[1]=101, num[3]=103
+    expect(r.numeric_annotation_data?.num).toEqual([101, 103]);
+    // projection coords sliced to rows 1 and 3
+    expect(Array.from(r.projections[0].data)).toEqual([10, 11, 30, 33]);
+    expect(r.projections[0].dimension).toBe(2);
+  });
+
+  it('produces identical slicing via the fallback path when the display is pre-filtered', () => {
+    const el = document.createElement('protspace-scatterplot') as SlicingInternals;
+    const data = buildData();
+    el.data = data;
+    el.selectedProjectionIndex = 0;
+
+    // Active view filter excludes p4, so _getCurrentDisplayData returns a strict
+    // subset (length 4 != full length 5). That defeats the originalIndices fast-path
+    // length guard and forces the membership-scan fallback.
+    el.filtersActive = true;
+    el.filteredProteinIds = ['p0', 'p1', 'p2', 'p3'];
+
+    // Isolated survivors p1, p3 are a subset of the filtered display.
+    el._isolationMode = true;
+    el._isolationHistory = [['p1', 'p3']];
+    el._plotData = {
+      length: 2,
+      xs: new Float32Array([10, 30]),
+      ys: new Float32Array([11, 33]),
+      zs: null,
+      originalIndices: new Int32Array([1, 3]),
+      proteinIds: data.protein_ids,
+    };
+
+    const result = el.getCurrentData();
+    expect(result).not.toBeNull();
+    const r = result as VisualizationData;
+
+    // Identical survivor slice to the fast-path test above.
+    expect(r.protein_ids).toEqual(['p1', 'p3']);
+    expect(Array.from(r.annotation_data.cat as Int32Array)).toEqual([1, 1]);
+    expect(r.numeric_annotation_data?.num).toEqual([101, 103]);
+    expect(Array.from(r.projections[0].data)).toEqual([10, 11, 30, 33]);
   });
 });

--- a/packages/core/src/components/scatter-plot/scatter-plot.ts
+++ b/packages/core/src/components/scatter-plot/scatter-plot.ts
@@ -2433,16 +2433,27 @@ export class ProtspaceScatterplot extends LitElement {
 
     // If we're in isolation mode, return filtered data based on current plot data
     if (this._isolationMode && this._plotData.length > 0) {
-      const currentProteinIds = Array.from({ length: this._plotData.length }, (_, s) =>
-        plotDataId(this._plotData, s),
-      );
-      const currentProteinIdsSet = new Set(currentProteinIds);
-      const keptIndices: number[] = [];
-      currentDisplayData.protein_ids.forEach((proteinId, index) => {
-        if (currentProteinIdsSet.has(proteinId)) {
-          keptIndices.push(index);
-        }
-      });
+      const pd = this._plotData;
+      const currentProteinIds = Array.from({ length: pd.length }, (_, s) => plotDataId(pd, s));
+
+      // `keptIndices` are the ascending positions in currentDisplayData.protein_ids to keep.
+      // _plotData.originalIndices is the ascending list of surviving indices into
+      // pd.proteinIds (the full source id array). When no view filter is active,
+      // currentDisplayData.protein_ids IS that same full array in the same order, so
+      // originalIndices already equals keptIndices — reuse it instead of re-scanning all
+      // ~573K ids and building a throwaway Set. The length-equality check detects that
+      // unfiltered case (a filtered display is always a strict subset, so its length
+      // differs); otherwise fall back to the membership scan.
+      let keptIndices: number[];
+      if (pd.originalIndices && currentDisplayData.protein_ids.length === pd.proteinIds.length) {
+        keptIndices = Array.from(pd.originalIndices);
+      } else {
+        const currentProteinIdsSet = new Set(currentProteinIds);
+        keptIndices = [];
+        currentDisplayData.protein_ids.forEach((proteinId, index) => {
+          if (currentProteinIdsSet.has(proteinId)) keptIndices.push(index);
+        });
+      }
 
       // Filter annotation data to match current protein IDs
       const filteredAnnotationData: Record<string, AnnotationData> = {};
@@ -2457,12 +2468,11 @@ export class ProtspaceScatterplot extends LitElement {
       for (const [annotationName, annotationValues] of Object.entries(
         currentDisplayData.numeric_annotation_data ?? {},
       )) {
-        filteredNumericAnnotationData[annotationName] = [];
-        currentDisplayData.protein_ids.forEach((proteinId, originalIndex) => {
-          if (currentProteinIdsSet.has(proteinId)) {
-            filteredNumericAnnotationData[annotationName].push(annotationValues[originalIndex]);
-          }
-        });
+        const sliced: (number | null)[] = new Array(keptIndices.length);
+        for (let k = 0; k < keptIndices.length; k++) {
+          sliced[k] = annotationValues[keptIndices[k]];
+        }
+        filteredNumericAnnotationData[annotationName] = sliced;
       }
 
       return {

--- a/packages/core/src/components/scatter-plot/scatter-plot.ts
+++ b/packages/core/src/components/scatter-plot/scatter-plot.ts
@@ -751,10 +751,18 @@ export class ProtspaceScatterplot extends LitElement {
     return {
       ...materializedData,
       protein_ids: keptIndices.map((index) => materializedData.protein_ids[index]),
-      projections: materializedData.projections.map((projection) => ({
-        ...projection,
-        data: keptIndices.map((index) => projection.data[index]),
-      })),
+      projections: materializedData.projections.map((projection) => {
+        const dim = projection.dimension;
+        const out = new Float32Array(keptIndices.length * dim);
+        for (let k = 0; k < keptIndices.length; k++) {
+          const base = keptIndices[k] * dim;
+          const o = k * dim;
+          out[o] = projection.data[base];
+          out[o + 1] = projection.data[base + 1];
+          if (dim === 3) out[o + 2] = projection.data[base + 2];
+        }
+        return { ...projection, data: out, dimension: dim };
+      }),
       annotation_data: Object.fromEntries(
         Object.entries(materializedData.annotation_data).map(([annotationName, rows]) => [
           annotationName,
@@ -804,22 +812,24 @@ export class ProtspaceScatterplot extends LitElement {
     const { xs, ys, zs } = pd;
     const oi = pd.originalIndices;
 
+    const dim = projection.dimension;
     for (let i = 0; i < pd.length; i++) {
       const origIdx = oi ? oi[i] : i;
-      const coords = (projection.data[origIdx] ?? [0, 0]) as
-        | [number, number]
-        | [number, number, number];
+      const base = origIdx * dim;
+      const c0 = projection.data[base];
+      const c1 = projection.data[base + 1];
 
-      let xVal = coords[0];
-      let yVal = coords[1];
+      let xVal = c0;
+      let yVal = c1;
 
-      if (coords.length === 3) {
-        if (zs) zs[i] = coords[2];
+      if (dim === 3) {
+        const c2 = projection.data[base + 2];
+        if (zs) zs[i] = c2;
         if (this.projectionPlane === 'xz') {
-          yVal = coords[2];
+          yVal = c2;
         } else if (this.projectionPlane === 'yz') {
-          xVal = coords[1];
-          yVal = coords[2];
+          xVal = c1;
+          yVal = c2;
         }
       }
 
@@ -2460,10 +2470,18 @@ export class ProtspaceScatterplot extends LitElement {
         protein_ids: currentProteinIds,
         annotation_data: filteredAnnotationData,
         numeric_annotation_data: filteredNumericAnnotationData,
-        projections: currentDisplayData.projections.map((projection) => ({
-          ...projection,
-          data: keptIndices.map((index) => projection.data[index]),
-        })),
+        projections: currentDisplayData.projections.map((projection) => {
+          const dim = projection.dimension;
+          const out = new Float32Array(keptIndices.length * dim);
+          for (let k = 0; k < keptIndices.length; k++) {
+            const base = keptIndices[k] * dim;
+            const o = k * dim;
+            out[o] = projection.data[base];
+            out[o + 1] = projection.data[base + 1];
+            if (dim === 3) out[o + 2] = projection.data[base + 2];
+          }
+          return { ...projection, data: out, dimension: dim };
+        }),
       };
     }
 

--- a/packages/core/src/components/scatter-plot/scatter-plot.ts
+++ b/packages/core/src/components/scatter-plot/scatter-plot.ts
@@ -4,6 +4,7 @@ import { customElement } from '../../utils/safe-custom-element';
 import * as d3 from 'd3';
 import type {
   VisualizationData,
+  PlotData,
   PlotDataPoint,
   ScatterplotConfig,
   NumericAnnotationDisplaySettingsMap,
@@ -15,6 +16,11 @@ import {
   buildTooltipView,
   materializeVisualizationData,
   sliceAnnotationData,
+  EMPTY_PLOT_DATA,
+  clonePlotData,
+  plotDataId,
+  materializePlotDataPoint,
+  gatherPlotData,
 } from '@protspace/utils';
 import type { LegendSortMode } from '../legend/types';
 import { scatterplotStyles } from './scatter-plot.styles';
@@ -79,7 +85,7 @@ export class ProtspaceScatterplot extends LitElement {
   @property({ type: Boolean, attribute: 'show-tour-button' }) showTourButton = false;
 
   // State
-  @state() private _plotData: PlotDataPoint[] = [];
+  @state() private _plotData: PlotData = EMPTY_PLOT_DATA;
   @state() private _tooltipData: {
     x: number;
     y: number;
@@ -129,7 +135,8 @@ export class ProtspaceScatterplot extends LitElement {
   private _quadtreeRebuildRafId: number | null = null;
   private _hoverRaf: number | null = null;
   private _pendingHover: { event: MouseEvent; mouseX: number; mouseY: number } | null = null;
-  private _visiblePlotData: PlotDataPoint[] = [];
+  private _visiblePlotData: PlotData = EMPTY_PLOT_DATA;
+  private _scratchPoint: PlotDataPoint = { id: '', x: 0, y: 0, originalIndex: 0 };
   private _virtualizationCacheKey: string | null = null;
   private _hoveredProteinId: string | null = null;
   private _cachedScales: ScalePair | null = null;
@@ -611,10 +618,10 @@ export class ProtspaceScatterplot extends LitElement {
       this._updatePlotDataCoordinates(dataToUse);
     } else {
       // Release old data references before allocating the new dataset.
-      // Without this, old and new arrays coexist in memory during processing
+      // Without this, old and new PlotData coexist in memory during processing
       // (e.g. 100K + 570K points), which can cause OOM on constrained devices.
-      this._plotData = [];
-      this._visiblePlotData = [];
+      this._plotData = EMPTY_PLOT_DATA;
+      this._visiblePlotData = EMPTY_PLOT_DATA;
       this._quadtreeIndex.clear();
       this._webglRenderer?.releaseDataReferences();
 
@@ -645,7 +652,7 @@ export class ProtspaceScatterplot extends LitElement {
 
     // Style-getters read annotation values lazily via getProteinAnnotationValues —
     // changing the selected annotation only requires re-render + cache invalidation.
-    this._plotData = [...this._plotData];
+    this._plotData = clonePlotData(this._plotData);
     this._lastDataRef = dataToUse;
     this._styleGettersCache = null;
     this._invalidateVirtualizationCache();
@@ -784,17 +791,22 @@ export class ProtspaceScatterplot extends LitElement {
   }
 
   /**
-   * Update PlotDataPoint coordinates in-place from a new projection.
+   * Update PlotData coordinates in-place from a new projection.
    * Reads directly from VisualizationData.projections — no intermediate allocation.
-   * This avoids the ~700MB memory spike from rebuilding the full PlotDataPoint array.
+   * This avoids the ~700MB memory spike from rebuilding the full PlotData container.
    */
   private _updatePlotDataCoordinates(data: VisualizationData) {
     const projection = data.projections[this.selectedProjectionIndex];
     if (!projection) return;
 
-    for (let i = 0; i < this._plotData.length; i++) {
-      const point = this._plotData[i];
-      const coords = (projection.data[point.originalIndex] ?? [0, 0]) as
+    const pd = this._plotData;
+    // xs/ys/zs are readonly fields, but the Float32Array contents are mutable.
+    const { xs, ys, zs } = pd;
+    const oi = pd.originalIndices;
+
+    for (let i = 0; i < pd.length; i++) {
+      const origIdx = oi ? oi[i] : i;
+      const coords = (projection.data[origIdx] ?? [0, 0]) as
         | [number, number]
         | [number, number, number];
 
@@ -802,7 +814,7 @@ export class ProtspaceScatterplot extends LitElement {
       let yVal = coords[1];
 
       if (coords.length === 3) {
-        point.z = coords[2];
+        if (zs) zs[i] = coords[2];
         if (this.projectionPlane === 'xz') {
           yVal = coords[2];
         } else if (this.projectionPlane === 'yz') {
@@ -811,12 +823,12 @@ export class ProtspaceScatterplot extends LitElement {
         }
       }
 
-      point.x = xVal;
-      point.y = yVal;
+      xs[i] = xVal;
+      ys[i] = yVal;
     }
 
-    // New array reference so Lit detects the change
-    this._plotData = [...this._plotData];
+    // New container ref so Lit detects the change and extent-cache invalidates.
+    this._plotData = clonePlotData(this._plotData);
   }
 
   private _buildQuadtree() {
@@ -832,9 +844,20 @@ export class ProtspaceScatterplot extends LitElement {
       this._duplicateStacksCacheKey = null;
       return;
     }
-    const visiblePoints = this._plotData.filter((d) => this._getOpacity(d) > 0);
+    const pd = this._plotData;
+    const oi = pd.originalIndices;
+    const sp = this._scratchPoint;
+    const visibleSlots: number[] = [];
+    for (let s = 0; s < pd.length; s++) {
+      const origIdx = oi ? oi[s] : s;
+      sp.id = pd.proteinIds[origIdx];
+      sp.x = pd.xs[s];
+      sp.y = pd.ys[s];
+      sp.originalIndex = origIdx;
+      if (this._getOpacity(sp) > 0) visibleSlots.push(s);
+    }
     this._quadtreeIndex.setScales(this._scales);
-    this._quadtreeIndex.rebuild(visiblePoints);
+    this._quadtreeIndex.rebuild(pd, visibleSlots);
     // Duplicate stacks are computed lazily for the current viewport (see _ensureDuplicateStacksForViewport)
     // to keep quadtree rebuilds fast on large datasets.
     this._duplicateStacks = [];
@@ -1202,8 +1225,8 @@ export class ProtspaceScatterplot extends LitElement {
       this._lassoPath.setAttribute('d', d + ' Z');
     }
 
-    const candidates = this._quadtreeIndex.queryByPolygon(this._lassoVertices);
-    const selectedIds = candidates.filter((d) => this._getOpacity(d) > 0).map((d) => d.id);
+    const slots = this._quadtreeIndex.queryByPolygon(this._lassoVertices);
+    const selectedIds = slots.map((s) => plotDataId(this._plotData, s));
     this._commitSelection(selectedIds, () => this._clearLassoVisual());
   }
 
@@ -1219,8 +1242,8 @@ export class ProtspaceScatterplot extends LitElement {
     if (!event.selection) return;
 
     const [[x0, y0], [x1, y1]] = event.selection as [[number, number], [number, number]];
-    const candidates = this._quadtreeIndex.queryByPixels(x0, y0, x1, y1);
-    const selectedIds = candidates.filter((d) => this._getOpacity(d) > 0).map((d) => d.id);
+    const slots = this._quadtreeIndex.queryByPixels(x0, y0, x1, y1);
+    const selectedIds = slots.map((s) => plotDataId(this._plotData, s));
     this._commitSelection(selectedIds, () => {
       if (this._brush && this._brushGroup) {
         this._brushGroup.call(this._brush.move, null);
@@ -1271,13 +1294,13 @@ export class ProtspaceScatterplot extends LitElement {
   private _renderWebGL(trigger: RenderWebGLTrigger = 'unknown') {
     const perfToken = this._webglRenderPerf.start(trigger);
 
-    const points = this._getPointsForRendering();
+    const pd = this._getPointsForRendering();
 
-    this._webglRenderer!.setTrackRenderedPointIds(points.length > MAX_POINTS_DIRECT_RENDER);
-    this._webglRenderer!.render(points);
+    this._webglRenderer!.setTrackRenderedPointIds(pd.length > MAX_POINTS_DIRECT_RENDER);
+    this._webglRenderer!.render(pd);
     this._mainGroup?.selectAll('.protein-point').remove();
 
-    this._webglRenderPerf.stop(perfToken, points.length);
+    this._webglRenderPerf.stop(perfToken, pd.length);
   }
 
   public async runWebGLRenderPerfMeasurements(
@@ -1287,10 +1310,10 @@ export class ProtspaceScatterplot extends LitElement {
     return this._webglRenderPerf.runWebGLRenderPerfMeasurements(iterations, options);
   }
 
-  private _getPointsForRendering(): PlotDataPoint[] {
+  private _getPointsForRendering(): PlotData {
     if (!this._scales || this._plotData.length === 0) {
-      this._visiblePlotData = [];
-      return [];
+      this._visiblePlotData = EMPTY_PLOT_DATA;
+      return EMPTY_PLOT_DATA;
     }
 
     // For smaller datasets, pass all points - renderer handles display mode
@@ -1316,8 +1339,8 @@ export class ProtspaceScatterplot extends LitElement {
 
     const cacheKey = `${Math.round(transform.x)}|${Math.round(transform.y)}|${transform.k.toFixed(3)}|${config.width}|${config.height}`;
     if (this._virtualizationCacheKey !== cacheKey) {
-      this._visiblePlotData = this._quadtreeIndex.queryByPixels(minX, minY, maxX, maxY);
-
+      const slots = this._quadtreeIndex.queryByPixels(minX, minY, maxX, maxY);
+      this._visiblePlotData = gatherPlotData(this._plotData, slots);
       this._virtualizationCacheKey = cacheKey;
     }
 
@@ -1327,6 +1350,7 @@ export class ProtspaceScatterplot extends LitElement {
   private _invalidateVirtualizationCache() {
     this._virtualizationCacheKey = null;
     this._visiblePlotData = this._plotData;
+    // Reset visible data to full dataset on any invalidation.
   }
 
   private _updateSelectionOverlays(options: { duplicateImmediate?: boolean } = {}) {
@@ -1387,8 +1411,8 @@ export class ProtspaceScatterplot extends LitElement {
     this._duplicateStacksComputing = true;
     const jobId = ++this._duplicateStacksComputeJobId;
 
-    // Query only the points currently in (or near) the viewport. This is the key perf win.
-    const candidates = this._quadtreeIndex.queryByPixels(minX, minY, maxX, maxY);
+    // Query only the slots currently in (or near) the viewport. This is the key perf win.
+    const candidateSlots = this._quadtreeIndex.queryByPixels(minX, minY, maxX, maxY);
     const scales = this._scales;
     if (!scales) {
       this._duplicateStacksComputing = false;
@@ -1404,9 +1428,10 @@ export class ProtspaceScatterplot extends LitElement {
     let idx = 0;
     const step = () => {
       if (jobId !== this._duplicateStacksComputeJobId) return; // cancelled
-      const end = Math.min(candidates.length, idx + DUPLICATE_STACK_COMPUTE_CHUNK_SIZE);
+      const end = Math.min(candidateSlots.length, idx + DUPLICATE_STACK_COMPUTE_CHUNK_SIZE);
       for (; idx < end; idx++) {
-        const p = candidates[idx];
+        const slot = candidateSlots[idx];
+        const p = materializePlotDataPoint(this._plotData, slot);
         if (!Number.isFinite(p.x) || !Number.isFinite(p.y)) continue;
 
         // Group only points that share coords in the *current* projection
@@ -1429,7 +1454,7 @@ export class ProtspaceScatterplot extends LitElement {
         idToKey.set(p.id, key);
       }
 
-      if (idx < candidates.length) {
+      if (idx < candidateSlots.length) {
         requestAnimationFrame(step);
         return;
       }
@@ -1943,11 +1968,13 @@ export class ProtspaceScatterplot extends LitElement {
     const dataX = (mouseX - this._transform.x) / this._transform.k;
     const dataY = (mouseY - this._transform.y) / this._transform.k;
 
-    // Find nearest point using spatial index
+    // Find nearest slot using spatial index
     const searchRadius = 15 / this._transform.k; // Search radius adjusted for zoom
-    const nearestPoint = this._quadtreeIndex.findNearest(dataX, dataY, searchRadius);
+    const nearestSlot = this._quadtreeIndex.findNearest(dataX, dataY, searchRadius);
 
-    if (nearestPoint) {
+    if (nearestSlot >= 0) {
+      const nearestPoint = materializePlotDataPoint(this._plotData, nearestSlot);
+
       // Don't hover hidden points (opacity=0)
       if (this._getOpacity(nearestPoint) === 0) {
         this._clearHoverState();
@@ -2003,11 +2030,13 @@ export class ProtspaceScatterplot extends LitElement {
     const dataX = (mouseX - this._transform.x) / this._transform.k;
     const dataY = (mouseY - this._transform.y) / this._transform.k;
 
-    // Find nearest point using spatial index
+    // Find nearest slot using spatial index
     const searchRadius = 15 / this._transform.k;
-    const nearestPoint = this._quadtreeIndex.findNearest(dataX, dataY, searchRadius);
+    const nearestSlot = this._quadtreeIndex.findNearest(dataX, dataY, searchRadius);
 
-    if (nearestPoint) {
+    if (nearestSlot >= 0) {
+      const nearestPoint = materializePlotDataPoint(this._plotData, nearestSlot);
+
       // Don't click hidden points (opacity=0)
       if (this._getOpacity(nearestPoint) === 0) {
         return;
@@ -2214,7 +2243,9 @@ export class ProtspaceScatterplot extends LitElement {
     }
 
     // Validate selected IDs against current plot data
-    const currentProteinIds = new Set(this._plotData.map((point) => point.id));
+    const currentProteinIds = new Set(
+      Array.from({ length: this._plotData.length }, (_, s) => plotDataId(this._plotData, s)),
+    );
     const validSelectedIds = this.selectedProteinIds.filter((id) => currentProteinIds.has(id));
 
     if (validSelectedIds.length === 0) {
@@ -2392,7 +2423,9 @@ export class ProtspaceScatterplot extends LitElement {
 
     // If we're in isolation mode, return filtered data based on current plot data
     if (this._isolationMode && this._plotData.length > 0) {
-      const currentProteinIds = this._plotData.map((point) => point.id);
+      const currentProteinIds = Array.from({ length: this._plotData.length }, (_, s) =>
+        plotDataId(this._plotData, s),
+      );
       const currentProteinIdsSet = new Set(currentProteinIds);
       const keptIndices: number[] = [];
       currentDisplayData.protein_ids.forEach((proteinId, index) => {

--- a/packages/core/src/components/scatter-plot/scatter-plot.ts
+++ b/packages/core/src/components/scatter-plot/scatter-plot.ts
@@ -127,6 +127,8 @@ export class ProtspaceScatterplot extends LitElement {
   private _styleSig: string | null = null;
   private _styleGettersCache: ReturnType<typeof createStyleGetters> | null = null;
   private _quadtreeRebuildRafId: number | null = null;
+  private _hoverRaf: number | null = null;
+  private _pendingHover: { event: MouseEvent; mouseX: number; mouseY: number } | null = null;
   private _visiblePlotData: PlotDataPoint[] = [];
   private _virtualizationCacheKey: string | null = null;
   private _hoveredProteinId: string | null = null;
@@ -315,6 +317,11 @@ export class ProtspaceScatterplot extends LitElement {
       cancelAnimationFrame(this._zoomRafId);
       this._zoomRafId = null;
     }
+    if (this._hoverRaf !== null) {
+      cancelAnimationFrame(this._hoverRaf);
+      this._hoverRaf = null;
+    }
+    this._pendingHover = null;
     this._cancelDuplicateOverlayDebounce();
     this._cancelDuplicateStackCompute();
     this._clearDuplicateBadgesCanvas();
@@ -1907,12 +1914,30 @@ export class ProtspaceScatterplot extends LitElement {
   }
 
   /**
-   * Handle mouse move events for canvas rendering
+   * Handle mouse move events for canvas rendering.
+   * Coalesces rapid mousemoves to at most one hover computation per animation frame.
    */
   private _handleCanvasMouseMove(event: MouseEvent): void {
     if (!this._scales) return;
-
+    // d3.pointer must be read synchronously: event.currentTarget is null after dispatch.
     const [mouseX, mouseY] = d3.pointer(event);
+    this._pendingHover = { event, mouseX, mouseY };
+    // Coalesce rapid mousemoves to at most one hover computation per frame (uses latest position).
+    if (this._hoverRaf !== null) return;
+    this._hoverRaf = requestAnimationFrame(() => {
+      this._hoverRaf = null;
+      const pending = this._pendingHover;
+      this._pendingHover = null;
+      if (pending) this._processCanvasHover(pending.event, pending.mouseX, pending.mouseY);
+    });
+  }
+
+  /**
+   * Deferred hover processing — runs inside a rAF scheduled by _handleCanvasMouseMove.
+   * Behaviour is identical to the former per-event body; only the call frequency is throttled.
+   */
+  private _processCanvasHover(event: MouseEvent, mouseX: number, mouseY: number): void {
+    if (!this._scales) return; // may have been cleared between scheduling and the frame
 
     // Transform mouse coordinates to data space
     const dataX = (mouseX - this._transform.x) / this._transform.k;
@@ -2023,6 +2048,11 @@ export class ProtspaceScatterplot extends LitElement {
    * Handle mouse out events for canvas rendering
    */
   private _handleCanvasMouseOut(): void {
+    if (this._hoverRaf !== null) {
+      cancelAnimationFrame(this._hoverRaf);
+      this._hoverRaf = null;
+    }
+    this._pendingHover = null;
     this._clearHoverState();
   }
 

--- a/packages/core/src/components/scatter-plot/style-getters.test.ts
+++ b/packages/core/src/components/scatter-plot/style-getters.test.ts
@@ -15,7 +15,13 @@ describe('style-getters', () => {
   describe('N/A value handling', () => {
     const createMockData = (annotationValues: (string | null)[]): VisualizationData => ({
       protein_ids: annotationValues.map((_, i) => `protein_${i}`),
-      projections: [{ name: 'test', data: annotationValues.map(() => [0, 0, 0]) }],
+      projections: [
+        {
+          name: 'test',
+          data: new Float32Array(annotationValues.length * 3),
+          dimension: 3,
+        },
+      ],
       annotations: {
         test_annotation: {
           values: annotationValues,
@@ -165,7 +171,13 @@ describe('style-getters', () => {
   describe('depth stability across visibility toggles', () => {
     const createMockData = (annotationValues: string[]): VisualizationData => ({
       protein_ids: annotationValues.map((_, i) => `protein_${i}`),
-      projections: [{ name: 'test', data: annotationValues.map(() => [0, 0, 0]) }],
+      projections: [
+        {
+          name: 'test',
+          data: new Float32Array(annotationValues.length * 3),
+          dimension: 3,
+        },
+      ],
       annotations: {
         test_annotation: {
           values: annotationValues,
@@ -269,11 +281,8 @@ describe('style-getters', () => {
         projections: [
           {
             name: 'test',
-            data: [
-              [0, 0, 0],
-              [1, 1, 0],
-              [2, 2, 0],
-            ],
+            data: Float32Array.of(0, 0, 0, 1, 1, 0, 2, 2, 0),
+            dimension: 3,
           },
         ],
         annotations: {
@@ -304,7 +313,13 @@ describe('style-getters', () => {
   describe('z-order change consistency', () => {
     const createMockData = (annotationValues: string[]): VisualizationData => ({
       protein_ids: annotationValues.map((_, i) => `protein_${i}`),
-      projections: [{ name: 'test', data: annotationValues.map(() => [0, 0, 0]) }],
+      projections: [
+        {
+          name: 'test',
+          data: new Float32Array(annotationValues.length * 3),
+          dimension: 3,
+        },
+      ],
       annotations: {
         test_annotation: {
           values: annotationValues,

--- a/packages/core/src/components/scatter-plot/webgl-render-perf.ts
+++ b/packages/core/src/components/scatter-plot/webgl-render-perf.ts
@@ -215,10 +215,13 @@ export class WebglRenderPerfRunner {
       await (this._hostAny().updateComplete ?? Promise.resolve());
       await this._sleep(16);
       const host = this._hostAny();
-      const plotData = host._plotData as unknown[] | undefined;
+      // _plotData is a PlotData SoA container (not an array since MODEL-O1); its
+      // `length` field is the populated point count.
+      const plotData = host._plotData as { length?: number } | undefined;
       if (
         host.data &&
-        Array.isArray(plotData) &&
+        !!plotData &&
+        typeof plotData.length === 'number' &&
         plotData.length > 0 &&
         host._svg &&
         host._svgSelection &&

--- a/packages/core/src/components/scatter-plot/webgl-render-perf.ts
+++ b/packages/core/src/components/scatter-plot/webgl-render-perf.ts
@@ -1,5 +1,6 @@
 import * as d3 from 'd3';
-import type { PlotDataPoint, VisualizationData } from '@protspace/utils';
+import type { PlotData, PlotDataPoint, VisualizationData } from '@protspace/utils';
+import { materializePlotDataPoint } from '@protspace/utils';
 
 const PERF_MEASURE_ITERATIONS = 10;
 const PERF_MEASURE_ZOOM_FACTOR = 3;
@@ -552,17 +553,15 @@ export class WebglRenderPerfRunner {
     const height = host._mergedConfig?.height as number;
     const transform = (host._transform as { x: number; y: number; k: number }) ?? d3.zoomIdentity;
 
-    const getPointsForRendering = host._getPointsForRendering as
-      | (() => PlotDataPoint[])
-      | undefined;
-    const candidates = getPointsForRendering
+    const getPointsForRendering = host._getPointsForRendering as (() => PlotData) | undefined;
+    const candidates: PlotData = getPointsForRendering
       ? getPointsForRendering.call(host)
-      : (host._plotData as PlotDataPoint[]);
+      : (host._plotData as PlotData);
     const getOpacity = host._getOpacity as ((p: PlotDataPoint) => number) | undefined;
 
     const clickable: PlotDataPoint[] = [];
     for (let i = 0; i < candidates.length && clickable.length < 2; i++) {
-      const p = candidates[i];
+      const p = materializePlotDataPoint(candidates, i);
       if (getOpacity && getOpacity.call(host, p) === 0) continue;
       const px = scales.x(p.x);
       const py = scales.y(p.y);

--- a/packages/core/src/components/scatter-plot/webgl/renderer/capacity-planner.test.ts
+++ b/packages/core/src/components/scatter-plot/webgl/renderer/capacity-planner.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect } from 'vitest';
+import { planRendererCapacity } from './capacity-planner';
+
+const FLOOR = 1024;
+const ROW = 256;
+
+describe('planRendererCapacity', () => {
+  it('first load 573230, current 0 → 573440 (NOT next pow2 1048576)', () => {
+    const result = planRendererCapacity(573230, 0, FLOOR, ROW);
+    expect(result).toBe(573440);
+    expect(result).not.toBe(1048576);
+  });
+
+  it('result is always a multiple of 256', () => {
+    const inputs = [1, 100, 573230, 700000, 1000000, 1500000, 256, 512, 1024];
+    for (const n of inputs) {
+      const result = planRendererCapacity(n, 0, FLOOR, ROW);
+      expect(result % ROW).toBe(0);
+    }
+  });
+
+  it('below floor: minCapacity 100, current 0 → 1024 (floor, multiple of 256)', () => {
+    const result = planRendererCapacity(100, 0, FLOOR, ROW);
+    expect(result).toBe(1024);
+    expect(result % ROW).toBe(0);
+  });
+
+  it('exact multiple at floor: minCapacity 512, current 0 → 1024 (floor wins, still multiple of 256)', () => {
+    // 512 < FLOOR (1024), so floor wins; 1024 is already a multiple of 256
+    const result = planRendererCapacity(512, 0, FLOOR, ROW);
+    expect(result).toBe(1024);
+    expect(result % ROW).toBe(0);
+  });
+
+  it('growth across reloads: minCapacity 700000, current 573440 → 860160', () => {
+    // ceil(573440 * 1.5) = 860160, which is already a multiple of 256
+    const result = planRendererCapacity(700000, 573440, FLOOR, ROW);
+    expect(result).toBe(860160);
+    expect(result % ROW).toBe(0);
+  });
+
+  it('large first load 1_500_000, current 0 → 1500160', () => {
+    // ceil(1500000 / 256) * 256 = 5860 * 256 = 1500160
+    const result = planRendererCapacity(1_500_000, 0, FLOOR, ROW);
+    expect(result).toBe(1500160);
+  });
+
+  it('result >= minCapacity and >= minCapacityFloor in all cases', () => {
+    const cases: Array<[number, number]> = [
+      [573230, 0],
+      [100, 0],
+      [512, 0],
+      [700000, 573440],
+      [1_500_000, 0],
+      [1024, 0],
+      [1025, 0],
+      [300000, 200000],
+    ];
+    for (const [min, cur] of cases) {
+      const result = planRendererCapacity(min, cur, FLOOR, ROW);
+      expect(result).toBeGreaterThanOrEqual(min);
+      expect(result).toBeGreaterThanOrEqual(FLOOR);
+    }
+  });
+});

--- a/packages/core/src/components/scatter-plot/webgl/renderer/capacity-planner.ts
+++ b/packages/core/src/components/scatter-plot/webgl/renderer/capacity-planner.ts
@@ -1,0 +1,21 @@
+/**
+ * Plan the next renderer buffer capacity.
+ *
+ * - At least `minCapacityFloor` (MIN_CAPACITY).
+ * - Across reloads (currentCapacity > 0), grow geometrically by 1.5x so progressively larger
+ *   datasets don't trigger a reallocation every time.
+ * - Rounded UP to a whole label-texture row (`pointsPerTextureRow` points) so the label texture
+ *   (LABEL_TEXTURE_WIDTH wide, MAX_LABELS texels/point) has no partial-row waste — and so SoA
+ *   arrays aren't oversized to the next power of two (which wasted ~83% at 573K).
+ */
+export function planRendererCapacity(
+  minCapacity: number,
+  currentCapacity: number,
+  minCapacityFloor: number,
+  pointsPerTextureRow: number,
+): number {
+  const required = Math.max(minCapacity, minCapacityFloor);
+  const target =
+    currentCapacity > 0 ? Math.max(required, Math.ceil(currentCapacity * 1.5)) : required;
+  return Math.ceil(target / pointsPerTextureRow) * pointsPerTextureRow;
+}

--- a/packages/core/src/components/scatter-plot/webgl/renderer/depth-sort.test.ts
+++ b/packages/core/src/components/scatter-plot/webgl/renderer/depth-sort.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect } from 'vitest';
+import { sortIndicesByDepthDescending } from './depth-sort';
+
+describe('sortIndicesByDepthDescending', () => {
+  it('basic: descending depth, ties break by ascending original index', () => {
+    const order = new Uint32Array(4);
+    const depths = new Float32Array([0.5, 0.1, 0.9, 0.1]);
+    sortIndicesByDepthDescending(order, depths, 4);
+    // Expected: 0.9 (idx2) > 0.5 (idx0) > 0.1 (idx1, idx3 — ascending tiebreak)
+    expect(Array.from(order)).toEqual([2, 0, 1, 3]);
+  });
+
+  it('all-equal depths: stable identity order', () => {
+    const n = 5;
+    const order = new Uint32Array(n);
+    const depths = new Float32Array([0.5, 0.5, 0.5, 0.5, 0.5]);
+    sortIndicesByDepthDescending(order, depths, n);
+    expect(Array.from(order)).toEqual([0, 1, 2, 3, 4]);
+  });
+
+  it('count smaller than array length: only order[0..count) is sorted', () => {
+    const order = new Uint32Array(6);
+    const depths = new Float32Array([0.3, 0.8, 0.1, 0.6, 0.9, 0.2]);
+    // Sort only first 3 elements: depths[0..3) = [0.3, 0.8, 0.1]
+    sortIndicesByDepthDescending(order, depths, 3);
+    // Sorted subarray: 0.8 (idx1) > 0.3 (idx0) > 0.1 (idx2)
+    expect(Array.from(order.subarray(0, 3))).toEqual([1, 0, 2]);
+    // Elements beyond count are not asserted (implementation-defined)
+  });
+
+  it('larger fixed array: non-increasing depth, equal-depth runs in ascending index', () => {
+    const depths = new Float32Array([0.7, 0.3, 0.7, 0.1, 0.5, 0.7, 0.3, 0.9]);
+    const n = depths.length;
+    const order = new Uint32Array(n);
+    sortIndicesByDepthDescending(order, depths, n);
+
+    // Verify non-increasing depth
+    for (let i = 0; i < n - 1; i++) {
+      expect(depths[order[i]]).toBeGreaterThanOrEqual(depths[order[i + 1]]);
+    }
+
+    // Within runs of equal depth, indices must be ascending
+    let runStart = 0;
+    while (runStart < n) {
+      let runEnd = runStart + 1;
+      while (runEnd < n && depths[order[runEnd]] === depths[order[runStart]]) {
+        runEnd++;
+      }
+      // Indices in [runStart, runEnd) must be ascending
+      for (let j = runStart; j < runEnd - 1; j++) {
+        expect(order[j]).toBeLessThan(order[j + 1]);
+      }
+      runStart = runEnd;
+    }
+  });
+
+  it('single element: no throw', () => {
+    const order = new Uint32Array(1);
+    const depths = new Float32Array([0.5]);
+    expect(() => sortIndicesByDepthDescending(order, depths, 1)).not.toThrow();
+    expect(order[0]).toBe(0);
+  });
+
+  it('count 0: no throw', () => {
+    const order = new Uint32Array(4);
+    const depths = new Float32Array([0.5, 0.3, 0.1, 0.8]);
+    expect(() => sortIndicesByDepthDescending(order, depths, 0)).not.toThrow();
+  });
+});

--- a/packages/core/src/components/scatter-plot/webgl/renderer/depth-sort.ts
+++ b/packages/core/src/components/scatter-plot/webgl/renderer/depth-sort.ts
@@ -1,0 +1,14 @@
+/**
+ * Fill `order[0..count)` with 0..count-1 and sort it so points are ordered far -> near
+ * (DESCENDING depth) for the painter's algorithm. Ties break by ascending original index
+ * (stable). Depth is continuous, so this is an O(n log n) comparator sort — NOT a bucket sort.
+ * Sorts `order` in place; `depths` is indexed by original point index and is not modified.
+ */
+export function sortIndicesByDepthDescending(
+  order: Uint32Array,
+  depths: Float32Array,
+  count: number,
+): void {
+  for (let i = 0; i < count; i++) order[i] = i;
+  order.subarray(0, count).sort((a, b) => depths[b] - depths[a] || a - b);
+}

--- a/packages/core/src/components/scatter-plot/webgl/renderer/label-texture-utils.test.ts
+++ b/packages/core/src/components/scatter-plot/webgl/renderer/label-texture-utils.test.ts
@@ -1,0 +1,117 @@
+import { describe, it, expect, vi } from 'vitest';
+import { fillLabelColorTexels } from './label-texture-utils';
+
+// Mock resolveColor so tests don't depend on a Canvas 2D context (unavailable in jsdom).
+// Each hex color maps to a predictable normalized RGB triple.
+vi.mock('../color-utils', () => ({
+  resolveColor: vi.fn((color: string): [number, number, number] => {
+    const map: Record<string, [number, number, number]> = {
+      '#ff0000': [1, 0, 0],
+      '#00ff00': [0, 1, 0],
+      '#0000ff': [0, 0, 1],
+      '#ffffff': [1, 1, 1],
+      '#000000': [0, 0, 0],
+    };
+    return map[color] ?? [0.5, 0.5, 0.5];
+  }),
+}));
+
+const MAX_LABELS = 8;
+
+function makeData(slots: number): Uint8Array {
+  return new Uint8Array(slots * MAX_LABELS * 4); // initialized to 0
+}
+
+describe('fillLabelColorTexels', () => {
+  it('0 colors → no bytes written', () => {
+    const data = makeData(4);
+    fillLabelColorTexels(data, 0, [], MAX_LABELS);
+    expect(data.every((b) => b === 0)).toBe(true);
+  });
+
+  it('1 color (single-label) → no bytes written (dead-slot optimization)', () => {
+    const data = makeData(4);
+    fillLabelColorTexels(data, 0, ['#ff0000'], MAX_LABELS);
+    // Single-label points use v_color in the shader; texture is never sampled.
+    expect(data.every((b) => b === 0)).toBe(true);
+  });
+
+  it('2 colors → texels for slices 0 and 1 written; slice 2 region untouched', () => {
+    const data = makeData(4);
+    fillLabelColorTexels(data, 0, ['#ff0000', '#00ff00'], MAX_LABELS);
+
+    // slice 0 → [255, 0, 0, 255]
+    expect(data[0]).toBe(255);
+    expect(data[1]).toBe(0);
+    expect(data[2]).toBe(0);
+    expect(data[3]).toBe(255);
+
+    // slice 1 → [0, 255, 0, 255]
+    expect(data[4]).toBe(0);
+    expect(data[5]).toBe(255);
+    expect(data[6]).toBe(0);
+    expect(data[7]).toBe(255);
+
+    // slice 2 region (bytes 8–11) must remain 0
+    expect(data[8]).toBe(0);
+    expect(data[9]).toBe(0);
+    expect(data[10]).toBe(0);
+    expect(data[11]).toBe(0);
+  });
+
+  it('more colors than maxLabels → only maxLabels slices written', () => {
+    const smallMax = 4;
+    // data sized for idx 0..1 with smallMax slots each
+    const data = new Uint8Array(2 * smallMax * 4);
+    const colors = ['#ff0000', '#00ff00', '#0000ff', '#ffffff', '#000000']; // 5 > smallMax=4
+    fillLabelColorTexels(data, 0, colors, smallMax);
+
+    // Exactly 4 slices filled (smallMax), 5th not written
+    // slice 3 → #ffffff → [255, 255, 255, 255]
+    const base3 = 3 * 4;
+    expect(data[base3]).toBe(255);
+    expect(data[base3 + 1]).toBe(255);
+    expect(data[base3 + 2]).toBe(255);
+    expect(data[base3 + 3]).toBe(255);
+
+    // No bytes beyond index 0..smallMax*4-1 should be non-zero
+    for (let i = smallMax * 4; i < data.length; i++) {
+      expect(data[i]).toBe(0);
+    }
+  });
+
+  it('idx offset correct: idx=2 writes start at byte 2 * maxLabels * 4; idx 0/1 untouched', () => {
+    const data = makeData(4); // 4 point slots
+    fillLabelColorTexels(data, 2, ['#ff0000', '#0000ff'], MAX_LABELS);
+
+    // idx 0 and idx 1 regions must be all zero
+    for (let i = 0; i < 2 * MAX_LABELS * 4; i++) {
+      expect(data[i]).toBe(0);
+    }
+
+    const base = 2 * MAX_LABELS * 4;
+
+    // idx 2, slice 0 → [255, 0, 0, 255]
+    expect(data[base]).toBe(255);
+    expect(data[base + 1]).toBe(0);
+    expect(data[base + 2]).toBe(0);
+    expect(data[base + 3]).toBe(255);
+
+    // idx 2, slice 1 → [0, 0, 255, 255]
+    expect(data[base + 4]).toBe(0);
+    expect(data[base + 5]).toBe(0);
+    expect(data[base + 6]).toBe(255);
+    expect(data[base + 7]).toBe(255);
+  });
+
+  it('bounds: small buffer where idx would overflow → no throw, no out-of-range writes', () => {
+    // Only enough room for 1 point slot with MAX_LABELS texels
+    const data = new Uint8Array(MAX_LABELS * 4);
+    // idx=1 would start at byte MAX_LABELS*4, which is exactly data.length → all guarded
+    expect(() => {
+      fillLabelColorTexels(data, 1, ['#ff0000', '#00ff00'], MAX_LABELS);
+    }).not.toThrow();
+    // The existing slot 0 bytes must remain 0 (idx 1 guard skipped all writes)
+    expect(data.every((b) => b === 0)).toBe(true);
+  });
+});

--- a/packages/core/src/components/scatter-plot/webgl/renderer/label-texture-utils.ts
+++ b/packages/core/src/components/scatter-plot/webgl/renderer/label-texture-utils.ts
@@ -1,0 +1,32 @@
+import { resolveColor } from '../color-utils';
+
+/**
+ * Fill the per-point label-color texels used for multi-label "pie" rendering.
+ *
+ * Single-label points (and 0-label) are colored directly from the per-point color buffer
+ * in the shader and NEVER sample the label texture, so we skip them entirely. For
+ * multi-label points we write only the actual label slices (`0..count-1`, capped at
+ * `maxLabels`), not all `maxLabels` slots.
+ *
+ * Texture layout: each point owns `maxLabels` RGBA texels at byte offset
+ * `idx * maxLabels * 4`. Bytes are 0..255 (RGBA8); the shader normalizes on sample.
+ */
+export function fillLabelColorTexels(
+  labelColorData: Uint8Array,
+  idx: number,
+  pointColors: readonly string[],
+  maxLabels: number,
+): void {
+  if (pointColors.length <= 1) return; // single-label points use v_color; texels unused
+  const count = Math.min(pointColors.length, maxLabels);
+  for (let j = 0; j < count; j++) {
+    const [lr, lg, lb] = resolveColor(pointColors[j]);
+    const texIndex = (idx * maxLabels + j) * 4;
+    if (texIndex < labelColorData.length) {
+      labelColorData[texIndex] = Math.round(lr * 255);
+      labelColorData[texIndex + 1] = Math.round(lg * 255);
+      labelColorData[texIndex + 2] = Math.round(lb * 255);
+      labelColorData[texIndex + 3] = 255;
+    }
+  }
+}

--- a/packages/core/src/components/scatter-plot/webgl/renderer/webgl-renderer.ts
+++ b/packages/core/src/components/scatter-plot/webgl/renderer/webgl-renderer.ts
@@ -20,6 +20,7 @@ import {
 } from '../types';
 import { resolveColor } from '../color-utils';
 import { createProgramFromSources } from '../shader-utils';
+import { fillLabelColorTexels } from './label-texture-utils';
 
 // ============================================================================
 // Shader Sources
@@ -270,6 +271,7 @@ export class WebGLRenderer {
 
   // State
   private capacity = 0;
+  private labelTextureInitialized = false;
 
   private currentPointCount = 0;
   private positionsDirty = true;
@@ -1276,19 +1278,8 @@ export class WebGLRenderer {
       labelCounts[idx] = pointColors.length;
       shapes[idx] = shapeIndex;
 
-      // Fill label color texture data
-      for (let j = 0; j < MAX_LABELS; j++) {
-        if (j < pointColors.length) {
-          const [lr, lg, lb] = resolveColor(pointColors[j]);
-          const texIndex = (idx * MAX_LABELS + j) * 4;
-          if (texIndex < labelColorData.length) {
-            labelColorData[texIndex] = Math.round(lr * 255);
-            labelColorData[texIndex + 1] = Math.round(lg * 255);
-            labelColorData[texIndex + 2] = Math.round(lb * 255);
-            labelColorData[texIndex + 3] = 255;
-          }
-        }
-      }
+      // Fill label color texture data (skips single-label points; see fillLabelColorTexels)
+      fillLabelColorTexels(labelColorData, idx, pointColors, MAX_LABELS);
 
       idx++;
     }
@@ -1495,6 +1486,7 @@ export class WebGLRenderer {
     this.shapeBuffer = gl.createBuffer();
     this.quadBuffer = gl.createBuffer();
     this.labelColorTexture = gl.createTexture();
+    this.labelTextureInitialized = false;
 
     this.createPointVAO();
 
@@ -1564,6 +1556,7 @@ export class WebGLRenderer {
     this.labelCountBuffer = null;
     this.shapeBuffer = null;
     this.labelColorTexture = null;
+    this.labelTextureInitialized = false;
     this.gammaPipelineAvailable = true;
     this.warnedGammaFallback = false;
     this.buffersInitialized = false;
@@ -1874,20 +1867,8 @@ export class WebGLRenderer {
         this.labelCounts[idx] = pointColors.length;
         this.shapes[idx] = shapeIndex;
 
-        // Fill label color texture data
-        for (let j = 0; j < MAX_LABELS; j++) {
-          if (j < pointColors.length) {
-            const [lr, lg, lb] = resolveColor(pointColors[j]);
-            const texIndex = (idx * MAX_LABELS + j) * 4;
-            if (texIndex < this.labelColorData.length) {
-              // RGBA8 texture: store 0..255 bytes. Sampling returns normalized floats automatically.
-              this.labelColorData[texIndex] = Math.round(lr * 255);
-              this.labelColorData[texIndex + 1] = Math.round(lg * 255);
-              this.labelColorData[texIndex + 2] = Math.round(lb * 255);
-              this.labelColorData[texIndex + 3] = 255;
-            }
-          }
-        }
+        // Fill label color texture data (skips single-label points; see fillLabelColorTexels)
+        fillLabelColorTexels(this.labelColorData, idx, pointColors, MAX_LABELS);
 
         idx++;
       }
@@ -1919,19 +1900,8 @@ export class WebGLRenderer {
         this.labelCounts[idx] = pointColors.length;
         this.shapes[idx] = shapeIndex;
 
-        // Fill label color texture data
-        for (let j = 0; j < MAX_LABELS; j++) {
-          if (j < pointColors.length) {
-            const [lr, lg, lb] = resolveColor(pointColors[j]);
-            const texIndex = (idx * MAX_LABELS + j) * 4;
-            if (texIndex < this.labelColorData.length) {
-              this.labelColorData[texIndex] = Math.round(lr * 255);
-              this.labelColorData[texIndex + 1] = Math.round(lg * 255);
-              this.labelColorData[texIndex + 2] = Math.round(lb * 255);
-              this.labelColorData[texIndex + 3] = 255;
-            }
-          }
-        }
+        // Fill label color texture data (skips single-label points; see fillLabelColorTexels)
+        fillLabelColorTexels(this.labelColorData, idx, pointColors, MAX_LABELS);
 
         idx++;
       }
@@ -1973,22 +1943,38 @@ export class WebGLRenderer {
       this.updateBuffer(gl, this.labelCountBuffer, this.labelCounts, idx);
       this.updateBuffer(gl, this.shapeBuffer, this.shapes, idx);
 
-      // Update texture
+      // Update label-color texture. Allocate storage once (and whenever capacity grew);
+      // afterwards update in place with texSubImage2D — no 32 MiB reallocation per recolor.
       gl.bindTexture(gl.TEXTURE_2D, this.labelColorTexture);
       const texHeight = this.labelColorData.length / 4 / LABEL_TEXTURE_WIDTH;
-      gl.texImage2D(
-        gl.TEXTURE_2D,
-        0,
-        gl.RGBA8,
-        LABEL_TEXTURE_WIDTH,
-        texHeight,
-        0,
-        gl.RGBA,
-        gl.UNSIGNED_BYTE,
-        this.labelColorData,
-      );
-      gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.NEAREST);
-      gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.NEAREST);
+      if (!this.labelTextureInitialized) {
+        gl.texImage2D(
+          gl.TEXTURE_2D,
+          0,
+          gl.RGBA8,
+          LABEL_TEXTURE_WIDTH,
+          texHeight,
+          0,
+          gl.RGBA,
+          gl.UNSIGNED_BYTE,
+          this.labelColorData,
+        );
+        gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.NEAREST);
+        gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.NEAREST);
+        this.labelTextureInitialized = true;
+      } else {
+        gl.texSubImage2D(
+          gl.TEXTURE_2D,
+          0,
+          0,
+          0,
+          LABEL_TEXTURE_WIDTH,
+          texHeight,
+          gl.RGBA,
+          gl.UNSIGNED_BYTE,
+          this.labelColorData,
+        );
+      }
       gl.bindTexture(gl.TEXTURE_2D, null);
     }
 
@@ -2027,6 +2013,7 @@ export class WebGLRenderer {
     const requiredPixels = nextCapacity * MAX_LABELS;
     const texHeight = Math.ceil(requiredPixels / LABEL_TEXTURE_WIDTH);
     this.labelColorData = new Uint8Array(LABEL_TEXTURE_WIDTH * texHeight * 4);
+    this.labelTextureInitialized = false;
 
     this.buffersInitialized = false;
   }

--- a/packages/core/src/components/scatter-plot/webgl/renderer/webgl-renderer.ts
+++ b/packages/core/src/components/scatter-plot/webgl/renderer/webgl-renderer.ts
@@ -21,6 +21,7 @@ import {
 import { resolveColor } from '../color-utils';
 import { createProgramFromSources } from '../shader-utils';
 import { fillLabelColorTexels } from './label-texture-utils';
+import { sortIndicesByDepthDescending } from './depth-sort';
 
 // ============================================================================
 // Shader Sources
@@ -285,9 +286,13 @@ export class WebGLRenderer {
   // Store last rendered points for off-screen export rendering
   private lastRenderedPoints: PlotDataPoint[] | null = null;
 
-  // Cached sorted point order from last full rebuild. Used by the color-only
-  // update path so it iterates points in the same order as the position buffer.
-  private sortedPoints: PlotDataPoint[] = [];
+  // Reusable index-sort scratch (avoids per-render object staging + a retained mapped array).
+  // `sortOrder[0..currentPointCount)` holds point indices in far->near draw order; it indexes
+  // into `sortedPointsRef` (the points array from the last full rebuild). `sortDepths` is the
+  // per-point depth scratch, indexed by ORIGINAL point index.
+  private sortOrder = new Uint32Array(0);
+  private sortDepths = new Float32Array(0);
+  private sortedPointsRef: PlotDataPoint[] | null = null;
 
   // Selection-aware two-pass rendering
   private selectionActive = false;
@@ -434,7 +439,7 @@ export class WebGLRenderer {
    */
   releaseDataReferences() {
     this.lastRenderedPoints = null;
-    this.sortedPoints = [];
+    this.sortedPointsRef = null;
   }
 
   resize(width: number, height: number) {
@@ -1566,7 +1571,7 @@ export class WebGLRenderer {
     this.lastDataSignature = null;
     this.lastStyleSignature = null;
     this.renderedPointIds.clear();
-    this.sortedPoints = [];
+    this.sortedPointsRef = null;
   }
 
   private initializePointShaders(gl: WebGL2RenderingContext): boolean {
@@ -1813,35 +1818,30 @@ export class WebGLRenderer {
     let idx = 0;
 
     if (needsReorder) {
-      const staged: Array<{ point: PlotDataPoint; opacity: number; depth: number }> = [];
-      for (let i = 0; i < points.length && staged.length < maxPoints; i++) {
-        const point = points[i];
-        const opacity = this.style.getOpacity(point);
-        // Include hidden points (opacity=0) in the buffer with alpha=0.
-        // This preserves sort order across visibility toggles, enabling the
-        // fast color-only update path instead of a full rebuild + re-sort.
-        const depth = this.style.getDepth(point);
-        staged.push({ point, opacity, depth });
-      }
+      const count = maxPoints;
+      const order = this.sortOrder;
+      const depthScratch = this.sortDepths;
 
-      // Draw far -> near, so near points end up on top.
-      // NOTE: `getDepth` is defined such that smaller depth is "closer" (wins in LESS mode).
-      staged.sort((a, b) => b.depth - a.depth);
+      // Build depth scratch indexed by original point index, then sort indices far -> near.
+      // Include hidden points (opacity=0) so sort order is preserved across visibility toggles,
+      // enabling the fast color-only update path instead of a full rebuild + re-sort.
+      for (let i = 0; i < count; i++) {
+        depthScratch[i] = this.style.getDepth(points[i]);
+      }
+      sortIndicesByDepthDescending(order, depthScratch, count);
 
       // Find where selected points start (opacity ≈ 1.0, contiguous at the end after sort).
       // Used for two-pass rendering: unselected without blend, selected with blend.
-      if (this.selectionActive) {
-        const idx = staged.findIndex((s) => s.opacity >= 0.99);
-        this.selectedStartIndex = idx === -1 ? staged.length : idx;
-      } else {
-        this.selectedStartIndex = staged.length;
-      }
+      let firstSelected = -1;
 
-      // Cache sorted point order for the color-only update path
-      this.sortedPoints = staged.map((s) => s.point);
+      for (let k = 0; k < count; k++) {
+        const srcIndex = order[k];
+        const point = points[srcIndex];
+        const opacity = this.style.getOpacity(point);
 
-      for (let s = 0; s < staged.length; s++) {
-        const { point, opacity, depth } = staged[s];
+        if (this.selectionActive && firstSelected === -1 && opacity >= 0.99) {
+          firstSelected = k;
+        }
 
         if (this.trackRenderedPointIds && opacity > 0) {
           this.renderedPointIds.add(point.id);
@@ -1863,7 +1863,8 @@ export class WebGLRenderer {
         this.colors[idx * 4 + 3] = Math.min(1, Math.max(0, opacity));
         const basePointSize = Math.max(MIN_POINT_SIZE, size * 2 * this.dpr);
         this.sizes[idx] = shapeIndex === 2 ? basePointSize * DIAMOND_SIZE_SCALE : basePointSize;
-        this.depths[idx] = depth;
+        // Use depthScratch[srcIndex] (indexed by original point index), NOT depthScratch[k].
+        this.depths[idx] = depthScratch[srcIndex];
         this.labelCounts[idx] = pointColors.length;
         this.shapes[idx] = shapeIndex;
 
@@ -1872,59 +1873,73 @@ export class WebGLRenderer {
 
         idx++;
       }
+
+      this.selectedStartIndex = this.selectionActive
+        ? firstSelected === -1
+          ? count
+          : firstSelected
+        : count;
+      // Cache the points reference so color-only / positions-only paths can index via sortOrder.
+      this.sortedPointsRef = points;
     } else if (updateStyles) {
       // Color-only update: no reordering needed, just update color/shape buffers.
-      // Iterate sortedPoints to match the buffer order from the last full rebuild.
-      const source = this.sortedPoints;
-      for (let i = 0; i < source.length && idx < maxPoints; i++) {
-        const point = source[i];
-        const opacity = this.style.getOpacity(point);
+      // Iterate via sortOrder into sortedPointsRef to match the buffer order from the last rebuild.
+      const order = this.sortOrder;
+      const src = this.sortedPointsRef;
+      if (src) {
+        for (let i = 0; i < this.currentPointCount && idx < maxPoints; i++) {
+          const point = src[order[i]];
+          const opacity = this.style.getOpacity(point);
 
-        if (this.trackRenderedPointIds && opacity > 0) {
-          this.renderedPointIds.add(point.id);
+          if (this.trackRenderedPointIds && opacity > 0) {
+            this.renderedPointIds.add(point.id);
+          }
+
+          // Update only style buffers (colors, shapes, sizes)
+          const pointColors = this.style.getColors(point);
+          const [r, g, b] = resolveColor(pointColors[0] ?? '#888888');
+          const size = Math.sqrt(this.style.getPointSize(point)) / POINT_SIZE_DIVISOR;
+          const shapeType = this.style.getShape(point);
+          const shapeIndex = getShapeIndex(shapeType);
+
+          this.colors[idx * 4] = r;
+          this.colors[idx * 4 + 1] = g;
+          this.colors[idx * 4 + 2] = b;
+          this.colors[idx * 4 + 3] = Math.min(1, Math.max(0, opacity));
+          const basePointSize = Math.max(MIN_POINT_SIZE, size * 2 * this.dpr);
+          this.sizes[idx] = shapeIndex === 2 ? basePointSize * DIAMOND_SIZE_SCALE : basePointSize;
+          this.labelCounts[idx] = pointColors.length;
+          this.shapes[idx] = shapeIndex;
+
+          // Fill label color texture data (skips single-label points; see fillLabelColorTexels)
+          fillLabelColorTexels(this.labelColorData, idx, pointColors, MAX_LABELS);
+
+          idx++;
         }
-
-        // Update only style buffers (colors, shapes, sizes)
-        const pointColors = this.style.getColors(point);
-        const [r, g, b] = resolveColor(pointColors[0] ?? '#888888');
-        const size = Math.sqrt(this.style.getPointSize(point)) / POINT_SIZE_DIVISOR;
-        const shapeType = this.style.getShape(point);
-        const shapeIndex = getShapeIndex(shapeType);
-
-        this.colors[idx * 4] = r;
-        this.colors[idx * 4 + 1] = g;
-        this.colors[idx * 4 + 2] = b;
-        this.colors[idx * 4 + 3] = Math.min(1, Math.max(0, opacity));
-        const basePointSize = Math.max(MIN_POINT_SIZE, size * 2 * this.dpr);
-        this.sizes[idx] = shapeIndex === 2 ? basePointSize * DIAMOND_SIZE_SCALE : basePointSize;
-        this.labelCounts[idx] = pointColors.length;
-        this.shapes[idx] = shapeIndex;
-
-        // Fill label color texture data (skips single-label points; see fillLabelColorTexels)
-        fillLabelColorTexels(this.labelColorData, idx, pointColors, MAX_LABELS);
-
-        idx++;
       }
     } else {
       // No reordering and no style updates: only update positions if needed.
-      // Iterate sortedPoints to match the buffer order from the last full rebuild.
-      const source = this.sortedPoints;
-      for (let i = 0; i < source.length && idx < maxPoints; i++) {
-        const point = source[i];
+      // Iterate via sortOrder into sortedPointsRef to match the buffer order from the last rebuild.
+      const order = this.sortOrder;
+      const src = this.sortedPointsRef;
+      if (src) {
+        for (let i = 0; i < this.currentPointCount && idx < maxPoints; i++) {
+          const point = src[order[i]];
 
-        if (this.trackRenderedPointIds) {
-          const opacity = this.style.getOpacity(point);
-          if (opacity > 0) {
-            this.renderedPointIds.add(point.id);
+          if (this.trackRenderedPointIds) {
+            const opacity = this.style.getOpacity(point);
+            if (opacity > 0) {
+              this.renderedPointIds.add(point.id);
+            }
           }
-        }
 
-        if (updatePositions) {
-          this.dataPositions[idx * 2] = scales.x(point.x);
-          this.dataPositions[idx * 2 + 1] = scales.y(point.y);
-        }
+          if (updatePositions) {
+            this.dataPositions[idx * 2] = scales.x(point.x);
+            this.dataPositions[idx * 2 + 1] = scales.y(point.y);
+          }
 
-        idx++;
+          idx++;
+        }
       }
     }
 
@@ -2006,6 +2021,8 @@ export class WebGLRenderer {
     this.depths = new Float32Array(nextCapacity);
     this.labelCounts = new Float32Array(nextCapacity);
     this.shapes = new Float32Array(nextCapacity);
+    this.sortOrder = new Uint32Array(nextCapacity);
+    this.sortDepths = new Float32Array(nextCapacity);
     // Align texture height to next power of 2 or just simple expansion
     // Total pixels needed = nextCapacity * MAX_LABELS
     // Texture Width = LABEL_TEXTURE_WIDTH

--- a/packages/core/src/components/scatter-plot/webgl/renderer/webgl-renderer.ts
+++ b/packages/core/src/components/scatter-plot/webgl/renderer/webgl-renderer.ts
@@ -22,6 +22,7 @@ import { resolveColor } from '../color-utils';
 import { createProgramFromSources } from '../shader-utils';
 import { fillLabelColorTexels } from './label-texture-utils';
 import { sortIndicesByDepthDescending } from './depth-sort';
+import { planRendererCapacity } from './capacity-planner';
 
 // ============================================================================
 // Shader Sources
@@ -33,6 +34,7 @@ const MIN_POINT_SIZE = 1;
 const MIN_CAPACITY = 1024;
 const MAX_LABELS = 8;
 const LABEL_TEXTURE_WIDTH = 2048;
+const POINTS_PER_TEXTURE_ROW = LABEL_TEXTURE_WIDTH / MAX_LABELS;
 const DIAMOND_SIZE_SCALE = 1.25;
 
 // Stable reference dimensions for margin scaling at export time. Tying margin
@@ -2013,7 +2015,12 @@ export class WebGLRenderer {
   }
 
   private expandCapacity(minCapacity: number) {
-    const nextCapacity = Math.pow(2, Math.ceil(Math.log2(Math.max(minCapacity, MIN_CAPACITY))));
+    const nextCapacity = planRendererCapacity(
+      minCapacity,
+      this.capacity,
+      MIN_CAPACITY,
+      POINTS_PER_TEXTURE_ROW,
+    );
     this.capacity = nextCapacity;
     this.dataPositions = new Float32Array(nextCapacity * 2);
     this.colors = new Float32Array(nextCapacity * 4);

--- a/packages/core/src/components/scatter-plot/webgl/renderer/webgl-renderer.ts
+++ b/packages/core/src/components/scatter-plot/webgl/renderer/webgl-renderer.ts
@@ -9,8 +9,8 @@
  */
 
 import * as d3 from 'd3';
-import type { PlotDataPoint, ScatterplotConfig } from '@protspace/utils';
-import { getShapeIndex } from '@protspace/utils';
+import type { PlotData, PlotDataPoint, ScatterplotConfig } from '@protspace/utils';
+import { getShapeIndex, EMPTY_PLOT_DATA } from '@protspace/utils';
 import {
   type WebGLStyleGetters,
   type ScalePair,
@@ -285,16 +285,19 @@ export class WebGLRenderer {
   private depthOrderDirty = false;
   private buffersInitialized = false;
 
-  // Store last rendered points for off-screen export rendering
-  private lastRenderedPoints: PlotDataPoint[] | null = null;
+  // Store last rendered data for off-screen export rendering
+  private lastRenderedData: PlotData | null = null;
 
   // Reusable index-sort scratch (avoids per-render object staging + a retained mapped array).
-  // `sortOrder[0..currentPointCount)` holds point indices in far->near draw order; it indexes
-  // into `sortedPointsRef` (the points array from the last full rebuild). `sortDepths` is the
-  // per-point depth scratch, indexed by ORIGINAL point index.
+  // `sortOrder[0..currentPointCount)` holds slot indices in far->near draw order; it indexes
+  // into `sortedDataRef` (the PlotData from the last full rebuild). `sortDepths` is the
+  // per-slot depth scratch, indexed by ORIGINAL slot index.
   private sortOrder = new Uint32Array(0);
   private sortDepths = new Float32Array(0);
-  private sortedPointsRef: PlotDataPoint[] | null = null;
+  private sortedDataRef: PlotData | null = null;
+
+  // Single reused scratch point for the hot loop — populated per slot, passed to style getters.
+  private scratchPoint: PlotDataPoint = { id: '', x: 0, y: 0, originalIndex: 0 };
 
   // Selection-aware two-pass rendering
   private selectionActive = false;
@@ -322,10 +325,10 @@ export class WebGLRenderer {
   private readonly handleContextRestored = () => {
     this.contextLost = false;
     this.resetRendererState();
-    if (this.lastRenderedPoints && this.lastRenderedPoints.length > 0) {
+    if (this.lastRenderedData && this.lastRenderedData.length > 0) {
       requestAnimationFrame(() => {
         if (!this.contextLost) {
-          this.render(this.lastRenderedPoints ?? []);
+          this.render(this.lastRenderedData ?? EMPTY_PLOT_DATA);
         }
       });
     }
@@ -436,12 +439,12 @@ export class WebGLRenderer {
   }
 
   /**
-   * Release references to PlotDataPoint arrays so GC can reclaim old data
+   * Release references to PlotData so GC can reclaim old data
    * before a new dataset is allocated. Call before processing a new dataset.
    */
   releaseDataReferences() {
-    this.lastRenderedPoints = null;
-    this.sortedPointsRef = null;
+    this.lastRenderedData = null;
+    this.sortedDataRef = null;
   }
 
   resize(width: number, height: number) {
@@ -587,9 +590,9 @@ export class WebGLRenderer {
     this.currentPointCount = 0;
   }
 
-  render(points: PlotDataPoint[]) {
-    // Store points for potential off-screen export rendering
-    this.lastRenderedPoints = points;
+  render(pd: PlotData) {
+    // Store PlotData for potential off-screen export rendering
+    this.lastRenderedData = pd;
 
     const gl = this.ensureGL();
     const scales = this.getScales();
@@ -602,15 +605,15 @@ export class WebGLRenderer {
 
     const transform = this.getTransform();
 
-    const dataSignature = this.computeDataSignature(points);
-    const styleSignature = this.computeStyleSignature(points);
+    const dataSignature = this.computeDataSignature(pd);
+    const styleSignature = this.computeStyleSignature(pd);
 
     const needsPositionUpdate = this.positionsDirty || dataSignature !== this.lastDataSignature;
     const needsStyleUpdate = this.stylesDirty || styleSignature !== this.lastStyleSignature;
     const needsDepthOrderUpdate = this.depthOrderDirty;
 
     if (needsPositionUpdate || needsStyleUpdate || needsDepthOrderUpdate) {
-      this.populateBuffers(points, scales, needsPositionUpdate, needsStyleUpdate);
+      this.populateBuffers(pd, scales, needsPositionUpdate, needsStyleUpdate);
       this.lastDataSignature = dataSignature;
       this.lastStyleSignature = styleSignature;
       this.positionsDirty = false;
@@ -778,14 +781,14 @@ export class WebGLRenderer {
       );
     }
 
-    // Ensure we have points to render
-    const points = this.lastRenderedPoints;
-    if (!points || points.length === 0) {
+    // Ensure we have data to render
+    const pd = this.lastRenderedData;
+    if (!pd || pd.length === 0) {
       throw new Error('No points available to render. Call render() first.');
     }
 
     // Create scales for export dimensions
-    const exportScales = this.createExportScales(points, physicalWidth, physicalHeight, dataDomain);
+    const exportScales = this.createExportScales(pd, physicalWidth, physicalHeight, dataDomain);
     if (!exportScales) {
       throw new Error('Could not create scales for export rendering');
     }
@@ -814,7 +817,7 @@ export class WebGLRenderer {
         gl,
         physicalWidth,
         physicalHeight,
-        points,
+        pd,
         exportScales,
         dpr,
         pointSizeReference,
@@ -847,12 +850,12 @@ export class WebGLRenderer {
    * Scales the margin proportionally to maintain visual consistency.
    */
   private createExportScales(
-    points: PlotDataPoint[],
+    pd: PlotData,
     exportWidth: number,
     exportHeight: number,
     dataDomain?: { xMin: number; xMax: number; yMin: number; yMax: number },
   ): ScalePair | null {
-    if (points.length === 0) return null;
+    if (pd.length === 0) return null;
 
     const config = this.getConfig();
 
@@ -893,11 +896,12 @@ export class WebGLRenderer {
         xMax = -Infinity,
         yMin = Infinity,
         yMax = -Infinity;
-      for (const p of points) {
-        if (p.x < xMin) xMin = p.x;
-        if (p.x > xMax) xMax = p.x;
-        if (p.y < yMin) yMin = p.y;
-        if (p.y > yMax) yMax = p.y;
+      const { xs, ys, length } = pd;
+      for (let i = 0; i < length; i++) {
+        if (xs[i] < xMin) xMin = xs[i];
+        if (xs[i] > xMax) xMax = xs[i];
+        if (ys[i] < yMin) yMin = ys[i];
+        if (ys[i] > yMax) yMax = ys[i];
       }
       const padding = 0.05;
       const xPadding = Math.abs(xMax - xMin) * padding;
@@ -951,17 +955,18 @@ export class WebGLRenderer {
    * source rects (in normalized canvas coords) into data-coordinate viewports.
    */
   public getDataExtent(): { xMin: number; xMax: number; yMin: number; yMax: number } | null {
-    const points = this.lastRenderedPoints;
-    if (!points || points.length === 0) return null;
+    const pd = this.lastRenderedData;
+    if (!pd || pd.length === 0) return null;
     let xMin = Infinity,
       xMax = -Infinity,
       yMin = Infinity,
       yMax = -Infinity;
-    for (const p of points) {
-      if (p.x < xMin) xMin = p.x;
-      if (p.x > xMax) xMax = p.x;
-      if (p.y < yMin) yMin = p.y;
-      if (p.y > yMax) yMax = p.y;
+    const { xs, ys, length } = pd;
+    for (let i = 0; i < length; i++) {
+      if (xs[i] < xMin) xMin = xs[i];
+      if (xs[i] > xMax) xMax = xs[i];
+      if (ys[i] < yMin) yMin = ys[i];
+      if (ys[i] > yMax) yMax = ys[i];
     }
     return { xMin, xMax, yMin, yMax };
   }
@@ -973,7 +978,7 @@ export class WebGLRenderer {
     gl: WebGL2RenderingContext,
     width: number,
     height: number,
-    points: PlotDataPoint[],
+    pd: PlotData,
     scales: ScalePair,
     dpr: number,
     pointSizeReference?: { width: number; height: number },
@@ -1031,7 +1036,7 @@ export class WebGLRenderer {
     };
 
     // Prepare point data using existing CPU arrays (reuse from main renderer)
-    const maxPoints = Math.min(points.length, MAX_POINTS_DIRECT_RENDER);
+    const maxPoints = Math.min(pd.length, MAX_POINTS_DIRECT_RENDER);
 
     // Populate buffers for off-screen rendering
     const {
@@ -1043,7 +1048,7 @@ export class WebGLRenderer {
       shapes,
       labelColorData,
       pointCount,
-    } = this.prepareOffscreenBufferData(points, scales, maxPoints, dpr, sizeScaleFactor);
+    } = this.prepareOffscreenBufferData(pd, scales, maxPoints, dpr, sizeScaleFactor);
 
     // Create and upload buffers
     const dataPositionBuffer = gl.createBuffer();
@@ -1224,7 +1229,7 @@ export class WebGLRenderer {
    * Prepare buffer data for off-screen rendering
    */
   private prepareOffscreenBufferData(
-    points: PlotDataPoint[],
+    pd: PlotData,
     scales: ScalePair,
     maxPoints: number,
     dpr: number,
@@ -1250,28 +1255,40 @@ export class WebGLRenderer {
     const texHeight = Math.ceil(requiredPixels / LABEL_TEXTURE_WIDTH);
     const labelColorData = new Uint8Array(LABEL_TEXTURE_WIDTH * texHeight * 4);
 
-    // Stage and sort points by depth (painter's algorithm)
-    const staged: Array<{ point: PlotDataPoint; opacity: number; depth: number }> = [];
-    for (let i = 0; i < points.length && staged.length < maxPoints; i++) {
-      const point = points[i];
-      const opacity = this.style.getOpacity(point);
+    // Stage slots by depth (painter's algorithm) — use a temp scratch point per slot.
+    const { xs, ys } = pd;
+    const oi = pd.originalIndices;
+    const sp: PlotDataPoint = { id: '', x: 0, y: 0, originalIndex: 0 };
+    const staged: Array<{ slot: number; opacity: number; depth: number }> = [];
+    for (let i = 0; i < pd.length && staged.length < maxPoints; i++) {
+      const origIdx = oi ? oi[i] : i;
+      sp.id = pd.proteinIds[origIdx];
+      sp.x = xs[i];
+      sp.y = ys[i];
+      sp.originalIndex = origIdx;
+      const opacity = this.style.getOpacity(sp);
       if (opacity === 0) continue;
-      const depth = this.style.getDepth(point);
-      staged.push({ point, opacity, depth });
+      const depth = this.style.getDepth(sp);
+      staged.push({ slot: i, opacity, depth });
     }
     staged.sort((a, b) => b.depth - a.depth);
 
     let idx = 0;
     for (let s = 0; s < staged.length; s++) {
-      const { point, opacity, depth } = staged[s];
+      const { slot, opacity, depth } = staged[s];
+      const origIdx = oi ? oi[slot] : slot;
+      sp.id = pd.proteinIds[origIdx];
+      sp.x = xs[slot];
+      sp.y = ys[slot];
+      sp.originalIndex = origIdx;
 
-      dataPositions[idx * 2] = scales.x(point.x);
-      dataPositions[idx * 2 + 1] = scales.y(point.y);
+      dataPositions[idx * 2] = scales.x(xs[slot]);
+      dataPositions[idx * 2 + 1] = scales.y(ys[slot]);
 
-      const pointColors = this.style.getColors(point);
+      const pointColors = this.style.getColors(sp);
       const [r, g, b] = resolveColor(pointColors[0] ?? '#888888');
-      const size = Math.sqrt(this.style.getPointSize(point)) / POINT_SIZE_DIVISOR;
-      const shapeType = this.style.getShape(point);
+      const size = Math.sqrt(this.style.getPointSize(sp)) / POINT_SIZE_DIVISOR;
+      const shapeType = this.style.getShape(sp);
       const shapeIndex = getShapeIndex(shapeType);
 
       colors[idx * 4] = r;
@@ -1573,7 +1590,7 @@ export class WebGLRenderer {
     this.lastDataSignature = null;
     this.lastStyleSignature = null;
     this.renderedPointIds.clear();
-    this.sortedPointsRef = null;
+    this.sortedDataRef = null;
   }
 
   private initializePointShaders(gl: WebGL2RenderingContext): boolean {
@@ -1732,35 +1749,45 @@ export class WebGLRenderer {
   // Buffer Management
   // ============================================================================
 
-  private computeDataSignature(points: PlotDataPoint[]): string {
-    if (points.length === 0) return 'empty';
-    const len = points.length;
-    const s1 = points[0];
-    const s2 = points[Math.floor(len / 2)];
-    const s3 = points[len - 1];
-    return `${len}|${s1.x.toFixed(2)},${s1.y.toFixed(2)}|${s2.x.toFixed(2)},${s2.y.toFixed(2)}|${s3.x.toFixed(2)},${s3.y.toFixed(2)}`;
+  private computeDataSignature(pd: PlotData): string {
+    if (pd.length === 0) return 'empty';
+    const len = pd.length;
+    const s0 = 0;
+    const s1 = Math.floor(len / 2);
+    const s2 = len - 1;
+    return (
+      `${len}|${pd.xs[s0].toFixed(2)},${pd.ys[s0].toFixed(2)}` +
+      `|${pd.xs[s1].toFixed(2)},${pd.ys[s1].toFixed(2)}` +
+      `|${pd.xs[s2].toFixed(2)},${pd.ys[s2].toFixed(2)}`
+    );
   }
 
-  private computeStyleSignature(points: PlotDataPoint[]): string {
-    if (points.length === 0) return 'empty';
+  private computeStyleSignature(pd: PlotData): string {
+    if (pd.length === 0) return 'empty';
 
-    const len = points.length;
+    const len = pd.length;
     const indices = [0, Math.floor(len / 4), Math.floor(len / 2), len - 1];
+    const sp = this.scratchPoint;
+    const oi = pd.originalIndices;
     const parts = indices
       .filter((i) => i < len)
       .map((i) => {
-        const p = points[i];
+        const origIdx = oi ? oi[i] : i;
+        sp.id = pd.proteinIds[origIdx];
+        sp.x = pd.xs[i];
+        sp.y = pd.ys[i];
+        sp.originalIndex = origIdx;
         // Include depth to avoid missing z-order-only updates when we render via painter's algorithm.
-        return `${p.id}:${this.style.getOpacity(p).toFixed(2)}:${this.style
-          .getDepth(p)
-          .toFixed(4)}:${this.style.getColors(p)[0]}`;
+        return `${sp.id}:${this.style.getOpacity(sp).toFixed(2)}:${this.style
+          .getDepth(sp)
+          .toFixed(4)}:${this.style.getColors(sp)[0]}`;
       });
 
     return `${this.styleSignature}|${parts.join('|')}`;
   }
 
   private populateBuffers(
-    points: PlotDataPoint[],
+    pd: PlotData,
     scales: ScalePair,
     updatePositions: boolean,
     updateStyles: boolean,
@@ -1768,7 +1795,7 @@ export class WebGLRenderer {
     if (!this.gl) return;
     const gl = this.gl;
 
-    const maxPoints = Math.min(points.length, MAX_POINTS_DIRECT_RENDER);
+    const maxPoints = Math.min(pd.length, MAX_POINTS_DIRECT_RENDER);
 
     if (maxPoints > this.capacity) {
       this.expandCapacity(maxPoints);
@@ -1781,7 +1808,7 @@ export class WebGLRenderer {
     }
 
     // With depth testing disabled (to ensure overlaps are drawn), we preserve z-order using
-    // the painter's algorithm: draw far -> near. This requires reordering the points, so
+    // the painter's algorithm: draw far -> near. This requires reordering the slots, so
     // whenever styles update we must also update positions to keep all parallel buffers aligned.
     // However, if only colors changed (not depths), we can skip re-sorting and position updates.
     let needsReorder = updatePositions;
@@ -1792,16 +1819,25 @@ export class WebGLRenderer {
       updatePositions = true;
       this.depthOrderDirty = false;
     }
+
+    const sp = this.scratchPoint;
+    const oi = pd.originalIndices;
+    const { xs, ys } = pd;
+
     if (updateStyles && !updatePositions) {
-      // Check if depths have actually changed by sampling first few points
+      // Check if depths have actually changed by sampling first few slots
       // If depths are the same, we can skip re-sorting (color-only update optimization)
-      const sampleSize = Math.min(100, points.length);
+      const sampleSize = Math.min(100, pd.length);
       let depthsChanged = false;
       for (let i = 0; i < sampleSize && i < this.currentPointCount; i++) {
-        const point = points[i];
-        const opacity = this.style.getOpacity(point);
+        const origIdx = oi ? oi[i] : i;
+        sp.id = pd.proteinIds[origIdx];
+        sp.x = xs[i];
+        sp.y = ys[i];
+        sp.originalIndex = origIdx;
+        const opacity = this.style.getOpacity(sp);
         if (opacity === 0) continue;
-        const newDepth = this.style.getDepth(point);
+        const newDepth = this.style.getDepth(sp);
         // Compare with stored depth (note: depths array is in sorted order after last render)
         if (Math.abs(newDepth - this.depths[i]) > 1e-6) {
           depthsChanged = true;
@@ -1824,11 +1860,16 @@ export class WebGLRenderer {
       const order = this.sortOrder;
       const depthScratch = this.sortDepths;
 
-      // Build depth scratch indexed by original point index, then sort indices far -> near.
+      // Build depth scratch indexed by original slot index, then sort indices far -> near.
       // Include hidden points (opacity=0) so sort order is preserved across visibility toggles,
       // enabling the fast color-only update path instead of a full rebuild + re-sort.
       for (let i = 0; i < count; i++) {
-        depthScratch[i] = this.style.getDepth(points[i]);
+        const origIdx = oi ? oi[i] : i;
+        sp.id = pd.proteinIds[origIdx];
+        sp.x = xs[i];
+        sp.y = ys[i];
+        sp.originalIndex = origIdx;
+        depthScratch[i] = this.style.getDepth(sp);
       }
       sortIndicesByDepthDescending(order, depthScratch, count);
 
@@ -1837,26 +1878,30 @@ export class WebGLRenderer {
       let firstSelected = -1;
 
       for (let k = 0; k < count; k++) {
-        const srcIndex = order[k];
-        const point = points[srcIndex];
-        const opacity = this.style.getOpacity(point);
+        const srcSlot = order[k];
+        const origIdx = oi ? oi[srcSlot] : srcSlot;
+        sp.id = pd.proteinIds[origIdx];
+        sp.x = xs[srcSlot];
+        sp.y = ys[srcSlot];
+        sp.originalIndex = origIdx;
+        const opacity = this.style.getOpacity(sp);
 
         if (this.selectionActive && firstSelected === -1 && opacity >= 0.99) {
           firstSelected = k;
         }
 
         if (this.trackRenderedPointIds && opacity > 0) {
-          this.renderedPointIds.add(point.id);
+          this.renderedPointIds.add(sp.id);
         }
 
         // updatePositions is always true here (see above)
-        this.dataPositions[idx * 2] = scales.x(point.x);
-        this.dataPositions[idx * 2 + 1] = scales.y(point.y);
+        this.dataPositions[idx * 2] = scales.x(xs[srcSlot]);
+        this.dataPositions[idx * 2 + 1] = scales.y(ys[srcSlot]);
 
-        const pointColors = this.style.getColors(point);
+        const pointColors = this.style.getColors(sp);
         const [r, g, b] = resolveColor(pointColors[0] ?? '#888888');
-        const size = Math.sqrt(this.style.getPointSize(point)) / POINT_SIZE_DIVISOR;
-        const shapeType = this.style.getShape(point);
+        const size = Math.sqrt(this.style.getPointSize(sp)) / POINT_SIZE_DIVISOR;
+        const shapeType = this.style.getShape(sp);
         const shapeIndex = getShapeIndex(shapeType);
 
         this.colors[idx * 4] = r;
@@ -1865,8 +1910,8 @@ export class WebGLRenderer {
         this.colors[idx * 4 + 3] = Math.min(1, Math.max(0, opacity));
         const basePointSize = Math.max(MIN_POINT_SIZE, size * 2 * this.dpr);
         this.sizes[idx] = shapeIndex === 2 ? basePointSize * DIAMOND_SIZE_SCALE : basePointSize;
-        // Use depthScratch[srcIndex] (indexed by original point index), NOT depthScratch[k].
-        this.depths[idx] = depthScratch[srcIndex];
+        // Use depthScratch[srcSlot] (indexed by original slot), NOT depthScratch[k].
+        this.depths[idx] = depthScratch[srcSlot];
         this.labelCounts[idx] = pointColors.length;
         this.shapes[idx] = shapeIndex;
 
@@ -1881,27 +1926,35 @@ export class WebGLRenderer {
           ? count
           : firstSelected
         : count;
-      // Cache the points reference so color-only / positions-only paths can index via sortOrder.
-      this.sortedPointsRef = points;
+      // Cache the PlotData reference so color-only / positions-only paths can index via sortOrder.
+      this.sortedDataRef = pd;
     } else if (updateStyles) {
       // Color-only update: no reordering needed, just update color/shape buffers.
-      // Iterate via sortOrder into sortedPointsRef to match the buffer order from the last rebuild.
+      // Iterate via sortOrder into sortedDataRef to match the buffer order from the last rebuild.
       const order = this.sortOrder;
-      const src = this.sortedPointsRef;
+      const src = this.sortedDataRef;
       if (src) {
+        const srcOi = src.originalIndices;
+        const srcXs = src.xs;
+        const srcYs = src.ys;
         for (let i = 0; i < this.currentPointCount && idx < maxPoints; i++) {
-          const point = src[order[i]];
-          const opacity = this.style.getOpacity(point);
+          const slot = order[i];
+          const origIdx = srcOi ? srcOi[slot] : slot;
+          sp.id = src.proteinIds[origIdx];
+          sp.x = srcXs[slot];
+          sp.y = srcYs[slot];
+          sp.originalIndex = origIdx;
+          const opacity = this.style.getOpacity(sp);
 
           if (this.trackRenderedPointIds && opacity > 0) {
-            this.renderedPointIds.add(point.id);
+            this.renderedPointIds.add(sp.id);
           }
 
           // Update only style buffers (colors, shapes, sizes)
-          const pointColors = this.style.getColors(point);
+          const pointColors = this.style.getColors(sp);
           const [r, g, b] = resolveColor(pointColors[0] ?? '#888888');
-          const size = Math.sqrt(this.style.getPointSize(point)) / POINT_SIZE_DIVISOR;
-          const shapeType = this.style.getShape(point);
+          const size = Math.sqrt(this.style.getPointSize(sp)) / POINT_SIZE_DIVISOR;
+          const shapeType = this.style.getShape(sp);
           const shapeIndex = getShapeIndex(shapeType);
 
           this.colors[idx * 4] = r;
@@ -1921,23 +1974,31 @@ export class WebGLRenderer {
       }
     } else {
       // No reordering and no style updates: only update positions if needed.
-      // Iterate via sortOrder into sortedPointsRef to match the buffer order from the last rebuild.
+      // Iterate via sortOrder into sortedDataRef to match the buffer order from the last rebuild.
       const order = this.sortOrder;
-      const src = this.sortedPointsRef;
+      const src = this.sortedDataRef;
       if (src) {
+        const srcOi = src.originalIndices;
+        const srcXs = src.xs;
+        const srcYs = src.ys;
         for (let i = 0; i < this.currentPointCount && idx < maxPoints; i++) {
-          const point = src[order[i]];
+          const slot = order[i];
+          const origIdx = srcOi ? srcOi[slot] : slot;
+          sp.id = src.proteinIds[origIdx];
+          sp.x = srcXs[slot];
+          sp.y = srcYs[slot];
+          sp.originalIndex = origIdx;
 
           if (this.trackRenderedPointIds) {
-            const opacity = this.style.getOpacity(point);
+            const opacity = this.style.getOpacity(sp);
             if (opacity > 0) {
-              this.renderedPointIds.add(point.id);
+              this.renderedPointIds.add(sp.id);
             }
           }
 
           if (updatePositions) {
-            this.dataPositions[idx * 2] = scales.x(point.x);
-            this.dataPositions[idx * 2 + 1] = scales.y(point.y);
+            this.dataPositions[idx * 2] = scales.x(srcXs[slot]);
+            this.dataPositions[idx * 2 + 1] = scales.y(srcYs[slot]);
           }
 
           idx++;

--- a/packages/core/src/vite-env.d.ts
+++ b/packages/core/src/vite-env.d.ts
@@ -1,0 +1,13 @@
+/// <reference types="vite/client" />
+
+// Inline worker import (bundled into a base64 blob, self-contained)
+declare module '*?worker&inline' {
+  const c: new () => Worker;
+  export default c;
+}
+
+// Non-inline worker import (URL-based)
+declare module '*?worker' {
+  const c: new () => Worker;
+  export default c;
+}

--- a/packages/core/vite.config.ts
+++ b/packages/core/vite.config.ts
@@ -13,6 +13,9 @@ export default defineConfig({
       copyDtsFiles: true,
     }),
   ],
+  worker: {
+    format: 'es',
+  },
   build: {
     lib: {
       entry: {

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -3,6 +3,7 @@ export * from './visualization/shapes';
 export * from './visualization/annotation-data-access';
 export * from './visualization/plot-data-accessors';
 export * from './visualization/data-processor';
+export * from './visualization/plot-data';
 export * from './visualization/color-scheme';
 export * from './visualization/numeric-binning';
 export {

--- a/packages/utils/src/parquet/bundle-writer.test.ts
+++ b/packages/utils/src/parquet/bundle-writer.test.ts
@@ -10,20 +10,14 @@ const createMockVisualizationData = (): VisualizationData => ({
     {
       name: 'PCA_2',
       metadata: { dimension: 2 },
-      data: [
-        [1.0, 2.0],
-        [3.0, 4.0],
-        [5.0, 6.0],
-      ],
+      data: Float32Array.of(1.0, 2.0, 3.0, 4.0, 5.0, 6.0),
+      dimension: 2,
     },
     {
       name: 'UMAP_3',
       metadata: { dimension: 3 },
-      data: [
-        [1.0, 2.0, 3.0],
-        [4.0, 5.0, 6.0],
-        [7.0, 8.0, 9.0],
-      ],
+      data: Float32Array.of(1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0),
+      dimension: 3,
     },
   ],
   annotations: {

--- a/packages/utils/src/parquet/bundle-writer.ts
+++ b/packages/utils/src/parquet/bundle-writer.ts
@@ -83,7 +83,7 @@ function createProjectionsMetadataParquet(data: VisualizationData): ArrayBuffer 
 
   for (const projection of data.projections) {
     projectionNames.push(projection.name);
-    const dim = projection.metadata?.dimension ?? (projection.data[0]?.length === 3 ? 3 : 2);
+    const dim = projection.dimension;
     dimensions.push(dim);
     infoJsons.push(JSON.stringify(projection.metadata ?? {}, bigIntReplacer));
   }
@@ -114,12 +114,12 @@ function createProjectionsDataParquet(data: VisualizationData): ArrayBuffer {
   let rowIndex = 0;
   for (const projection of data.projections) {
     for (let i = 0; i < data.protein_ids.length; i++) {
-      const point = projection.data[i];
+      const base = i * projection.dimension;
       projectionNames[rowIndex] = projection.name;
       identifiers[rowIndex] = data.protein_ids[i];
-      xValues[rowIndex] = point[0];
-      yValues[rowIndex] = point[1];
-      zValues[rowIndex] = point.length === 3 ? (point as [number, number, number])[2] : null;
+      xValues[rowIndex] = projection.data[base];
+      yValues[rowIndex] = projection.data[base + 1];
+      zValues[rowIndex] = projection.dimension === 3 ? projection.data[base + 2] : null;
       rowIndex++;
     }
   }

--- a/packages/utils/src/types.ts
+++ b/packages/utils/src/types.ts
@@ -45,8 +45,13 @@ export type AnnotationData = Int32Array | readonly (readonly number[])[];
 export interface Projection {
   name: string;
   metadata?: Record<string, unknown> & { dimension?: 2 | 3 };
-  // Each point is either [x, y] or [x, y, z]
-  data: Array<[number, number] | [number, number, number]>;
+  /**
+   * Flat coordinates, length = pointCount * dimension.
+   * data[i*dimension + 0] = x, +1 = y, +2 = z (when dimension === 3).
+   */
+  data: Float32Array;
+  /** Coordinate stride: 2 (xy) or 3 (xyz). Authoritative — never infer from data. */
+  dimension: 2 | 3;
 }
 
 export interface VisualizationData {

--- a/packages/utils/src/types.ts
+++ b/packages/utils/src/types.ts
@@ -67,6 +67,30 @@ export interface PlotDataPoint {
   originalIndex: number;
 }
 
+/**
+ * Struct-of-Arrays container for the plotted points. Replaces PlotDataPoint[] as the
+ * bulk store — eliminates the per-point boxed { id, x, y, z?, originalIndex } objects.
+ * Individual PlotDataPoint objects are materialized on demand at interaction boundaries
+ * (hover/click/tooltip) via materializePlotDataPoint().
+ */
+export interface PlotData {
+  /** Number of plotted points (slots). */
+  readonly length: number;
+  /** X coordinate per slot (already plane-mapped for 3D projections). */
+  readonly xs: Float32Array;
+  /** Y coordinate per slot (already plane-mapped for 3D projections). */
+  readonly ys: Float32Array;
+  /** Raw z (coords[2]) per slot, or null for 2D projections. */
+  readonly zs: Float32Array | null;
+  /**
+   * Maps slot -> protein index (into proteinIds / VisualizationData.annotation_data).
+   * `null` means identity: slot i is protein i — the common non-isolated case.
+   */
+  readonly originalIndices: Int32Array | null;
+  /** Shared reference to VisualizationData.protein_ids. */
+  readonly proteinIds: readonly string[];
+}
+
 export interface StyleForAnnotation {
   color: string;
   shape: string;

--- a/packages/utils/src/visualization/data-processor.test.ts
+++ b/packages/utils/src/visualization/data-processor.test.ts
@@ -22,10 +22,8 @@ describe('DataProcessor.processVisualizationData', () => {
       projections: [
         {
           name: 't',
-          data: [
-            [1, 2],
-            [3, 4],
-          ],
+          data: Float32Array.of(1, 2, 3, 4),
+          dimension: 2,
         },
       ],
       annotations: {},
@@ -43,7 +41,7 @@ describe('DataProcessor.processVisualizationData', () => {
   it('preserves z coordinate for 3D projections', () => {
     const data: VisualizationData = {
       protein_ids: ['p0'],
-      projections: [{ name: 't', data: [[1, 2, 3]] }],
+      projections: [{ name: 't', data: Float32Array.of(1, 2, 3), dimension: 3 }],
       annotations: {},
       annotation_data: {},
     };
@@ -59,7 +57,7 @@ describe('DataProcessor.processVisualizationData', () => {
   it('maps coordinates to xz plane when projectionPlane is "xz"', () => {
     const data: VisualizationData = {
       protein_ids: ['p0'],
-      projections: [{ name: 't', data: [[10, 20, 30]] }],
+      projections: [{ name: 't', data: Float32Array.of(10, 20, 30), dimension: 3 }],
       annotations: {},
       annotation_data: {},
     };
@@ -72,7 +70,7 @@ describe('DataProcessor.processVisualizationData', () => {
   it('maps coordinates to yz plane when projectionPlane is "yz"', () => {
     const data: VisualizationData = {
       protein_ids: ['p0'],
-      projections: [{ name: 't', data: [[10, 20, 30]] }],
+      projections: [{ name: 't', data: Float32Array.of(10, 20, 30), dimension: 3 }],
       annotations: {},
       annotation_data: {},
     };
@@ -97,7 +95,7 @@ describe('DataProcessor.processVisualizationData', () => {
   it('does not materialize annotation Records on slots', () => {
     const data: VisualizationData = {
       protein_ids: ['p0'],
-      projections: [{ name: 't', data: [[0, 0]] }],
+      projections: [{ name: 't', data: Float32Array.of(0, 0), dimension: 2 }],
       annotations: {
         species: {
           kind: 'categorical',
@@ -122,12 +120,8 @@ describe('DataProcessor.processVisualizationData — isolation (Set-based, MODEL
     projections: [
       {
         name: 't',
-        data: [
-          [1, 2],
-          [3, 4],
-          [5, 6],
-          [7, 8],
-        ],
+        data: Float32Array.of(1, 2, 3, 4, 5, 6, 7, 8),
+        dimension: 2,
       },
     ],
     annotations: {},
@@ -219,10 +213,8 @@ describe('materializePlotDataPoint', () => {
       projections: [
         {
           name: 't',
-          data: [
-            [1, 2],
-            [3, 4],
-          ],
+          data: Float32Array.of(1, 2, 3, 4),
+          dimension: 2,
         },
       ],
       annotations: {},
@@ -242,12 +234,8 @@ describe('materializePlotDataPoint', () => {
       projections: [
         {
           name: 't',
-          data: [
-            [1, 2],
-            [3, 4],
-            [5, 6],
-            [7, 8],
-          ],
+          data: Float32Array.of(1, 2, 3, 4, 5, 6, 7, 8),
+          dimension: 2,
         },
       ],
       annotations: {},
@@ -268,7 +256,7 @@ describe('materializePlotDataPoint', () => {
   it('includes z field for 3D PlotData', () => {
     const data: VisualizationData = {
       protein_ids: ['p0'],
-      projections: [{ name: 't', data: [[1, 2, 3]] }],
+      projections: [{ name: 't', data: Float32Array.of(1, 2, 3), dimension: 3 }],
       annotations: {},
       annotation_data: {},
     };

--- a/packages/utils/src/visualization/data-processor.test.ts
+++ b/packages/utils/src/visualization/data-processor.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { DataProcessor } from './data-processor';
-import type { VisualizationData } from '../types';
+import type { VisualizationData, PlotDataPoint } from '../types';
 
 describe('DataProcessor.processVisualizationData', () => {
   it('returns one bare PlotDataPoint per protein for 2D coordinates', () => {
@@ -210,5 +210,117 @@ describe('DataProcessor.processVisualizationData — isolation (Set-based, MODEL
     expect(result).toHaveLength(2);
     expect(result[0]).toMatchObject({ id: 'c', originalIndex: 2, x: 5, y: 6 });
     expect(result[1]).toMatchObject({ id: 'd', originalIndex: 3, x: 7, y: 8 });
+  });
+});
+
+describe('DataProcessor.createScales', () => {
+  const margin = { top: 10, right: 20, bottom: 30, left: 40 };
+
+  it('returns null for empty plotData', () => {
+    const result = DataProcessor.createScales([], 800, 600, margin);
+    expect(result).toBeNull();
+  });
+
+  it('returns correct domain and range for a known fixture', () => {
+    // x in [0, 10], y in [-5, 5]
+    const plotData: PlotDataPoint[] = [
+      { id: 'a', x: 0, y: -5, originalIndex: 0 },
+      { id: 'b', x: 10, y: 5, originalIndex: 1 },
+    ];
+    const width = 800;
+    const height = 600;
+    const scales = DataProcessor.createScales(plotData, width, height, margin);
+    expect(scales).not.toBeNull();
+
+    // xRange = 10 - 0 = 10, xPadding = 0.5
+    const xDomainMin = 0 - 0.5;
+    const xDomainMax = 10 + 0.5;
+    expect(scales!.x.domain()).toEqual([xDomainMin, xDomainMax]);
+    expect(scales!.x.range()).toEqual([margin.left, width - margin.right]);
+
+    // yRange = 5 - (-5) = 10, yPadding = 0.5
+    const yDomainMin = -5 - 0.5;
+    const yDomainMax = 5 + 0.5;
+    expect(scales!.y.domain()).toEqual([yDomainMin, yDomainMax]);
+    expect(scales!.y.range()).toEqual([height - margin.bottom, margin.top]);
+
+    // spot-check: x(0) should map near margin.left (but slightly inside due to padding)
+    const xAtMin = scales!.x(0);
+    expect(xAtMin).toBeGreaterThan(margin.left);
+    expect(xAtMin).toBeLessThan(width - margin.right);
+
+    // spot-check: x(10) should map near width - margin.right
+    const xAtMax = scales!.x(10);
+    expect(xAtMax).toBeGreaterThan(margin.left);
+    expect(xAtMax).toBeLessThan(width - margin.right);
+  });
+
+  it('handles single point (min === max) — zero padding, domain equals the point value', () => {
+    const plotData: PlotDataPoint[] = [{ id: 'only', x: 7, y: 3, originalIndex: 0 }];
+    const scales = DataProcessor.createScales(plotData, 800, 600, margin);
+    expect(scales).not.toBeNull();
+    // padding = abs(7 - 7) * 0.05 = 0
+    expect(scales!.x.domain()).toEqual([7, 7]);
+    expect(scales!.y.domain()).toEqual([3, 3]);
+    // construction must not throw — scale still returned
+  });
+
+  it('RESIZE path: same array reference → domain identical, range reflects new dimensions', () => {
+    const plotData: PlotDataPoint[] = [
+      { id: 'a', x: 0, y: 0, originalIndex: 0 },
+      { id: 'b', x: 10, y: 10, originalIndex: 1 },
+    ];
+    const margin1 = { top: 10, right: 20, bottom: 30, left: 40 };
+
+    // First call: 800×600
+    const scales1 = DataProcessor.createScales(plotData, 800, 600, margin1);
+    expect(scales1).not.toBeNull();
+    const domain1X = scales1!.x.domain();
+    const domain1Y = scales1!.y.domain();
+
+    // Second call: SAME array, different dimensions (simulates resize)
+    const scales2 = DataProcessor.createScales(plotData, 1200, 900, margin1);
+    expect(scales2).not.toBeNull();
+    const domain2X = scales2!.x.domain();
+    const domain2Y = scales2!.y.domain();
+
+    // Domain must be identical — extents reused from cache
+    expect(domain2X).toEqual(domain1X);
+    expect(domain2Y).toEqual(domain1Y);
+
+    // Range must reflect new dimensions
+    expect(scales1!.x.range()).toEqual([margin1.left, 800 - margin1.right]);
+    expect(scales2!.x.range()).toEqual([margin1.left, 1200 - margin1.right]);
+    expect(scales1!.y.range()).toEqual([600 - margin1.bottom, margin1.top]);
+    expect(scales2!.y.range()).toEqual([900 - margin1.bottom, margin1.top]);
+  });
+
+  it('different plotData arrays with different coordinate ranges → different domains', () => {
+    const plotData1: PlotDataPoint[] = [
+      { id: 'a', x: 0, y: 0, originalIndex: 0 },
+      { id: 'b', x: 10, y: 10, originalIndex: 1 },
+    ];
+    const plotData2: PlotDataPoint[] = [
+      { id: 'c', x: 100, y: 200, originalIndex: 0 },
+      { id: 'd', x: 300, y: 400, originalIndex: 1 },
+    ];
+    const width = 800;
+    const height = 600;
+
+    const scales1 = DataProcessor.createScales(plotData1, width, height, margin);
+    const scales2 = DataProcessor.createScales(plotData2, width, height, margin);
+
+    expect(scales1).not.toBeNull();
+    expect(scales2).not.toBeNull();
+
+    // Domains must differ — separate arrays, separate cache entries
+    expect(scales1!.x.domain()).not.toEqual(scales2!.x.domain());
+    expect(scales1!.y.domain()).not.toEqual(scales2!.y.domain());
+
+    // Verify exact domains for each
+    // plotData1: x in [0,10] → padding 0.5 → domain [-0.5, 10.5]
+    expect(scales1!.x.domain()).toEqual([-0.5, 10.5]);
+    // plotData2: x in [100,300] → range 200 → padding 10 → domain [90, 310]
+    expect(scales2!.x.domain()).toEqual([90, 310]);
   });
 });

--- a/packages/utils/src/visualization/data-processor.test.ts
+++ b/packages/utils/src/visualization/data-processor.test.ts
@@ -1,9 +1,22 @@
 import { describe, it, expect } from 'vitest';
 import { DataProcessor } from './data-processor';
-import type { VisualizationData, PlotDataPoint } from '../types';
+import { materializePlotDataPoint } from './plot-data';
+import type { VisualizationData, PlotData } from '../types';
+
+// Helper to build a minimal PlotData literal for createScales tests
+function makePlotData(xs: number[], ys: number[], proteinIds?: string[]): PlotData {
+  return {
+    length: xs.length,
+    xs: new Float32Array(xs),
+    ys: new Float32Array(ys),
+    zs: null,
+    originalIndices: null,
+    proteinIds: proteinIds ?? xs.map((_, i) => `p${i}`),
+  };
+}
 
 describe('DataProcessor.processVisualizationData', () => {
-  it('returns one bare PlotDataPoint per protein for 2D coordinates', () => {
+  it('returns correct SoA shape for 2D coordinates', () => {
     const data: VisualizationData = {
       protein_ids: ['p0', 'p1'],
       projections: [
@@ -19,9 +32,12 @@ describe('DataProcessor.processVisualizationData', () => {
       annotation_data: {},
     };
     const result = DataProcessor.processVisualizationData(data, 0);
-    expect(result).toHaveLength(2);
-    expect(result[0]).toEqual({ id: 'p0', x: 1, y: 2, originalIndex: 0 });
-    expect(result[1]).toEqual({ id: 'p1', x: 3, y: 4, originalIndex: 1 });
+    expect(result.length).toBe(2);
+    expect(Array.from(result.xs)).toEqual([1, 3]);
+    expect(Array.from(result.ys)).toEqual([2, 4]);
+    expect(result.zs).toBeNull();
+    expect(result.originalIndices).toBeNull();
+    expect(result.proteinIds).toBe(data.protein_ids);
   });
 
   it('preserves z coordinate for 3D projections', () => {
@@ -32,7 +48,12 @@ describe('DataProcessor.processVisualizationData', () => {
       annotation_data: {},
     };
     const result = DataProcessor.processVisualizationData(data, 0);
-    expect(result[0]).toEqual({ id: 'p0', x: 1, y: 2, z: 3, originalIndex: 0 });
+    expect(result.length).toBe(1);
+    expect(result.xs[0]).toBe(1);
+    expect(result.ys[0]).toBe(2);
+    expect(result.zs).not.toBeNull();
+    expect(result.zs![0]).toBe(3);
+    expect(result.originalIndices).toBeNull();
   });
 
   it('maps coordinates to xz plane when projectionPlane is "xz"', () => {
@@ -43,7 +64,9 @@ describe('DataProcessor.processVisualizationData', () => {
       annotation_data: {},
     };
     const result = DataProcessor.processVisualizationData(data, 0, false, undefined, 'xz');
-    expect(result[0]).toEqual({ id: 'p0', x: 10, y: 30, z: 30, originalIndex: 0 });
+    expect(result.xs[0]).toBe(10);
+    expect(result.ys[0]).toBe(30);
+    expect(result.zs![0]).toBe(30);
   });
 
   it('maps coordinates to yz plane when projectionPlane is "yz"', () => {
@@ -54,64 +77,24 @@ describe('DataProcessor.processVisualizationData', () => {
       annotation_data: {},
     };
     const result = DataProcessor.processVisualizationData(data, 0, false, undefined, 'yz');
-    expect(result[0]).toEqual({ id: 'p0', x: 20, y: 30, z: 30, originalIndex: 0 });
+    expect(result.xs[0]).toBe(20);
+    expect(result.ys[0]).toBe(30);
+    expect(result.zs![0]).toBe(30);
   });
 
-  it('returns empty array when projection index is out of range', () => {
+  it('returns empty PlotData when projection index is out of range', () => {
     const data: VisualizationData = {
       protein_ids: ['p0'],
       projections: [],
       annotations: {},
       annotation_data: {},
     };
-    expect(DataProcessor.processVisualizationData(data, 0)).toEqual([]);
+    const result = DataProcessor.processVisualizationData(data, 0);
+    expect(result.length).toBe(0);
+    expect(result.xs.length).toBe(0);
   });
 
-  it('filters points using isolation history', () => {
-    const data: VisualizationData = {
-      protein_ids: ['p0', 'p1', 'p2'],
-      projections: [
-        {
-          name: 't',
-          data: [
-            [0, 0],
-            [1, 1],
-            [2, 2],
-          ],
-        },
-      ],
-      annotations: {},
-      annotation_data: {},
-    };
-    const result = DataProcessor.processVisualizationData(data, 0, true, [['p0', 'p2']]);
-    expect(result.map((p) => p.id)).toEqual(['p0', 'p2']);
-  });
-
-  it('applies multiple isolation history layers (intersection)', () => {
-    const data: VisualizationData = {
-      protein_ids: ['p0', 'p1', 'p2', 'p3'],
-      projections: [
-        {
-          name: 't',
-          data: [
-            [0, 0],
-            [1, 1],
-            [2, 2],
-            [3, 3],
-          ],
-        },
-      ],
-      annotations: {},
-      annotation_data: {},
-    };
-    const result = DataProcessor.processVisualizationData(data, 0, true, [
-      ['p0', 'p1', 'p2'],
-      ['p1', 'p2', 'p3'],
-    ]);
-    expect(result.map((p) => p.id)).toEqual(['p1', 'p2']);
-  });
-
-  it('does not materialize annotation Records on points', () => {
+  it('does not materialize annotation Records on slots', () => {
     const data: VisualizationData = {
       protein_ids: ['p0'],
       projections: [{ name: 't', data: [[0, 0]] }],
@@ -126,8 +109,10 @@ describe('DataProcessor.processVisualizationData', () => {
       annotation_data: { species: Int32Array.of(0) },
     };
     const result = DataProcessor.processVisualizationData(data, 0);
-    expect(result).toHaveLength(1);
-    expect(Object.keys(result[0]).sort()).toEqual(['id', 'originalIndex', 'x', 'y']);
+    expect(result.length).toBe(1);
+    // SoA container only has the typed-array fields
+    expect(result.xs[0]).toBe(0);
+    expect(result.ys[0]).toBe(0);
   });
 });
 
@@ -151,13 +136,15 @@ describe('DataProcessor.processVisualizationData — isolation (Set-based, MODEL
 
   it('single-layer isolation keeps only ids present in that layer', () => {
     const result = DataProcessor.processVisualizationData(fixture, 0, true, [['a', 'c']]);
-    expect(result.map((p) => p.id)).toEqual(['a', 'c']);
+    expect(result.length).toBe(2);
+    expect(result.proteinIds[result.originalIndices![0]]).toBe('a');
+    expect(result.proteinIds[result.originalIndices![1]]).toBe('c');
   });
 
   it('single-layer isolation excludes ids absent from the layer', () => {
     const result = DataProcessor.processVisualizationData(fixture, 0, true, [['b']]);
-    expect(result.map((p) => p.id)).toEqual(['b']);
-    expect(result.find((p) => p.id === 'a')).toBeUndefined();
+    expect(result.length).toBe(1);
+    expect(result.proteinIds[result.originalIndices![0]]).toBe('b');
   });
 
   it('multi-layer isolation returns intersection (points in ALL layers only)', () => {
@@ -166,7 +153,12 @@ describe('DataProcessor.processVisualizationData — isolation (Set-based, MODEL
       ['a', 'b', 'c'],
       ['b', 'c', 'd'],
     ]);
-    expect(result.map((p) => p.id)).toEqual(['b', 'c']);
+    expect(result.length).toBe(2);
+    const ids = Array.from(
+      { length: result.length },
+      (_, k) => result.proteinIds[result.originalIndices![k]],
+    );
+    expect(ids).toEqual(['b', 'c']);
   });
 
   it('point in first layer but not second is removed', () => {
@@ -175,41 +167,114 @@ describe('DataProcessor.processVisualizationData — isolation (Set-based, MODEL
       ['a', 'b'],
       ['b', 'c'],
     ]);
-    expect(result.find((p) => p.id === 'a')).toBeUndefined();
-    expect(result.map((p) => p.id)).toEqual(['b']);
+    expect(result.length).toBe(1);
+    expect(result.proteinIds[result.originalIndices![0]]).toBe('b');
   });
 
   it('empty isolation layer returns empty result', () => {
     const result = DataProcessor.processVisualizationData(fixture, 0, true, [[]]);
-    expect(result).toHaveLength(0);
+    expect(result.length).toBe(0);
   });
 
   it('empty isolation layer in second position returns empty result', () => {
     const result = DataProcessor.processVisualizationData(fixture, 0, true, [['a', 'b'], []]);
-    expect(result).toHaveLength(0);
+    expect(result.length).toBe(0);
   });
 
   it('isolationMode false returns all processed points unchanged', () => {
     const result = DataProcessor.processVisualizationData(fixture, 0, false, [['a']]);
-    expect(result).toHaveLength(4);
+    expect(result.length).toBe(4);
+    expect(result.originalIndices).toBeNull();
   });
 
   it('empty isolationHistory returns all processed points unchanged', () => {
     const result = DataProcessor.processVisualizationData(fixture, 0, true, []);
-    expect(result).toHaveLength(4);
+    expect(result.length).toBe(4);
+    expect(result.originalIndices).toBeNull();
   });
 
   it('no isolationHistory argument returns all processed points unchanged', () => {
     const result = DataProcessor.processVisualizationData(fixture, 0, true, undefined);
-    expect(result).toHaveLength(4);
+    expect(result.length).toBe(4);
+    expect(result.originalIndices).toBeNull();
   });
 
-  it('surviving points preserve originalIndex (index in protein_ids, not filtered position)', () => {
+  it('surviving slots preserve originalIndex (protein index in protein_ids)', () => {
     // 'c' is at index 2 and 'd' at index 3 in protein_ids
     const result = DataProcessor.processVisualizationData(fixture, 0, true, [['c', 'd']]);
-    expect(result).toHaveLength(2);
-    expect(result[0]).toMatchObject({ id: 'c', originalIndex: 2, x: 5, y: 6 });
-    expect(result[1]).toMatchObject({ id: 'd', originalIndex: 3, x: 7, y: 8 });
+    expect(result.length).toBe(2);
+    expect(result.originalIndices![0]).toBe(2);
+    expect(result.originalIndices![1]).toBe(3);
+    expect(result.xs[0]).toBe(5);
+    expect(result.ys[0]).toBe(6);
+    expect(result.xs[1]).toBe(7);
+    expect(result.ys[1]).toBe(8);
+  });
+});
+
+describe('materializePlotDataPoint', () => {
+  it('reconstructs {id,x,y,originalIndex} for a non-isolated (identity) PlotData', () => {
+    const data: VisualizationData = {
+      protein_ids: ['p0', 'p1'],
+      projections: [
+        {
+          name: 't',
+          data: [
+            [1, 2],
+            [3, 4],
+          ],
+        },
+      ],
+      annotations: {},
+      annotation_data: {},
+    };
+    const pd = DataProcessor.processVisualizationData(data, 0);
+    const p0 = materializePlotDataPoint(pd, 0);
+    expect(p0).toEqual({ id: 'p0', x: 1, y: 2, originalIndex: 0 });
+    const p1 = materializePlotDataPoint(pd, 1);
+    expect(p1).toEqual({ id: 'p1', x: 3, y: 4, originalIndex: 1 });
+  });
+
+  it('reconstructs correct originalIndex for an isolated PlotData', () => {
+    // protein_ids = [a, b, c, d]; isolate [c, d] → slot 0 = protein index 2 (c), slot 1 = protein index 3 (d)
+    const data: VisualizationData = {
+      protein_ids: ['a', 'b', 'c', 'd'],
+      projections: [
+        {
+          name: 't',
+          data: [
+            [1, 2],
+            [3, 4],
+            [5, 6],
+            [7, 8],
+          ],
+        },
+      ],
+      annotations: {},
+      annotation_data: {},
+    };
+    const pd = DataProcessor.processVisualizationData(data, 0, true, [['c', 'd']]);
+    const slot0 = materializePlotDataPoint(pd, 0);
+    expect(slot0.id).toBe('c');
+    expect(slot0.originalIndex).toBe(2);
+    expect(slot0.x).toBe(5);
+    expect(slot0.y).toBe(6);
+
+    const slot1 = materializePlotDataPoint(pd, 1);
+    expect(slot1.id).toBe('d');
+    expect(slot1.originalIndex).toBe(3);
+  });
+
+  it('includes z field for 3D PlotData', () => {
+    const data: VisualizationData = {
+      protein_ids: ['p0'],
+      projections: [{ name: 't', data: [[1, 2, 3]] }],
+      annotations: {},
+      annotation_data: {},
+    };
+    const pd = DataProcessor.processVisualizationData(data, 0);
+    const p = materializePlotDataPoint(pd, 0);
+    expect(p.z).toBe(3);
   });
 });
 
@@ -217,16 +282,13 @@ describe('DataProcessor.createScales', () => {
   const margin = { top: 10, right: 20, bottom: 30, left: 40 };
 
   it('returns null for empty plotData', () => {
-    const result = DataProcessor.createScales([], 800, 600, margin);
+    const result = DataProcessor.createScales(makePlotData([], []), 800, 600, margin);
     expect(result).toBeNull();
   });
 
   it('returns correct domain and range for a known fixture', () => {
     // x in [0, 10], y in [-5, 5]
-    const plotData: PlotDataPoint[] = [
-      { id: 'a', x: 0, y: -5, originalIndex: 0 },
-      { id: 'b', x: 10, y: 5, originalIndex: 1 },
-    ];
+    const plotData = makePlotData([0, 10], [-5, 5]);
     const width = 800;
     const height = 600;
     const scales = DataProcessor.createScales(plotData, width, height, margin);
@@ -256,7 +318,7 @@ describe('DataProcessor.createScales', () => {
   });
 
   it('handles single point (min === max) — zero padding, domain equals the point value', () => {
-    const plotData: PlotDataPoint[] = [{ id: 'only', x: 7, y: 3, originalIndex: 0 }];
+    const plotData = makePlotData([7], [3]);
     const scales = DataProcessor.createScales(plotData, 800, 600, margin);
     expect(scales).not.toBeNull();
     // padding = abs(7 - 7) * 0.05 = 0
@@ -265,11 +327,8 @@ describe('DataProcessor.createScales', () => {
     // construction must not throw — scale still returned
   });
 
-  it('RESIZE path: same array reference → domain identical, range reflects new dimensions', () => {
-    const plotData: PlotDataPoint[] = [
-      { id: 'a', x: 0, y: 0, originalIndex: 0 },
-      { id: 'b', x: 10, y: 10, originalIndex: 1 },
-    ];
+  it('RESIZE path: same PlotData reference → domain identical, range reflects new dimensions', () => {
+    const plotData = makePlotData([0, 10], [0, 10]);
     const margin1 = { top: 10, right: 20, bottom: 30, left: 40 };
 
     // First call: 800×600
@@ -278,7 +337,7 @@ describe('DataProcessor.createScales', () => {
     const domain1X = scales1!.x.domain();
     const domain1Y = scales1!.y.domain();
 
-    // Second call: SAME array, different dimensions (simulates resize)
+    // Second call: SAME PlotData ref, different dimensions (simulates resize)
     const scales2 = DataProcessor.createScales(plotData, 1200, 900, margin1);
     expect(scales2).not.toBeNull();
     const domain2X = scales2!.x.domain();
@@ -295,15 +354,9 @@ describe('DataProcessor.createScales', () => {
     expect(scales2!.y.range()).toEqual([900 - margin1.bottom, margin1.top]);
   });
 
-  it('different plotData arrays with different coordinate ranges → different domains', () => {
-    const plotData1: PlotDataPoint[] = [
-      { id: 'a', x: 0, y: 0, originalIndex: 0 },
-      { id: 'b', x: 10, y: 10, originalIndex: 1 },
-    ];
-    const plotData2: PlotDataPoint[] = [
-      { id: 'c', x: 100, y: 200, originalIndex: 0 },
-      { id: 'd', x: 300, y: 400, originalIndex: 1 },
-    ];
+  it('different PlotData objects with different coordinate ranges → different domains', () => {
+    const plotData1 = makePlotData([0, 10], [0, 10]);
+    const plotData2 = makePlotData([100, 300], [200, 400]);
     const width = 800;
     const height = 600;
 
@@ -313,7 +366,7 @@ describe('DataProcessor.createScales', () => {
     expect(scales1).not.toBeNull();
     expect(scales2).not.toBeNull();
 
-    // Domains must differ — separate arrays, separate cache entries
+    // Domains must differ — separate PlotData objects, separate cache entries
     expect(scales1!.x.domain()).not.toEqual(scales2!.x.domain());
     expect(scales1!.y.domain()).not.toEqual(scales2!.y.domain());
 

--- a/packages/utils/src/visualization/data-processor.test.ts
+++ b/packages/utils/src/visualization/data-processor.test.ts
@@ -130,3 +130,85 @@ describe('DataProcessor.processVisualizationData', () => {
     expect(Object.keys(result[0]).sort()).toEqual(['id', 'originalIndex', 'x', 'y']);
   });
 });
+
+describe('DataProcessor.processVisualizationData — isolation (Set-based, MODEL-O5b)', () => {
+  const fixture: VisualizationData = {
+    protein_ids: ['a', 'b', 'c', 'd'],
+    projections: [
+      {
+        name: 't',
+        data: [
+          [1, 2],
+          [3, 4],
+          [5, 6],
+          [7, 8],
+        ],
+      },
+    ],
+    annotations: {},
+    annotation_data: {},
+  };
+
+  it('single-layer isolation keeps only ids present in that layer', () => {
+    const result = DataProcessor.processVisualizationData(fixture, 0, true, [['a', 'c']]);
+    expect(result.map((p) => p.id)).toEqual(['a', 'c']);
+  });
+
+  it('single-layer isolation excludes ids absent from the layer', () => {
+    const result = DataProcessor.processVisualizationData(fixture, 0, true, [['b']]);
+    expect(result.map((p) => p.id)).toEqual(['b']);
+    expect(result.find((p) => p.id === 'a')).toBeUndefined();
+  });
+
+  it('multi-layer isolation returns intersection (points in ALL layers only)', () => {
+    // layer0 = {a,b,c}, layer1 = {b,c,d} → intersection = {b,c}
+    const result = DataProcessor.processVisualizationData(fixture, 0, true, [
+      ['a', 'b', 'c'],
+      ['b', 'c', 'd'],
+    ]);
+    expect(result.map((p) => p.id)).toEqual(['b', 'c']);
+  });
+
+  it('point in first layer but not second is removed', () => {
+    // 'a' is in layer0 but absent from layer1 → must not appear
+    const result = DataProcessor.processVisualizationData(fixture, 0, true, [
+      ['a', 'b'],
+      ['b', 'c'],
+    ]);
+    expect(result.find((p) => p.id === 'a')).toBeUndefined();
+    expect(result.map((p) => p.id)).toEqual(['b']);
+  });
+
+  it('empty isolation layer returns empty result', () => {
+    const result = DataProcessor.processVisualizationData(fixture, 0, true, [[]]);
+    expect(result).toHaveLength(0);
+  });
+
+  it('empty isolation layer in second position returns empty result', () => {
+    const result = DataProcessor.processVisualizationData(fixture, 0, true, [['a', 'b'], []]);
+    expect(result).toHaveLength(0);
+  });
+
+  it('isolationMode false returns all processed points unchanged', () => {
+    const result = DataProcessor.processVisualizationData(fixture, 0, false, [['a']]);
+    expect(result).toHaveLength(4);
+  });
+
+  it('empty isolationHistory returns all processed points unchanged', () => {
+    const result = DataProcessor.processVisualizationData(fixture, 0, true, []);
+    expect(result).toHaveLength(4);
+  });
+
+  it('no isolationHistory argument returns all processed points unchanged', () => {
+    const result = DataProcessor.processVisualizationData(fixture, 0, true, undefined);
+    expect(result).toHaveLength(4);
+  });
+
+  it('surviving points preserve originalIndex (index in protein_ids, not filtered position)', () => {
+    // 'c' is at index 2 and 'd' at index 3 in protein_ids
+    const result = DataProcessor.processVisualizationData(fixture, 0, true, [['c', 'd']]);
+    expect(result).toHaveLength(2);
+    expect(result[0]).toMatchObject({ id: 'c', originalIndex: 2, x: 5, y: 6 });
+    expect(result[1]).toMatchObject({ id: 'd', originalIndex: 3, x: 7, y: 8 });
+  });
+});

--- a/packages/utils/src/visualization/data-processor.ts
+++ b/packages/utils/src/visualization/data-processor.ts
@@ -19,12 +19,12 @@ export class DataProcessor {
       return { ...EMPTY_PLOT_DATA, proteinIds: data.protein_ids };
     }
 
-    const projData = data.projections[projectionIndex].data;
+    const proj = data.projections[projectionIndex];
+    const src = proj.data;
+    const dim = proj.dimension;
+    const is3D = dim === 3;
     const proteinIds = data.protein_ids;
     const n = proteinIds.length;
-
-    // Determine if any point is 3D
-    const is3D = projData.some((c) => c != null && c.length === 3);
 
     if (isolationMode && isolationHistory && isolationHistory.length > 0) {
       // Two-pass isolation: find surviving protein indices (those in EVERY layer set).
@@ -45,18 +45,21 @@ export class DataProcessor {
 
       for (let k = 0; k < count; k++) {
         const origIdx = survivors[k];
-        const coords = (projData[origIdx] ?? [0, 0]) as [number, number] | [number, number, number];
+        const base = origIdx * dim;
+        const c0 = src[base];
+        const c1 = src[base + 1];
+        const c2 = is3D ? src[base + 2] : undefined;
 
-        let xVal = coords[0];
-        let yVal = coords[1];
+        let xVal = c0;
+        let yVal = c1;
 
-        if (coords.length === 3) {
-          if (zs) zs[k] = coords[2];
+        if (is3D && c2 !== undefined) {
+          if (zs) zs[k] = c2;
           if (projectionPlane === 'xz') {
-            yVal = coords[2];
+            yVal = c2;
           } else if (projectionPlane === 'yz') {
-            xVal = coords[1];
-            yVal = coords[2];
+            xVal = c1;
+            yVal = c2;
           }
         }
 
@@ -74,18 +77,21 @@ export class DataProcessor {
     const zs = is3D ? new Float32Array(n) : null;
 
     for (let i = 0; i < n; i++) {
-      const coords = (projData[i] ?? [0, 0]) as [number, number] | [number, number, number];
+      const base = i * dim;
+      const c0 = src[base];
+      const c1 = src[base + 1];
+      const c2 = is3D ? src[base + 2] : undefined;
 
-      let xVal = coords[0];
-      let yVal = coords[1];
+      let xVal = c0;
+      let yVal = c1;
 
-      if (coords.length === 3) {
-        if (zs) zs[i] = coords[2];
+      if (is3D && c2 !== undefined) {
+        if (zs) zs[i] = c2;
         if (projectionPlane === 'xz') {
-          yVal = coords[2];
+          yVal = c2;
         } else if (projectionPlane === 'yz') {
-          xVal = coords[1];
-          yVal = coords[2];
+          xVal = c1;
+          yVal = c2;
         }
       }
 

--- a/packages/utils/src/visualization/data-processor.ts
+++ b/packages/utils/src/visualization/data-processor.ts
@@ -1,6 +1,12 @@
 import type { VisualizationData, PlotDataPoint } from '../types.js';
 import * as d3 from 'd3';
 
+// Memoize x/y extents per plotData array reference. Resizes pass the same array (extents
+// unchanged) and reuse the cached scan; any data/projection/plane change builds a NEW array
+// (fresh point objects), correctly missing the cache. Point x/y are never mutated in place
+// for a given array reference, so cached extents cannot go stale.
+const extentCache = new WeakMap<PlotDataPoint[], { x: [number, number]; y: [number, number] }>();
+
 export class DataProcessor {
   static processVisualizationData(
     data: VisualizationData,
@@ -50,8 +56,16 @@ export class DataProcessor {
   ) {
     if (plotData.length === 0) return null;
 
-    const xExtent = d3.extent(plotData, (d) => d.x) as [number, number];
-    const yExtent = d3.extent(plotData, (d) => d.y) as [number, number];
+    let extents = extentCache.get(plotData);
+    if (!extents) {
+      extents = {
+        x: d3.extent(plotData, (d) => d.x) as [number, number],
+        y: d3.extent(plotData, (d) => d.y) as [number, number],
+      };
+      extentCache.set(plotData, extents);
+    }
+    const xExtent = extents.x;
+    const yExtent = extents.y;
 
     const xPadding = Math.abs(xExtent[1] - xExtent[0]) * 0.05;
     const yPadding = Math.abs(yExtent[1] - yExtent[0]) * 0.05;

--- a/packages/utils/src/visualization/data-processor.ts
+++ b/packages/utils/src/visualization/data-processor.ts
@@ -31,10 +31,10 @@ export class DataProcessor {
     });
 
     if (isolationMode && isolationHistory && isolationHistory.length > 0) {
-      let filteredData = processedData.filter((p) => isolationHistory[0].includes(p.id));
-      for (let i = 1; i < isolationHistory.length; i++) {
-        const splitIds = isolationHistory[i];
-        filteredData = filteredData.filter((p) => splitIds.includes(p.id));
+      let filteredData = processedData;
+      for (let i = 0; i < isolationHistory.length; i++) {
+        const layerSet = new Set(isolationHistory[i]);
+        filteredData = filteredData.filter((p) => layerSet.has(p.id));
       }
       return filteredData;
     }

--- a/packages/utils/src/visualization/data-processor.ts
+++ b/packages/utils/src/visualization/data-processor.ts
@@ -1,11 +1,11 @@
-import type { VisualizationData, PlotDataPoint } from '../types.js';
+import type { VisualizationData, PlotData } from '../types.js';
+import { EMPTY_PLOT_DATA } from './plot-data.js';
 import * as d3 from 'd3';
 
-// Memoize x/y extents per plotData array reference. Resizes pass the same array (extents
-// unchanged) and reuse the cached scan; any data/projection/plane change builds a NEW array
-// (fresh point objects), correctly missing the cache. Point x/y are never mutated in place
-// for a given array reference, so cached extents cannot go stale.
-const extentCache = new WeakMap<PlotDataPoint[], { x: [number, number]; y: [number, number] }>();
+// Memoize x/y extents per PlotData object reference. Resizes pass the same PlotData
+// (extents unchanged) and reuse the cached scan; any data/projection/plane change builds
+// a NEW PlotData via clonePlotData, correctly missing the cache.
+const extentCache = new WeakMap<PlotData, { x: [number, number]; y: [number, number] }>();
 
 export class DataProcessor {
   static processVisualizationData(
@@ -14,42 +14,90 @@ export class DataProcessor {
     isolationMode: boolean = false,
     isolationHistory?: string[][],
     projectionPlane: 'xy' | 'xz' | 'yz' = 'xy',
-  ): PlotDataPoint[] {
-    if (!data.projections[projectionIndex]) return [];
-
-    const processedData: PlotDataPoint[] = data.protein_ids.map((id, index) => {
-      const coordinates = (data.projections[projectionIndex].data[index] ?? [0, 0]) as
-        | [number, number]
-        | [number, number, number];
-
-      let xVal = coordinates[0];
-      let yVal = coordinates[1];
-      if (coordinates.length === 3) {
-        if (projectionPlane === 'xz') {
-          yVal = coordinates[2];
-        } else if (projectionPlane === 'yz') {
-          xVal = coordinates[1];
-          yVal = coordinates[2];
-        }
-        return { id, x: xVal, y: yVal, z: coordinates[2], originalIndex: index };
-      }
-      return { id, x: xVal, y: yVal, originalIndex: index };
-    });
-
-    if (isolationMode && isolationHistory && isolationHistory.length > 0) {
-      let filteredData = processedData;
-      for (let i = 0; i < isolationHistory.length; i++) {
-        const layerSet = new Set(isolationHistory[i]);
-        filteredData = filteredData.filter((p) => layerSet.has(p.id));
-      }
-      return filteredData;
+  ): PlotData {
+    if (!data.projections[projectionIndex]) {
+      return { ...EMPTY_PLOT_DATA, proteinIds: data.protein_ids };
     }
 
-    return processedData;
+    const projData = data.projections[projectionIndex].data;
+    const proteinIds = data.protein_ids;
+    const n = proteinIds.length;
+
+    // Determine if any point is 3D
+    const is3D = projData.some((c) => c != null && c.length === 3);
+
+    if (isolationMode && isolationHistory && isolationHistory.length > 0) {
+      // Two-pass isolation: find surviving protein indices (those in EVERY layer set).
+      const layerSets = isolationHistory.map((layer) => new Set(layer));
+      const survivors: number[] = [];
+      for (let i = 0; i < n; i++) {
+        const id = proteinIds[i];
+        if (layerSets.every((s) => s.has(id))) {
+          survivors.push(i);
+        }
+      }
+
+      const count = survivors.length;
+      const xs = new Float32Array(count);
+      const ys = new Float32Array(count);
+      const zs = is3D ? new Float32Array(count) : null;
+      const originalIndices = new Int32Array(count);
+
+      for (let k = 0; k < count; k++) {
+        const origIdx = survivors[k];
+        const coords = (projData[origIdx] ?? [0, 0]) as [number, number] | [number, number, number];
+
+        let xVal = coords[0];
+        let yVal = coords[1];
+
+        if (coords.length === 3) {
+          if (zs) zs[k] = coords[2];
+          if (projectionPlane === 'xz') {
+            yVal = coords[2];
+          } else if (projectionPlane === 'yz') {
+            xVal = coords[1];
+            yVal = coords[2];
+          }
+        }
+
+        xs[k] = xVal;
+        ys[k] = yVal;
+        originalIndices[k] = origIdx;
+      }
+
+      return { length: count, xs, ys, zs, originalIndices, proteinIds };
+    }
+
+    // Non-isolated: identity mapping (originalIndices = null).
+    const xs = new Float32Array(n);
+    const ys = new Float32Array(n);
+    const zs = is3D ? new Float32Array(n) : null;
+
+    for (let i = 0; i < n; i++) {
+      const coords = (projData[i] ?? [0, 0]) as [number, number] | [number, number, number];
+
+      let xVal = coords[0];
+      let yVal = coords[1];
+
+      if (coords.length === 3) {
+        if (zs) zs[i] = coords[2];
+        if (projectionPlane === 'xz') {
+          yVal = coords[2];
+        } else if (projectionPlane === 'yz') {
+          xVal = coords[1];
+          yVal = coords[2];
+        }
+      }
+
+      xs[i] = xVal;
+      ys[i] = yVal;
+    }
+
+    return { length: n, xs, ys, zs, originalIndices: null, proteinIds };
   }
 
   static createScales(
-    plotData: PlotDataPoint[],
+    plotData: PlotData,
     width: number,
     height: number,
     margin: { top: number; right: number; bottom: number; left: number },
@@ -58,9 +106,22 @@ export class DataProcessor {
 
     let extents = extentCache.get(plotData);
     if (!extents) {
+      let xMin = Infinity,
+        xMax = -Infinity,
+        yMin = Infinity,
+        yMax = -Infinity;
+      const { xs, ys, length } = plotData;
+      for (let i = 0; i < length; i++) {
+        const x = xs[i];
+        const y = ys[i];
+        if (x < xMin) xMin = x;
+        if (x > xMax) xMax = x;
+        if (y < yMin) yMin = y;
+        if (y > yMax) yMax = y;
+      }
       extents = {
-        x: d3.extent(plotData, (d) => d.x) as [number, number],
-        y: d3.extent(plotData, (d) => d.y) as [number, number],
+        x: [xMin, xMax],
+        y: [yMin, yMax],
       };
       extentCache.set(plotData, extents);
     }

--- a/packages/utils/src/visualization/numeric-binning.test.ts
+++ b/packages/utils/src/visualization/numeric-binning.test.ts
@@ -40,7 +40,8 @@ describe('numeric-binning', () => {
     expect(result.annotation.numericMetadata?.bins.map((bin) => bin.count)).toEqual([
       2, 2, 2, 2, 2,
     ]);
-    expect(result.annotationData).toEqual([[0], [0], [1], [1], [2], [2], [3], [3], [4], [4]]);
+    expect(result.annotationData).toBeInstanceOf(Int32Array);
+    expect(Array.from(result.annotationData)).toEqual([0, 0, 1, 1, 2, 2, 3, 3, 4, 4]);
   });
 
   it('uses quantile settings when materializing visualization data', () => {
@@ -92,7 +93,10 @@ describe('numeric-binning', () => {
     expect(materialized.annotations.length.numericMetadata?.bins.map((bin) => bin.count)).toEqual([
       2, 2, 2,
     ]);
-    expect(materialized.annotation_data.length).toEqual([[0], [0], [1], [1], [2], [2]]);
+    expect(materialized.annotation_data.length).toBeInstanceOf(Int32Array);
+    expect(Array.from(materialized.annotation_data.length as Int32Array)).toEqual([
+      0, 0, 1, 1, 2, 2,
+    ]);
   });
 
   it('formats int labels without grouping or decimals and preserves numeric type metadata', () => {
@@ -264,7 +268,8 @@ describe('numeric-binning', () => {
     expect(materialized.annotations.weight.sourceKind).toBe('numeric');
     expect(materialized.annotations.weight.numericMetadata?.strategy).toBe('quantile');
     expect(materialized.annotation_data.length).toEqual([[], [], []]);
-    expect(materialized.annotation_data.weight).toEqual([[0], [1], [1]]);
+    expect(materialized.annotation_data.weight).toBeInstanceOf(Int32Array);
+    expect(Array.from(materialized.annotation_data.weight as Int32Array)).toEqual([0, 1, 1]);
   });
 
   it('falls back from logarithmic binning when non-positive values are present', () => {
@@ -304,7 +309,8 @@ describe('numeric-binning', () => {
       0, 0.375, 0.625, 1,
     ]);
     expect(result.annotation.numericMetadata?.bins.map((bin) => bin.count)).toEqual([1, 1, 1, 1]);
-    expect(result.annotationData).toEqual([[0], [1], [2], [3]]);
+    expect(result.annotationData).toBeInstanceOf(Int32Array);
+    expect(Array.from(result.annotationData)).toEqual([0, 1, 2, 3]);
   });
 
   it('uses the midpoint color when only one realized bin remains', () => {
@@ -350,7 +356,7 @@ describe('numeric-binning', () => {
       forward.annotation.numericMetadata?.signature,
     );
     expect(reversed.annotation.colors).toEqual([...forward.annotation.colors].reverse());
-    expect(reversed.annotationData).toEqual(forward.annotationData);
+    expect(Array.from(reversed.annotationData)).toEqual(Array.from(forward.annotationData));
   });
 
   it('changes the compatibility signature when bin counts change inside the same topology', () => {
@@ -383,7 +389,7 @@ describe('numeric-binning', () => {
     expect(result.annotation.numericMetadata?.binCount).toBe(result.annotation.values.length);
     expect(result.annotation.numericMetadata?.binCount).toBeLessThan(12);
     expect(result.annotation.numericMetadata?.bins.every((bin) => bin.count > 0)).toBe(true);
-    expect(Math.max(...result.annotationData.map((row) => row[0] ?? -1))).toBe(
+    expect(Math.max(...Array.from(result.annotationData))).toBe(
       (result.annotation.numericMetadata?.binCount ?? 1) - 1,
     );
   });
@@ -415,7 +421,8 @@ describe('numeric-binning', () => {
       '5 - 10',
     ]);
     expect(result.annotation.numericMetadata?.bins.map((bin) => bin.count)).toEqual([1, 2]);
-    expect(result.annotationData).toEqual([[0], [1], [1]]);
+    expect(result.annotationData).toBeInstanceOf(Int32Array);
+    expect(Array.from(result.annotationData)).toEqual([0, 1, 1]);
   });
 
   it('resolves persisted numeric settings with shared precedence rules', () => {
@@ -467,14 +474,14 @@ describe('numeric-binning', () => {
     expect(result.annotation.colors[1]).toBe('#FDE725'); // viridis end
 
     // Missing-value proteins assigned to N/A index
-    expect(result.annotationData[1]).toEqual([naIndex]);
-    expect(result.annotationData[3]).toEqual([naIndex]);
+    expect(result.annotationData[1]).toBe(naIndex);
+    expect(result.annotationData[3]).toBe(naIndex);
 
     // Non-missing proteins assigned to numeric bins
-    expect(result.annotationData[0].length).toBe(1);
-    expect(result.annotationData[0][0]).not.toBe(naIndex);
-    expect(result.annotationData[4].length).toBe(1);
-    expect(result.annotationData[4][0]).not.toBe(naIndex);
+    expect(result.annotationData[0]).toBeGreaterThanOrEqual(0);
+    expect(result.annotationData[0]).not.toBe(naIndex);
+    expect(result.annotationData[4]).toBeGreaterThanOrEqual(0);
+    expect(result.annotationData[4]).not.toBe(naIndex);
   });
 
   it('does not append N/A bin when there are no missing values', () => {
@@ -525,14 +532,14 @@ describe('numeric-binning', () => {
     expect(result.annotation.values).toHaveLength(binCount);
     expect(result.annotation.values).toContain(NA_VALUE);
 
-    // Every data point must be assigned to a bin (no empty annotationData)
+    // Every data point must be assigned to a bin (no missing annotationData)
     for (let i = 0; i < values.length; i++) {
-      expect(result.annotationData[i].length).toBe(1);
+      expect(result.annotationData[i]).toBeGreaterThanOrEqual(0);
     }
 
     // The highest value (49.5) must be in one of the numeric bins, not lost
     const lastDataIndex = 99; // index of value 49.5
-    const lastBinIdx = result.annotationData[lastDataIndex][0];
+    const lastBinIdx = result.annotationData[lastDataIndex];
     expect(result.annotation.values[lastBinIdx]).not.toBe(NA_VALUE);
 
     // The gradient must use the full color spectrum
@@ -560,8 +567,8 @@ describe('numeric-binning', () => {
     expect(numericBins).toHaveLength(1);
 
     // All data points still assigned
-    for (const data of result.annotationData) {
-      expect(data.length).toBe(1);
+    for (let i = 0; i < result.annotationData.length; i++) {
+      expect(result.annotationData[i]).toBeGreaterThanOrEqual(0);
     }
   });
 });

--- a/packages/utils/src/visualization/numeric-binning.test.ts
+++ b/packages/utils/src/visualization/numeric-binning.test.ts
@@ -50,14 +50,8 @@ describe('numeric-binning', () => {
       projections: [
         {
           name: 'UMAP',
-          data: [
-            [0, 0],
-            [1, 1],
-            [2, 2],
-            [3, 3],
-            [4, 4],
-            [5, 5],
-          ],
+          data: Float32Array.of(0, 0, 1, 1, 2, 2, 3, 3, 4, 4, 5, 5),
+          dimension: 2,
         },
       ],
       annotations: {
@@ -190,11 +184,8 @@ describe('numeric-binning', () => {
       projections: [
         {
           name: 'UMAP',
-          data: [
-            [0, 0],
-            [1, 1],
-            [2, 2],
-          ],
+          data: Float32Array.of(0, 0, 1, 1, 2, 2),
+          dimension: 2,
         },
       ],
       annotations: {
@@ -232,11 +223,8 @@ describe('numeric-binning', () => {
       projections: [
         {
           name: 'UMAP',
-          data: [
-            [0, 0],
-            [1, 1],
-            [2, 2],
-          ],
+          data: Float32Array.of(0, 0, 1, 1, 2, 2),
+          dimension: 2,
         },
       ],
       annotations: {
@@ -580,10 +568,8 @@ describe('materializeVisualizationData null-selection gate', () => {
       projections: [
         {
           name: 'UMAP',
-          data: [
-            [0, 0],
-            [1, 1],
-          ],
+          data: Float32Array.of(0, 0, 1, 1),
+          dimension: 2,
         },
       ],
       annotations: {
@@ -622,10 +608,8 @@ describe('materializeVisualizationData null-selection gate', () => {
       projections: [
         {
           name: 'UMAP',
-          data: [
-            [0, 0],
-            [1, 1],
-          ],
+          data: Float32Array.of(0, 0, 1, 1),
+          dimension: 2,
         },
       ],
       annotations: {

--- a/packages/utils/src/visualization/numeric-binning.ts
+++ b/packages/utils/src/visualization/numeric-binning.ts
@@ -588,7 +588,7 @@ export function materializeNumericAnnotation(
   numericType?: NumericAnnotationType,
 ): {
   annotation: Annotation;
-  annotationData: number[][];
+  annotationData: Int32Array;
 } {
   const summary = createSummary(values, {
     includeSortedValues: settings.strategy === 'quantile',
@@ -627,7 +627,7 @@ export function materializeNumericAnnotation(
           bins: [],
         },
       },
-      annotationData: values.map(() => []),
+      annotationData: new Int32Array(values.length).fill(-1),
     };
   }
 
@@ -686,11 +686,16 @@ export function materializeNumericAnnotation(
     }
   }
 
-  const annotationData = rawBinIndices.map((binIndex) => {
-    if (binIndex < 0) return [];
-    const realizedIndex = originalToRealizedIndex.get(binIndex);
-    return realizedIndex == null ? [] : [realizedIndex];
-  });
+  const annotationData = new Int32Array(rawBinIndices.length);
+  for (let i = 0; i < rawBinIndices.length; i++) {
+    const binIndex = rawBinIndices[i];
+    if (binIndex < 0) {
+      annotationData[i] = -1;
+    } else {
+      const realizedIndex = originalToRealizedIndex.get(binIndex);
+      annotationData[i] = realizedIndex == null ? -1 : realizedIndex;
+    }
+  }
 
   const colorPositions = createColorPositions(effectiveSettings.strategy, bins, summary);
   const colors = createBinColors(
@@ -733,9 +738,7 @@ export function materializeNumericAnnotation(
     finalShapes.push('circle');
 
     for (let i = 0; i < annotationData.length; i++) {
-      if (annotationData[i].length === 0) {
-        annotationData[i] = [naIndex];
-      }
+      if (annotationData[i] < 0) annotationData[i] = naIndex;
     }
   }
 

--- a/packages/utils/src/visualization/plot-data-accessors.test.ts
+++ b/packages/utils/src/visualization/plot-data-accessors.test.ts
@@ -15,11 +15,8 @@ const baseData = (): VisualizationData => ({
   projections: [
     {
       name: 't',
-      data: [
-        [0, 0],
-        [1, 1],
-        [2, 2],
-      ],
+      data: Float32Array.of(0, 0, 1, 1, 2, 2),
+      dimension: 2,
     },
   ],
   annotations: {
@@ -178,7 +175,7 @@ describe('plot-data-accessors', () => {
     it('falls back to "Gene name" / "Protein name" keys when snake_case keys are absent', () => {
       const data: VisualizationData = {
         protein_ids: ['p0'],
-        projections: [{ name: 't', data: [[0, 0]] }],
+        projections: [{ name: 't', data: Float32Array.of(0, 0), dimension: 2 as const }],
         annotations: {
           'Gene name': {
             kind: 'categorical',
@@ -206,7 +203,7 @@ describe('plot-data-accessors', () => {
     it('prefers gene_name over "Gene name" / protein_name over "Protein name" when both are present', () => {
       const data: VisualizationData = {
         protein_ids: ['p0'],
-        projections: [{ name: 't', data: [[0, 0]] }],
+        projections: [{ name: 't', data: Float32Array.of(0, 0), dimension: 2 as const }],
         annotations: {
           gene_name: {
             kind: 'categorical',

--- a/packages/utils/src/visualization/plot-data.test.ts
+++ b/packages/utils/src/visualization/plot-data.test.ts
@@ -1,0 +1,162 @@
+import { describe, it, expect } from 'vitest';
+import {
+  EMPTY_PLOT_DATA,
+  plotDataOriginalIndex,
+  plotDataId,
+  materializePlotDataPoint,
+  clonePlotData,
+  gatherPlotData,
+} from './plot-data';
+import type { PlotData } from '../types';
+
+function makeIdentityPD(xs: number[], ys: number[], ids?: string[]): PlotData {
+  return {
+    length: xs.length,
+    xs: new Float32Array(xs),
+    ys: new Float32Array(ys),
+    zs: null,
+    originalIndices: null,
+    proteinIds: ids ?? xs.map((_, i) => `p${i}`),
+  };
+}
+
+function makeIsolatedPD(
+  xs: number[],
+  ys: number[],
+  originalIndices: number[],
+  proteinIds: string[],
+): PlotData {
+  return {
+    length: xs.length,
+    xs: new Float32Array(xs),
+    ys: new Float32Array(ys),
+    zs: null,
+    originalIndices: new Int32Array(originalIndices),
+    proteinIds,
+  };
+}
+
+describe('EMPTY_PLOT_DATA', () => {
+  it('has length 0 and empty typed arrays', () => {
+    expect(EMPTY_PLOT_DATA.length).toBe(0);
+    expect(EMPTY_PLOT_DATA.xs.length).toBe(0);
+    expect(EMPTY_PLOT_DATA.ys.length).toBe(0);
+    expect(EMPTY_PLOT_DATA.zs).toBeNull();
+    expect(EMPTY_PLOT_DATA.originalIndices).toBeNull();
+    expect(EMPTY_PLOT_DATA.proteinIds).toHaveLength(0);
+  });
+});
+
+describe('plotDataOriginalIndex', () => {
+  it('returns slot index directly when originalIndices is null (identity mapping)', () => {
+    const pd = makeIdentityPD([1, 2, 3], [4, 5, 6]);
+    expect(plotDataOriginalIndex(pd, 0)).toBe(0);
+    expect(plotDataOriginalIndex(pd, 2)).toBe(2);
+  });
+
+  it('returns mapped protein index when originalIndices is present', () => {
+    const pd = makeIsolatedPD([5, 7], [6, 8], [2, 3], ['a', 'b', 'c', 'd']);
+    expect(plotDataOriginalIndex(pd, 0)).toBe(2);
+    expect(plotDataOriginalIndex(pd, 1)).toBe(3);
+  });
+});
+
+describe('plotDataId', () => {
+  it('returns correct protein id for identity mapping', () => {
+    const pd = makeIdentityPD([1, 2], [3, 4], ['alpha', 'beta']);
+    expect(plotDataId(pd, 0)).toBe('alpha');
+    expect(plotDataId(pd, 1)).toBe('beta');
+  });
+
+  it('returns correct protein id for isolated mapping', () => {
+    const pd = makeIsolatedPD([5, 7], [6, 8], [2, 3], ['a', 'b', 'c', 'd']);
+    expect(plotDataId(pd, 0)).toBe('c'); // originalIndices[0] = 2 → proteinIds[2]
+    expect(plotDataId(pd, 1)).toBe('d'); // originalIndices[1] = 3 → proteinIds[3]
+  });
+});
+
+describe('materializePlotDataPoint', () => {
+  it('creates correct PlotDataPoint for identity-mapped slot', () => {
+    const pd = makeIdentityPD([1, 3], [2, 4], ['p0', 'p1']);
+    const pt = materializePlotDataPoint(pd, 1);
+    expect(pt).toEqual({ id: 'p1', x: 3, y: 4, originalIndex: 1 });
+  });
+
+  it('creates correct PlotDataPoint for isolated slot', () => {
+    // slot 0 → protein index 2 → id 'c'
+    const pd = makeIsolatedPD([5, 7], [6, 8], [2, 3], ['a', 'b', 'c', 'd']);
+    const pt = materializePlotDataPoint(pd, 0);
+    expect(pt).toEqual({ id: 'c', x: 5, y: 6, originalIndex: 2 });
+  });
+
+  it('includes z field when zs is present', () => {
+    const pd: PlotData = {
+      length: 1,
+      xs: new Float32Array([10]),
+      ys: new Float32Array([20]),
+      zs: new Float32Array([30]),
+      originalIndices: null,
+      proteinIds: ['x'],
+    };
+    const pt = materializePlotDataPoint(pd, 0);
+    expect(pt.z).toBe(30);
+  });
+
+  it('omits z field when zs is null', () => {
+    const pd = makeIdentityPD([1], [2], ['p0']);
+    const pt = materializePlotDataPoint(pd, 0);
+    expect('z' in pt).toBe(false);
+  });
+});
+
+describe('clonePlotData', () => {
+  it('returns a new object with the SAME typed-array references', () => {
+    const pd = makeIdentityPD([1, 2], [3, 4]);
+    const clone = clonePlotData(pd);
+    expect(clone).not.toBe(pd); // different container
+    expect(clone.xs).toBe(pd.xs); // same buffer ref
+    expect(clone.ys).toBe(pd.ys);
+    expect(clone.length).toBe(pd.length);
+    expect(clone.originalIndices).toBeNull();
+    expect(clone.proteinIds).toBe(pd.proteinIds);
+  });
+});
+
+describe('gatherPlotData', () => {
+  it('gathers a subset of slots into a new PlotData', () => {
+    const pd = makeIdentityPD([10, 20, 30, 40], [1, 2, 3, 4], ['a', 'b', 'c', 'd']);
+    const gathered = gatherPlotData(pd, [1, 3]);
+    expect(gathered.length).toBe(2);
+    expect(Array.from(gathered.xs)).toEqual([20, 40]);
+    expect(Array.from(gathered.ys)).toEqual([2, 4]);
+    expect(gathered.originalIndices).not.toBeNull();
+    expect(Array.from(gathered.originalIndices!)).toEqual([1, 3]);
+    expect(gathered.proteinIds).toBe(pd.proteinIds); // shared ref
+  });
+
+  it('propagates zs when source has zs', () => {
+    const pd: PlotData = {
+      length: 3,
+      xs: new Float32Array([1, 2, 3]),
+      ys: new Float32Array([4, 5, 6]),
+      zs: new Float32Array([7, 8, 9]),
+      originalIndices: null,
+      proteinIds: ['p0', 'p1', 'p2'],
+    };
+    const gathered = gatherPlotData(pd, [0, 2]);
+    expect(gathered.zs).not.toBeNull();
+    expect(Array.from(gathered.zs!)).toEqual([7, 9]);
+  });
+
+  it('returns null zs when source has no zs', () => {
+    const pd = makeIdentityPD([1, 2], [3, 4]);
+    const gathered = gatherPlotData(pd, [0]);
+    expect(gathered.zs).toBeNull();
+  });
+
+  it('handles empty slots array', () => {
+    const pd = makeIdentityPD([1, 2, 3], [4, 5, 6]);
+    const gathered = gatherPlotData(pd, []);
+    expect(gathered.length).toBe(0);
+  });
+});

--- a/packages/utils/src/visualization/plot-data.ts
+++ b/packages/utils/src/visualization/plot-data.ts
@@ -1,0 +1,55 @@
+import type { PlotData, PlotDataPoint } from '../types.js';
+
+export const EMPTY_PLOT_DATA: PlotData = {
+  length: 0,
+  xs: new Float32Array(0),
+  ys: new Float32Array(0),
+  zs: null,
+  originalIndices: null,
+  proteinIds: [],
+};
+
+/** Protein index for a slot (handles the identity-mapping fast path). */
+export function plotDataOriginalIndex(pd: PlotData, slot: number): number {
+  return pd.originalIndices ? pd.originalIndices[slot] : slot;
+}
+
+/** Protein id for a slot. */
+export function plotDataId(pd: PlotData, slot: number): string {
+  return pd.proteinIds[plotDataOriginalIndex(pd, slot)];
+}
+
+/** Materialize a boxed PlotDataPoint for a slot — use only at interaction boundaries. */
+export function materializePlotDataPoint(pd: PlotData, slot: number): PlotDataPoint {
+  const originalIndex = plotDataOriginalIndex(pd, slot);
+  const point: PlotDataPoint = {
+    id: pd.proteinIds[originalIndex],
+    x: pd.xs[slot],
+    y: pd.ys[slot],
+    originalIndex,
+  };
+  if (pd.zs) point.z = pd.zs[slot];
+  return point;
+}
+
+/** Shallow clone (SAME typed-array refs) — to trigger Lit @state reactivity after in-place coord mutation. */
+export function clonePlotData(pd: PlotData): PlotData {
+  return { ...pd };
+}
+
+/** Gather a subset PlotData for the given slots (used only by >1M viewport virtualization). */
+export function gatherPlotData(pd: PlotData, slots: ArrayLike<number>): PlotData {
+  const n = slots.length;
+  const xs = new Float32Array(n);
+  const ys = new Float32Array(n);
+  const zs = pd.zs ? new Float32Array(n) : null;
+  const originalIndices = new Int32Array(n);
+  for (let i = 0; i < n; i++) {
+    const slot = slots[i];
+    xs[i] = pd.xs[slot];
+    ys[i] = pd.ys[slot];
+    if (zs && pd.zs) zs[i] = pd.zs[slot];
+    originalIndices[i] = plotDataOriginalIndex(pd, slot);
+  }
+  return { length: n, xs, ys, zs, originalIndices, proteinIds: pd.proteinIds };
+}

--- a/perf/README.md
+++ b/perf/README.md
@@ -12,6 +12,23 @@ PERF_ITERATIONS=5 pnpm perf      # override iteration count
 This launches headed browsers (Chrome, Firefox, Safari), loads every dataset
 listed in `app/public/data/datasets.json`, and runs four scenarios per dataset:
 
+#### Scoping to specific datasets
+
+Use `PERF_DATASETS` (comma-separated dataset IDs) to benchmark only the
+datasets you care about. This is especially useful for the large `573K_swissprot`
+dataset, which is too slow to include in every full suite run:
+
+```sh
+# Benchmark only the 573K SwissProt dataset, Chrome only
+PERF_DATASETS=573K_swissprot pnpm perf -- --project=chrome
+
+# Multiple datasets
+PERF_DATASETS=573K_swissprot,127K_beta_lactamase pnpm perf -- --project=chrome
+```
+
+The spec passes the IDs to the in-page suite via the `webglPerfDatasets` URL
+parameter, which overrides the default `datasets.json` list.
+
 | Scenario           | What it measures                      |
 | ------------------ | ------------------------------------- |
 | `annotationChange` | Re-render after switching annotations |
@@ -33,6 +50,42 @@ perf/test-results/
 
 Each JSON contains per-dataset, per-scenario render-pass timings, dataset
 metadata (point count), and browser/hardware metadata collected at runtime.
+
+#### Per-dataset `load` metrics and CDP heap sidecar
+
+Each per-dataset result now includes a `load` block:
+
+```json
+{
+  "dataset": { "id": "573K_swissprot", ... },
+  "scenarios": [...],
+  "load": {
+    "datasetId": "573K_swissprot",
+    "loadDurationMs": 4321.5,
+    "heapBefore":    { "usedBytes": 45000000, "totalBytes": 60000000, "limitBytes": 4294705152 },
+    "heapAfterLoad": { "usedBytes": 312000000, "totalBytes": 380000000, "limitBytes": 4294705152 },
+    "heapSteady":    { "usedBytes": 290000000, "totalBytes": 360000000, "limitBytes": 4294705152 },
+    "peakUsedDuringLoadBytes": 325000000
+  }
+}
+```
+
+- `heapBefore` / `heapAfterLoad` / `heapSteady` — in-page `performance.memory`
+  samples (bytes). Chrome is launched with `--enable-precise-memory-info` so
+  these are byte-accurate rather than bucketed.
+- `peakUsedDuringLoadBytes` — best-effort in-page poll max during the load
+  window (50 ms intervals; may miss synchronous-decode peaks).
+- A `*-cdp.json` sidecar file is written alongside the main JSON for Chrome
+  runs. It contains the out-of-process `JSHeapUsedSize` peak sampled via the
+  Chrome DevTools Protocol every ~200 ms:
+
+```
+perf/test-results/webgl-perf-suite-chrome/
+  webgl-perf-suite-chrome.json
+  webgl-perf-suite-chrome-cdp.json   <-- { peakJSHeapUsedBytes, samples: [{t, bytes}] }
+```
+
+The CDP sidecar is best-effort and is silently skipped on Firefox and Safari.
 
 ### 2. Generate plots
 

--- a/perf/playwright.config.ts
+++ b/perf/playwright.config.ts
@@ -36,6 +36,8 @@ export default defineConfig({
             '--disable-renderer-backgrounding',
             '--disable-features=CalculateNativeWinOcclusion',
             '--disable-frame-rate-limit',
+            // Memory — make performance.memory byte-accurate instead of bucketed
+            '--enable-precise-memory-info',
           ],
         },
       },

--- a/perf/webgl-perf.spec.ts
+++ b/perf/webgl-perf.spec.ts
@@ -36,7 +36,14 @@ test.describe('WebGL render perf benchmark (headed)', () => {
       predicate: (dl) => dl.suggestedFilename().includes('webgl-perf-suite'),
     });
 
-    await page.goto(`/explore?webglPerf=1&webglPerfIterations=${ITERATIONS}`);
+    // Build the goto URL, optionally scoping to specific datasets
+    const rawDatasets = process.env.PERF_DATASETS;
+    const datasetsParam =
+      rawDatasets && rawDatasets.trim().length > 0
+        ? `&webglPerfDatasets=${encodeURIComponent(rawDatasets.trim())}`
+        : '';
+
+    await page.goto(`/explore?webglPerf=1&webglPerfIterations=${ITERATIONS}${datasetsParam}`);
     await page.bringToFront();
 
     await Promise.race([
@@ -52,6 +59,39 @@ test.describe('WebGL render perf benchmark (headed)', () => {
       }),
     ]);
 
+    // Best-effort CDP peak-heap poller (Chrome only)
+    let polling = true;
+    let maxBytes: number | null = null;
+    const samples: Array<{ t: number; bytes: number }> = [];
+    let cdpPollLoop: Promise<void> = Promise.resolve();
+
+    if (testInfo.project.name === 'chrome') {
+      try {
+        const client = await page.context().newCDPSession(page);
+        await client.send('Performance.enable');
+
+        cdpPollLoop = (async () => {
+          while (polling) {
+            try {
+              const { metrics } = await client.send('Performance.getMetrics');
+              const heapUsed = (metrics as Array<{ name: string; value: number }>).find(
+                (m) => m.name === 'JSHeapUsedSize',
+              )?.value;
+              if (typeof heapUsed === 'number') {
+                if (maxBytes === null || heapUsed > maxBytes) maxBytes = heapUsed;
+                samples.push({ t: Date.now(), bytes: heapUsed });
+              }
+            } catch {
+              // ignore individual poll errors
+            }
+            await new Promise<void>((resolve) => setTimeout(resolve, 200));
+          }
+        })();
+      } catch {
+        // CDP not available — skip silently
+      }
+    }
+
     const dl = await Promise.race([
       downloadPromise,
       firstPageError.then((err) => {
@@ -61,14 +101,41 @@ test.describe('WebGL render perf benchmark (headed)', () => {
     const savedTo = testInfo.outputPath(`webgl-perf-suite-${testInfo.project.name}.json`);
     await dl.saveAs(savedTo);
 
-    const suite = JSON.parse(fs.readFileSync(savedTo, 'utf-8')) as any;
+    // Stop CDP poller and write sidecar
+    polling = false;
+    try {
+      await cdpPollLoop;
+    } catch {
+      // ignore
+    }
+    if (testInfo.project.name === 'chrome' && maxBytes !== null) {
+      try {
+        const cdpPath = testInfo.outputPath(`webgl-perf-suite-${testInfo.project.name}-cdp.json`);
+        fs.writeFileSync(
+          cdpPath,
+          JSON.stringify({ peakJSHeapUsedBytes: maxBytes, samples }, null, 2),
+        );
+        console.log('CDP peak JSHeapUsedSize bytes:', maxBytes);
+      } catch {
+        // best-effort — never fail the test
+      }
+    }
+
+    const suite = JSON.parse(fs.readFileSync(savedTo, 'utf-8')) as {
+      createdAt: string;
+      iterations: number;
+      results: Array<{
+        dataset: { id: string };
+        scenarios: Array<{ name: string }>;
+      }>;
+    };
     expect(suite).toBeTruthy();
     expect(typeof suite.createdAt).toBe('string');
     expect(suite.iterations).toBe(ITERATIONS);
     expect(Array.isArray(suite.results)).toBeTruthy();
     expect((suite.results as unknown[]).length).toBeGreaterThan(0);
 
-    const results = suite.results as any[];
+    const results = suite.results;
     const datasetIds = results.map((r) => r?.dataset?.id);
     for (const id of datasetIds) {
       expect(typeof id).toBe('string');
@@ -80,7 +147,7 @@ test.describe('WebGL render perf benchmark (headed)', () => {
       expect(r).toBeTruthy();
       expect(Array.isArray(r.scenarios)).toBeTruthy();
 
-      const scenarioNames = (r.scenarios as any[]).map((s) => s?.name).filter(Boolean);
+      const scenarioNames = r.scenarios.map((s) => s?.name).filter(Boolean);
       for (const expected of EXPECTED_SCENARIOS) {
         expect(scenarioNames).toContain(expected);
       }

--- a/scripts/docs-screenshots/capture-animations.spec.ts
+++ b/scripts/docs-screenshots/capture-animations.spec.ts
@@ -45,11 +45,12 @@ async function collectClusterScreenPoints(
     };
 
     const targetPoints: Array<{ sx: number; sy: number }> = [];
-    for (const point of plotData) {
-      const values = readValuesAt(point.originalIndex);
-      if (values.some((v) => v?.includes(needle))) {
-        const sx = plotRect.left + scales.x(point.x) * transform.k + transform.x;
-        const sy = plotRect.top + scales.y(point.y) * transform.k + transform.y;
+    for (let i = 0; i < plotData.length; i++) {
+      const origIdx = plotData.originalIndices ? plotData.originalIndices[i] : i;
+      const values = readValuesAt(origIdx);
+      if (values.some((v: string | null) => v?.includes(needle))) {
+        const sx = plotRect.left + scales.x(plotData.xs[i]) * transform.k + transform.x;
+        const sy = plotRect.top + scales.y(plotData.ys[i]) * transform.k + transform.y;
         targetPoints.push({ sx, sy });
       }
     }


### PR DESCRIPTION
## Summary

Makes the 573,649-protein SwissProt dataset usable client-side. Before this branch the dataset pushed the tab toward the ~4 GB "Aw, Snap!" crash, froze the UI for ~24 s on load, and froze it again for ~20 s on Isolate. After: peak memory is down 3.5×, and both load and isolate run without freezing the UI.

## Results (573K SwissProt, Chrome `pnpm perf` A/B)

| Metric | Before | After | Improvement |
|---|---|---|---|
| Peak memory (load) | ~2336 MiB | **664 MiB** | **−72% (3.5×)** |
| Steady memory | ~2255 MiB | **620 MiB** | **−72%** |
| Load UI freeze (main-thread block) | ~24 s frozen | **0 s blocked** (load runs in background) | UI stays responsive |
| Isolate action | ~20 s frozen | **< 1 s** | responsive |
| Legend re-filter (`getFilteredIndices`) | ~18.5 s | **~18 ms** | **~1000×** |
| Convert/parse phase | ~15 s | **~9–11 s** | **~30%** |

## How

- **Tier 1 — memory & load freeze:** moved parquet decode + conversion into a Web Worker (off the main thread, ~470 MB of scratch freed on terminate), and replaced the 573K boxed point objects with a Struct-of-Arrays model (`Float32Array` coords, `Int32Array` annotations). Plus right-sized GPU buffers, incremental label-texture updates, and allocation-free depth sorting.
- **Tier 2 — Isolate:** replaced an O(N × subset) `Array.includes` membership scan (~82B comparisons) with per-layer `Set` membership, and reused the already-computed survivor→row map instead of rescanning all 573K rows per numeric column.
- **Tier 3 — load time:** annotation columns are dictionary-encoded, so the converter was re-parsing the same ~22 distinct strings hundreds of thousands of times, twice. Now parses each cell once (CONV-O1) and memoizes per distinct value (CONV-O2) — byte-identical output, ~1.74× faster extraction.

fixes #255