### PR TITLE
feat: surface support inbox across the interface

### DIFF
--- a/app/src/components/ErrorBoundary.test.ts
+++ b/app/src/components/ErrorBoundary.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest';
+import { ErrorBoundary, buildCrashLinks } from './ErrorBoundary';
+
+// The project's Vitest harness runs in Node without a DOM, so this exercises
+// the boundary's error-capture logic and its (pure) report-link builder rather
+// than a full render.
+
+describe('ErrorBoundary.getDerivedStateFromError', () => {
+  it('flags the error state when a child throws', () => {
+    const error = new Error('render boom');
+
+    expect(ErrorBoundary.getDerivedStateFromError(error)).toEqual({
+      hasError: true,
+      error,
+    });
+  });
+});
+
+describe('buildCrashLinks', () => {
+  it('produces a prefilled mailto and GitHub-issue link carrying context', () => {
+    const { mailtoHref, issueHref } = buildCrashLinks(
+      new Error('render boom'),
+      'https://protspace.app/explore',
+      'TestAgent/1.0',
+    );
+
+    expect(mailtoHref).toMatch(/^mailto:hello@protspace\.app\?/);
+    expect(mailtoHref).toContain('subject=%5BBug%5D%20App%20crashed');
+    expect(mailtoHref).toContain('render%20boom');
+    expect(mailtoHref).toContain(encodeURIComponent('https://protspace.app/explore'));
+
+    expect(issueHref).toMatch(/\/issues\/new\?/);
+    expect(issueHref).toContain('labels=bug');
+    expect(issueHref).toContain('render%20boom');
+  });
+});

--- a/app/src/components/ErrorBoundary.tsx
+++ b/app/src/components/ErrorBoundary.tsx
@@ -1,0 +1,84 @@
+import { Component, type ErrorInfo, type ReactNode } from 'react';
+import { Button } from '@/components/ui/button';
+import { buildBugContext, buildIssueUrl, buildMailto } from '@/lib/support';
+
+/**
+ * Build the prefilled email and GitHub-issue links for a crash report. Pure so
+ * it can be unit-tested without rendering; the component injects the page URL
+ * and user agent at render time.
+ */
+export function buildCrashLinks(
+  error: unknown,
+  page?: string,
+  userAgent?: string,
+): { mailtoHref: string; issueHref: string } {
+  const body = buildBugContext({ operation: 'app-crash', error, page, userAgent });
+
+  return {
+    mailtoHref: buildMailto({ subject: '[Bug] App crashed', body }),
+    issueHref: buildIssueUrl({ title: '[Bug] App crashed', body }),
+  };
+}
+
+interface ErrorBoundaryProps {
+  children: ReactNode;
+}
+
+interface ErrorBoundaryState {
+  hasError: boolean;
+  error: unknown;
+}
+
+/**
+ * Top-level boundary that replaces a blank screen on a render-time crash with a
+ * recovery fallback offering Reload, a prefilled support email, and a prefilled
+ * GitHub issue.
+ */
+export class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundaryState> {
+  state: ErrorBoundaryState = { hasError: false, error: null };
+
+  static getDerivedStateFromError(error: unknown): ErrorBoundaryState {
+    return { hasError: true, error };
+  }
+
+  componentDidCatch(error: unknown, info: ErrorInfo): void {
+    console.error('ProtSpace crashed:', error, info);
+  }
+
+  private handleReload = (): void => {
+    window.location.reload();
+  };
+
+  render(): ReactNode {
+    if (!this.state.hasError) {
+      return this.props.children;
+    }
+
+    const page = typeof window !== 'undefined' ? window.location.href : undefined;
+    const userAgent = typeof navigator !== 'undefined' ? navigator.userAgent : undefined;
+    const { mailtoHref, issueHref } = buildCrashLinks(this.state.error, page, userAgent);
+
+    return (
+      <div className="flex min-h-screen items-center justify-center bg-background px-4">
+        <div className="max-w-md text-center">
+          <h1 className="mb-3 text-2xl font-bold text-foreground">Something went wrong</h1>
+          <p className="mb-6 text-muted-foreground">
+            ProtSpace hit an unexpected error. Reloading often helps. If it keeps happening, let us
+            know — the report is prefilled with technical details.
+          </p>
+          <div className="flex flex-col items-center justify-center gap-3 sm:flex-row">
+            <Button onClick={this.handleReload}>Reload</Button>
+            <Button variant="outline" asChild>
+              <a href={mailtoHref}>Email us</a>
+            </Button>
+            <Button variant="outline" asChild>
+              <a href={issueHref} target="_blank" rel="noopener noreferrer">
+                Open a GitHub issue
+              </a>
+            </Button>
+          </div>
+        </div>
+      </div>
+    );
+  }
+}

--- a/app/src/components/Footer.tsx
+++ b/app/src/components/Footer.tsx
@@ -1,5 +1,6 @@
 import { GitHubIcon } from '@/components/icons/brand-icons';
 import { DOCS_URL } from '@/config';
+import { buildMailto } from '@/lib/support';
 import { Link } from 'react-router-dom';
 
 const Footer = () => {
@@ -28,6 +29,12 @@ const Footer = () => {
               className="text-sm text-muted-foreground hover:text-primary transition-colors"
             >
               Documentation
+            </a>
+            <a
+              href={buildMailto({ subject: 'ProtSpace contact' })}
+              className="text-sm text-muted-foreground hover:text-primary transition-colors"
+            >
+              Contact
             </a>
             <Link
               to="/privacy"

--- a/app/src/components/Header.tsx
+++ b/app/src/components/Header.tsx
@@ -1,9 +1,13 @@
-import { Menu, X, ChevronDown } from 'lucide-react';
+import { Menu, X, ChevronDown, MessageSquareText } from 'lucide-react';
 import { useState } from 'react';
 import { Link } from 'react-router-dom';
 import { GitHubIcon } from '@/components/icons/brand-icons';
+import { Button } from '@/components/ui/button';
+import { buildMailto } from '@/lib/support';
 import { cn } from '@/lib/utils';
 import { getNavigation } from '../../../config/navigation';
+
+const FEEDBACK_HREF = buildMailto({ subject: 'ProtSpace feedback' });
 
 const mode = import.meta.env.MODE === 'production' ? 'production' : 'development';
 const navItems = getNavigation(mode);
@@ -121,6 +125,14 @@ const Header = ({ variant = 'default', className }: HeaderProps) => {
                 </a>
               );
             })}
+
+            {/* Feedback CTA */}
+            <Button asChild size="sm">
+              <a href={FEEDBACK_HREF}>
+                <MessageSquareText />
+                Feedback
+              </a>
+            </Button>
           </nav>
 
           {/* Mobile Menu Button */}
@@ -218,6 +230,14 @@ const Header = ({ variant = 'default', className }: HeaderProps) => {
                 </a>
               );
             })}
+
+            {/* Feedback CTA */}
+            <Button asChild size="sm" className="w-full mt-2">
+              <a href={FEEDBACK_HREF} onClick={() => setIsMenuOpen(false)}>
+                <MessageSquareText />
+                Feedback
+              </a>
+            </Button>
           </nav>
         )}
       </div>

--- a/app/src/explore/notifications.test.ts
+++ b/app/src/explore/notifications.test.ts
@@ -155,4 +155,20 @@ describe('explore notifications', () => {
       description: 'Disk full',
     });
   });
+
+  it('attaches a "Report this" mailto action to the import failure notification', () => {
+    const action = getDataLoadFailureNotification(dataError('Invalid parquet bundle')).action;
+
+    expect(action?.label).toBe('Report this');
+    expect(action?.href).toMatch(/^mailto:hello@protspace\.app\?/);
+    expect(action?.href).toContain('subject=%5BBug%5D%20Dataset%20import%20failed');
+  });
+
+  it('attaches a "Report this" mailto action to the export failure notification', () => {
+    const action = getExportFailureNotification(new Error('Disk full')).action;
+
+    expect(action?.label).toBe('Report this');
+    expect(action?.href).toMatch(/^mailto:hello@protspace\.app\?/);
+    expect(action?.href).toContain('subject=%5BBug%5D%20Export%20failed');
+  });
 });

--- a/app/src/explore/notifications.ts
+++ b/app/src/explore/notifications.ts
@@ -4,8 +4,23 @@ import type {
   SelectionDisabledNotificationDetail,
 } from '@protspace/core';
 import type { NotifyOptions } from '../lib/notify';
+import { buildBugContext, buildMailto, clientContext } from '../lib/support';
 import { FastaPrepError } from './fasta-prep-client';
 import { MAX_UPLOAD_LABEL, MAX_SEQUENCES } from './fasta-prep-limits';
+
+/**
+ * Build a "Report this" toast action that opens a prefilled support email
+ * describing the failing operation and its error.
+ */
+function buildReportAction(operation: string, error: unknown): NotifyOptions['action'] {
+  return {
+    label: 'Report this',
+    href: buildMailto({
+      subject: `[Bug] ${operation} failed`,
+      body: buildBugContext({ operation, error, ...clientContext() }),
+    }),
+  };
+}
 
 /**
  * Friendly, actionable copy for the prep backend's known error codes. When a
@@ -106,6 +121,7 @@ export function getDataLoadFailureNotification(detail: DataErrorEventDetail): No
     description,
     durationMs: 10_000,
     dedupeKey,
+    action: buildReportAction('Dataset import', prepError ?? detail.message),
   };
 }
 
@@ -123,6 +139,7 @@ export function getExportFailureNotification(error: unknown): NotifyOptions {
     description: getErrorMessage(error),
     durationMs: 10_000,
     dedupeKey: `export-error:${getErrorMessage(error)}`,
+    action: buildReportAction('Export', error),
   };
 }
 

--- a/app/src/lib/notify.test.ts
+++ b/app/src/lib/notify.test.ts
@@ -47,4 +47,24 @@ describe('notify', () => {
 
     expect(mockedToast.error).toHaveBeenCalledTimes(2);
   });
+
+  it('forwards an action to sonner as a label and onClick handler', () => {
+    notify.error({
+      title: 'Export failed.',
+      action: { label: 'Report this', href: 'mailto:hello@protspace.app?subject=x' },
+    });
+
+    const [, payload] = mockedToast.error.mock.calls[0];
+    expect(payload.action).toEqual({
+      label: 'Report this',
+      onClick: expect.any(Function),
+    });
+  });
+
+  it('omits the action key when no action is provided', () => {
+    notify.success({ title: 'Export ready.' });
+
+    const [, payload] = mockedToast.success.mock.calls[0];
+    expect(payload).not.toHaveProperty('action');
+  });
 });

--- a/app/src/lib/notify.ts
+++ b/app/src/lib/notify.ts
@@ -1,10 +1,19 @@
 import { toast } from '../components/ui/sonner';
 
+export interface NotifyAction {
+  /** Button label shown on the toast. */
+  label: string;
+  /** Link the action opens — a `mailto:` or an `http(s)` URL. */
+  href: string;
+}
+
 export interface NotifyOptions {
   title: string;
   description?: string;
   durationMs?: number;
   dedupeKey?: string;
+  /** Optional action button (e.g. a "Report this" bug-report link). */
+  action?: NotifyAction;
 }
 
 type NotifyLevel = 'success' | 'info' | 'warning' | 'error';
@@ -44,6 +53,16 @@ function shouldSkipNotification(dedupeKey?: string): boolean {
   return false;
 }
 
+function openHref(href: string): void {
+  // A `mailto:` should hand off to the mail client in place; web links open
+  // in a new tab so the user keeps their ProtSpace session.
+  if (href.startsWith('mailto:')) {
+    window.location.href = href;
+  } else {
+    window.open(href, '_blank', 'noopener,noreferrer');
+  }
+}
+
 function emitNotification(level: NotifyLevel, options: NotifyOptions): void {
   if (shouldSkipNotification(options.dedupeKey)) {
     return;
@@ -51,10 +70,17 @@ function emitNotification(level: NotifyLevel, options: NotifyOptions): void {
 
   const description = options.description?.trim();
   const duration = options.durationMs ?? DEFAULT_DURATIONS_MS[level];
+  const action = options.action;
 
   toast[level](options.title, {
     description,
     duration,
+    ...(action && {
+      action: {
+        label: action.label,
+        onClick: () => openHref(action.href),
+      },
+    }),
   });
 }
 

--- a/app/src/lib/support.test.ts
+++ b/app/src/lib/support.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from 'vitest';
+import {
+  GITHUB_REPO_URL,
+  MAX_ERROR_CHARS,
+  SUPPORT_EMAIL,
+  buildBugContext,
+  buildIssueUrl,
+  buildMailto,
+} from './support';
+
+describe('buildMailto', () => {
+  it('targets the support inbox and encodes subject and body', () => {
+    const href = buildMailto({ subject: 'A subject', body: 'line one\nline two' });
+
+    expect(href).toBe(`mailto:${SUPPORT_EMAIL}?subject=A%20subject&body=line%20one%0Aline%20two`);
+  });
+
+  it('encodes spaces as %20 rather than +', () => {
+    expect(buildMailto({ subject: 'two words' })).toContain('subject=two%20words');
+  });
+
+  it('omits empty parameters and works with no arguments', () => {
+    expect(buildMailto({ subject: 'Hello', body: '' })).toBe(
+      `mailto:${SUPPORT_EMAIL}?subject=Hello`,
+    );
+    expect(buildMailto()).toBe(`mailto:${SUPPORT_EMAIL}`);
+  });
+});
+
+describe('buildIssueUrl', () => {
+  it('targets the repository issue endpoint with a bug label', () => {
+    const href = buildIssueUrl({ title: 'Crash', body: 'details' });
+
+    expect(href).toBe(`${GITHUB_REPO_URL}/issues/new?title=Crash&body=details&labels=bug`);
+  });
+
+  it('omits empty title/body but keeps the label', () => {
+    expect(buildIssueUrl()).toBe(`${GITHUB_REPO_URL}/issues/new?labels=bug`);
+  });
+});
+
+describe('buildBugContext', () => {
+  it('includes the operation, error, page, and browser in a technical block', () => {
+    const body = buildBugContext({
+      operation: 'Export',
+      error: new Error('boom'),
+      page: 'https://protspace.app/explore',
+      userAgent: 'TestAgent/1.0',
+    });
+
+    expect(body).toContain('What happened:');
+    expect(body).toContain('Steps to reproduce:');
+    expect(body).toContain('Operation: Export');
+    expect(body).toContain('boom');
+    expect(body).toContain('Page: https://protspace.app/explore');
+    expect(body).toContain('Browser: TestAgent/1.0');
+  });
+
+  it('truncates long error text below the cap', () => {
+    const error = new Error('x'.repeat(5_000));
+    const body = buildBugContext({ operation: 'Crash', error });
+
+    const errorLine = body.split('\n').find((line) => line.startsWith('Error: '));
+    expect(errorLine).toBeDefined();
+    expect(errorLine).toContain('(truncated)');
+    // Error payload (after the "Error: " prefix) stays within the cap + marker.
+    expect((errorLine as string).length).toBeLessThan(MAX_ERROR_CHARS + 40);
+  });
+
+  it('tolerates non-Error values without throwing', () => {
+    expect(() => buildBugContext({ operation: 'Export', error: 'plain string' })).not.toThrow();
+    expect(buildBugContext({ operation: 'Export', error: 'plain string' })).toContain(
+      'Error: plain string',
+    );
+    expect(buildBugContext({ operation: 'Export', error: undefined })).toContain(
+      'Error: Unknown error',
+    );
+  });
+});

--- a/app/src/lib/support.ts
+++ b/app/src/lib/support.ts
@@ -1,0 +1,130 @@
+/**
+ * Support contact helpers.
+ *
+ * Single source of truth for the support inbox and for constructing the links
+ * that reach it: `mailto:` links, prefilled GitHub-issue links, and the
+ * bug-report body shared by toasts, the crash fallback, and the 404 page.
+ *
+ * All builders are pure — callers inject runtime context (page URL, user
+ * agent) via {@link clientContext} so the builders stay testable in a
+ * non-browser environment.
+ */
+
+/** Support inbox reachable for contact, bug reports, and privacy requests. */
+export const SUPPORT_EMAIL = 'hello@protspace.app';
+
+/** Project repository, used to build prefilled bug-report issue links. */
+export const GITHUB_REPO_URL = 'https://github.com/tsenoner/protspace_web';
+
+/**
+ * Upper bound on the error/stack text embedded in a bug report. Keeps the
+ * resulting `mailto:`/issue URL within the practical ~2000-character limit
+ * once the rest of the body, page URL, and user agent are added.
+ */
+export const MAX_ERROR_CHARS = 1200;
+
+interface MailtoParams {
+  subject?: string;
+  body?: string;
+}
+
+interface IssueParams {
+  title?: string;
+  body?: string;
+}
+
+interface BugContextParams {
+  /** Short label for the failing operation, e.g. "Export". */
+  operation: string;
+  /** The error to describe; may be an Error, string, or unknown value. */
+  error: unknown;
+  /** Page the report originates from (e.g. `window.location.href`). */
+  page?: string;
+  /** Reporter's browser string (e.g. `navigator.userAgent`). */
+  userAgent?: string;
+}
+
+/**
+ * Build an `application/x-www-form-urlencoded`-style query, omitting empty
+ * values and encoding spaces as `%20` (mail clients treat `+` literally, so
+ * `URLSearchParams` is unsafe for `mailto:`).
+ */
+function buildQuery(params: Record<string, string | undefined>): string {
+  return Object.entries(params)
+    .filter(([, value]) => Boolean(value))
+    .map(([key, value]) => `${key}=${encodeURIComponent(value as string)}`)
+    .join('&');
+}
+
+function describeError(error: unknown): string {
+  if (error instanceof Error) {
+    return error.stack ?? error.message;
+  }
+
+  if (typeof error === 'string') {
+    return error;
+  }
+
+  if (error == null) {
+    return 'Unknown error';
+  }
+
+  try {
+    return JSON.stringify(error);
+  } catch {
+    return String(error);
+  }
+}
+
+function truncate(text: string, max: number): string {
+  return text.length > max ? `${text.slice(0, max)}… (truncated)` : text;
+}
+
+/**
+ * Runtime contact context for bug reports. Returns empty fields outside a
+ * browser so the calling builders remain usable (and testable) in Node.
+ */
+export function clientContext(): { page?: string; userAgent?: string } {
+  if (typeof window === 'undefined') {
+    return {};
+  }
+
+  return { page: window.location.href, userAgent: window.navigator.userAgent };
+}
+
+/** Build a `mailto:` link to the support inbox, omitting empty parameters. */
+export function buildMailto({ subject, body }: MailtoParams = {}): string {
+  const query = buildQuery({ subject, body });
+  return query ? `mailto:${SUPPORT_EMAIL}?${query}` : `mailto:${SUPPORT_EMAIL}`;
+}
+
+/**
+ * Build a prefilled "new issue" link for the project repository, labelled
+ * `bug` and omitting empty title/body parameters.
+ */
+export function buildIssueUrl({ title, body }: IssueParams = {}): string {
+  const query = buildQuery({ title, body, labels: 'bug' });
+  return `${GITHUB_REPO_URL}/issues/new?${query}`;
+}
+
+/**
+ * Build a bug-report body: free-text prompts for the reporter followed by a
+ * technical block. The error/stack is truncated to {@link MAX_ERROR_CHARS}.
+ */
+export function buildBugContext({ operation, error, page, userAgent }: BugContextParams): string {
+  const errorText = truncate(describeError(error), MAX_ERROR_CHARS);
+
+  return [
+    'What happened:',
+    '',
+    '',
+    'Steps to reproduce:',
+    '',
+    '',
+    '--- technical details (please keep) ---',
+    `Operation: ${operation}`,
+    `Error: ${errorText}`,
+    `Page: ${page ?? ''}`,
+    `Browser: ${userAgent ?? ''}`,
+  ].join('\n');
+}

--- a/app/src/main.tsx
+++ b/app/src/main.tsx
@@ -1,5 +1,10 @@
 import { createRoot } from 'react-dom/client';
 import App from './App.tsx';
+import { ErrorBoundary } from './components/ErrorBoundary';
 import './index.css';
 
-createRoot(document.getElementById('root')!).render(<App />);
+createRoot(document.getElementById('root')!).render(
+  <ErrorBoundary>
+    <App />
+  </ErrorBoundary>,
+);

--- a/app/src/pages/NotFound.tsx
+++ b/app/src/pages/NotFound.tsx
@@ -1,6 +1,13 @@
 import { Link } from 'react-router-dom';
+import { buildMailto } from '@/lib/support';
 
 const NotFound = () => {
+  const attemptedPath = typeof window !== 'undefined' ? window.location.pathname : '';
+  const reportHref = buildMailto({
+    subject: '[Bug] Broken link',
+    body: `I reached a 404 page.\n\nAttempted path: ${attemptedPath}`,
+  });
+
   return (
     <div className="flex min-h-screen items-center justify-center bg-gray-100">
       <div className="text-center">
@@ -9,6 +16,13 @@ const NotFound = () => {
         <Link to="/" className="text-blue-500 underline hover:text-blue-700">
           Return to Home
         </Link>
+        <p className="mt-4 text-sm text-gray-500">
+          Think this is a broken link?{' '}
+          <a href={reportHref} className="text-blue-500 underline hover:text-blue-700">
+            Email us
+          </a>
+          .
+        </p>
       </div>
     </div>
   );

--- a/app/src/pages/Privacy.tsx
+++ b/app/src/pages/Privacy.tsx
@@ -1,6 +1,7 @@
 import { Link } from 'react-router-dom';
 import Header from '@/components/Header';
 import Footer from '@/components/Footer';
+import { SUPPORT_EMAIL, buildMailto } from '@/lib/support';
 
 const Privacy = () => {
   return (
@@ -143,7 +144,14 @@ const Privacy = () => {
             <section>
               <h2 className="text-xl font-semibold text-foreground mb-3">Contact</h2>
               <p>
-                For privacy-related questions, open an issue on{' '}
+                For privacy or data requests, email{' '}
+                <a
+                  href={buildMailto({ subject: 'Privacy request' })}
+                  className="text-primary hover:underline"
+                >
+                  {SUPPORT_EMAIL}
+                </a>{' '}
+                or open an issue on{' '}
                 <a
                   href="https://github.com/tsenoner/protspace_web"
                   target="_blank"
@@ -151,8 +159,8 @@ const Privacy = () => {
                   className="text-primary hover:underline"
                 >
                   GitHub
-                </a>{' '}
-                or contact the ProtSpace contributors.
+                </a>
+                .
               </p>
             </section>
           </div>

--- a/app/vitest.config.ts
+++ b/app/vitest.config.ts
@@ -1,6 +1,12 @@
+import path from 'path';
 import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
+  resolve: {
+    alias: {
+      '@': path.resolve(__dirname, './src'),
+    },
+  },
   test: {
     include: ['src/**/*.test.ts'],
   },

--- a/openspec/changes/archive/2026-06-13-support-mailto-integration/.openspec.yaml
+++ b/openspec/changes/archive/2026-06-13-support-mailto-integration/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-13

--- a/openspec/changes/archive/2026-06-13-support-mailto-integration/design.md
+++ b/openspec/changes/archive/2026-06-13-support-mailto-integration/design.md
@@ -1,0 +1,39 @@
+## Context
+
+ProtSpace is a React SPA (Vite, React Router, Tailwind, shadcn-style UI). User-facing notifications go through `app/src/lib/notify.ts`, a thin wrapper over the `sonner` toast library; the Explore feature builds notification payloads via pure functions in `app/src/explore/notifications.ts` that return `NotifyOptions` objects. Site chrome (`Header`, `Footer`) already follows established external-link patterns, and shared link config lives in root `config/` (`urls.ts`, `navigation.ts`). There is currently no top-level React error boundary — `main.tsx` renders `<App />` bare, so a render crash yields a blank screen. The support inbox `hello@protspace.app` exists but is not referenced anywhere in the UI.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- One place owning the support address and all link/body construction.
+- Reach the inbox for general contact, privacy/legal, and bug reporting.
+- Prefill bug reports with enough context (operation, error, page, browser) to be actionable.
+- Offer a GitHub-issue fallback for bug reporting (works without a mail client).
+- Replace the blank-screen crash with a recovery fallback.
+
+**Non-Goals:**
+
+- A server-backed contact form (email/GitHub links are the channel).
+- Header navigation contact entry (footer covers general contact site-wide).
+- Data/research inquiry routing.
+- Centralizing the GitHub repo URL already hardcoded in `Footer.tsx`/`navigation.ts` (unrelated refactor; the new module defines its own constant).
+
+## Decisions
+
+**Support module in `app/src/lib/support.ts`, not root `config/`.** Only the React app consumes these links; VitePress docs do not. Keeping it app-scoped lets it be unit-tested with the existing Vitest setup. _Alternative considered:_ root `config/` alongside `urls.ts` — rejected because it widens the shared surface for no consumer.
+
+**Pure builders, context injected.** `buildMailto`, `buildIssueUrl`, and `buildBugContext` take all inputs as arguments (including `page` and `userAgent`), so they are deterministic and testable; call sites supply `window.location.href` / `navigator.userAgent`. _Alternative:_ read `window`/`navigator` inside the builders — rejected for testability.
+
+**Extend `NotifyOptions` with an optional `action`, forwarded to sonner.** `emitNotification` maps `action: { label, href }` to sonner's `action: { label, onClick }`. The `onClick` opens `mailto:` via same-window navigation and `http(s)` via a new tab — matching how a `mailto:` is expected to hand off to the mail client while a GitHub link opens a page. The field is optional, so all existing notifications are unchanged. _Alternative:_ a separate toast helper — rejected; it would duplicate dedupe/duration logic.
+
+**Email in toasts, both channels on the crash fallback.** A toast fits one action, so it uses the primary channel (email). The `ErrorBoundary` screen has room for both Email and GitHub. _Alternative:_ GitHub in toasts — rejected; email is the stated primary contact.
+
+**`ErrorBoundary` as a class component wrapping `<App />` in `main.tsx`.** React error boundaries require a class (`getDerivedStateFromError` + `componentDidCatch`). Wrapping at the `main.tsx` root catches everything; route context comes from `window.location` rather than router context, so the boundary needs no router. _Alternative:_ wrap inside `App` under the router — unnecessary; `window.location` suffices.
+
+## Risks / Trade-offs
+
+- **`mailto:` does nothing without a configured mail client** → the GitHub-issue link on the crash fallback covers bug reporting for those users; general/privacy contact accept this limitation as the chosen channel.
+- **Long stacks could exceed `mailto` URL limits** → `buildBugContext` truncates error/stack below a cap, keeping links within the practical ~1500-char limit.
+- **A bug inside the `ErrorBoundary` fallback would defeat its purpose** → the fallback uses only static markup and link builders that never throw.
+- **User context (page URL, user agent) is placed in the report body** → acceptable: it is user-initiated, visible/editable before sending, and contains no secrets.

--- a/openspec/changes/archive/2026-06-13-support-mailto-integration/proposal.md
+++ b/openspec/changes/archive/2026-06-13-support-mailto-integration/proposal.md
@@ -1,0 +1,29 @@
+## Why
+
+A support inbox, `hello@protspace.app`, now exists but is unreachable from the interface — users have no in-app way to ask questions, report a bug with useful context, or send a privacy/data request (the Privacy page even names the domain but offers no contact). Surfacing it turns dead-end errors and unanswered questions into actionable reports.
+
+## What Changes
+
+- Add a shared support module (`app/src/lib/support.ts`) holding the support address, the GitHub repo URL, and pure builders for `mailto:` links, prefilled GitHub-issue links, and a bug-report context body (operation, error, page URL, browser; error/stack truncated to stay under the practical `mailto` length limit).
+- Add a **Contact** link to the Footer (site-wide general contact).
+- Add a **Contact** section to the Privacy page for privacy/data requests.
+- Add a **"Report this"** action button to the dataset-import and export failure toasts, opening a prefilled `mailto:`.
+- Add an app-level `ErrorBoundary` (new) wrapping `<App />`, with a crash fallback offering Reload, **Email us**, and **Open a GitHub issue** (both prefilled with route + truncated stack).
+- Add a "broken link? Email us" line to the NotFound (404) page, prefilled with the attempted path.
+
+## Capabilities
+
+### New Capabilities
+
+- `support-contact`: In-app paths to reach the support inbox for general contact, bug/error reporting (email primary, prefilled GitHub issue as a browser-only fallback), and privacy/legal requests — including prefilled context for bug reports and a catch-all crash fallback.
+
+### Modified Capabilities
+
+<!-- None — no existing spec's requirements change. -->
+
+## Impact
+
+- **New code:** `app/src/lib/support.ts` (+ tests), `app/src/components/ErrorBoundary.tsx` (+ tests).
+- **Modified code:** `app/src/lib/notify.ts` (`NotifyOptions` gains an optional `action`; `emitNotification` forwards it to sonner), `app/src/explore/notifications.ts` (failure builders attach the report action), `app/src/components/Footer.tsx`, `app/src/pages/Privacy.tsx`, `app/src/pages/NotFound.tsx`, `app/src/main.tsx` (wraps `<App />`).
+- **APIs/contracts:** internal only — `NotifyOptions` extended with an optional, backward-compatible field. No new dependencies. No backend changes; `mailto:`/GitHub links are client-side.
+- **Known limitation:** `mailto:` requires a configured mail client; the GitHub-issue path covers users without one for bug reports.

--- a/openspec/changes/archive/2026-06-13-support-mailto-integration/specs/support-contact/spec.md
+++ b/openspec/changes/archive/2026-06-13-support-mailto-integration/specs/support-contact/spec.md
@@ -1,0 +1,95 @@
+## ADDED Requirements
+
+### Requirement: Support link construction
+
+The system SHALL provide pure builder functions that construct `mailto:` links, prefilled GitHub-issue links, and bug-report bodies from a single source for the support address (`hello@protspace.app`) and the project's GitHub repository URL.
+
+#### Scenario: Mailto link with subject and body
+
+- **WHEN** a `mailto:` link is built with a subject and body
+- **THEN** the result targets `hello@protspace.app` with `subject` and `body` query parameters, each URL-encoded
+
+#### Scenario: Empty parameters omitted
+
+- **WHEN** a `mailto:` or GitHub-issue link is built with an empty or absent subject or body
+- **THEN** that empty query parameter is omitted from the resulting URL and the URL remains valid
+
+#### Scenario: GitHub issue link is prefilled and labeled
+
+- **WHEN** a GitHub-issue link is built with a title and body
+- **THEN** the result targets the project repository's `/issues/new` endpoint with URL-encoded `title` and `body` and a `bug` label
+
+#### Scenario: Bug context includes technical details
+
+- **WHEN** a bug-report body is built for a given operation and error
+- **THEN** the body contains free-text prompts for what happened and steps to reproduce, plus a technical block listing the operation, the error message, the page URL, and the browser string
+
+#### Scenario: Long error text is truncated
+
+- **WHEN** a bug-report body is built from an error whose message or stack exceeds the length cap
+- **THEN** the error text is truncated below the cap so the resulting link stays within the practical `mailto` length limit
+
+#### Scenario: Non-Error values are tolerated
+
+- **WHEN** a bug-report body is built from a value that is not an `Error` (such as a string or unknown value)
+- **THEN** the builder produces a body without throwing
+
+### Requirement: General contact link in footer
+
+The site footer SHALL present a Contact link that opens a `mailto:` to the support inbox.
+
+#### Scenario: Footer contact link present
+
+- **WHEN** a page that renders the footer is displayed
+- **THEN** a "Contact" link is shown alongside the existing footer links, and its target is a `mailto:` to `hello@protspace.app`
+
+### Requirement: Privacy contact section
+
+The Privacy page SHALL provide a contact path for privacy and data requests.
+
+#### Scenario: Privacy page exposes a contact
+
+- **WHEN** the Privacy page is displayed
+- **THEN** it includes a contact section with a `mailto:` to `hello@protspace.app` whose subject identifies a privacy request
+
+### Requirement: Bug report action on failure notifications
+
+Dataset-import and export failure notifications SHALL offer an action that opens a prefilled support email.
+
+#### Scenario: Report action on import/export failure
+
+- **WHEN** a dataset-import or export failure notification is shown
+- **THEN** it includes a "Report this" action whose target is a `mailto:` prefilled with a bug subject and a bug-report body describing the failing operation and its error
+
+#### Scenario: Notification action opens its target
+
+- **WHEN** a notification's report action is activated
+- **THEN** the action's `mailto:` target is opened in the current window
+
+#### Scenario: Notifications without an action are unaffected
+
+- **WHEN** a notification that defines no action is shown
+- **THEN** it renders as before with no action button and existing deduplication behavior unchanged
+
+### Requirement: Application crash fallback
+
+The application SHALL render a recovery fallback instead of a blank screen when a render-time error escapes to the top level.
+
+#### Scenario: Render crash shows fallback
+
+- **WHEN** a render-time error propagates to the top-level error boundary
+- **THEN** a fallback screen is shown with a Reload action, an "Email us" action, and an "Open a GitHub issue" action
+
+#### Scenario: Crash report links carry context
+
+- **WHEN** the crash fallback is shown
+- **THEN** the "Email us" target is a `mailto:` and the "Open a GitHub issue" target is a GitHub-issue link, each prefilled with the current page and a truncated error/stack
+
+### Requirement: Broken-link contact on not-found page
+
+The 404 page SHALL offer a contact path prefilled with the attempted path.
+
+#### Scenario: Not-found page offers email
+
+- **WHEN** the 404 page is displayed
+- **THEN** it includes a line linking to a `mailto:` whose body includes the attempted path

--- a/openspec/changes/archive/2026-06-13-support-mailto-integration/tasks.md
+++ b/openspec/changes/archive/2026-06-13-support-mailto-integration/tasks.md
@@ -1,0 +1,37 @@
+## 1. Support module
+
+- [x] 1.1 Create `app/src/lib/support.ts` exporting `SUPPORT_EMAIL` (`hello@protspace.app`) and `GITHUB_REPO_URL`
+- [x] 1.2 Implement `buildMailto({ subject?, body? })` — targets `SUPPORT_EMAIL`, URL-encodes params, omits empty params
+- [x] 1.3 Implement `buildIssueUrl({ title?, body? })` — `${GITHUB_REPO_URL}/issues/new` with encoded `title`/`body` and `labels=bug`, omitting empty params
+- [x] 1.4 Implement `buildBugContext({ operation, error, page, userAgent })` — free-text prompts + technical block (operation/error/page/browser), tolerating non-`Error` values
+- [x] 1.5 Add a `MAX_ERROR_CHARS` cap so error/stack is truncated and links stay under the practical `mailto` limit
+- [x] 1.6 Add `app/src/lib/support.test.ts` covering encoding, empty-param omission, bug-context contents, truncation, and non-`Error` input
+
+## 2. Notification action plumbing
+
+- [x] 2.1 Extend `NotifyOptions` in `app/src/lib/notify.ts` with optional `action?: { label: string; href: string }`
+- [x] 2.2 In `emitNotification`, forward `action` to sonner as `{ label, onClick }`; `onClick` navigates the current window for `mailto:` and opens a new tab (`noopener,noreferrer`) for `http(s)`
+- [x] 2.3 Add/extend notify tests asserting `action` is forwarded to the sonner mock as `{ label, onClick }` and absence leaves behavior unchanged
+
+## 3. Bug-report action on Explore failures
+
+- [x] 3.1 In `app/src/explore/notifications.ts`, attach a "Report this" `action` to `getDataLoadFailureNotification` (operation: dataset import) via `buildMailto` + `buildBugContext`
+- [x] 3.2 Attach the same "Report this" action to `getExportFailureNotification` (operation: export)
+- [x] 3.3 Update/extend `notifications.test.ts` to assert the failure builders include the report action with a `mailto:` href
+
+## 4. Static contact surfaces
+
+- [x] 4.1 Add a "Contact" `mailto:` link to `app/src/components/Footer.tsx` matching existing footer link styling
+- [x] 4.2 Add a "Contact" section to `app/src/pages/Privacy.tsx` with a `mailto:` (subject: privacy request)
+- [x] 4.3 Add a "broken link? Email us" line to `app/src/pages/NotFound.tsx` prefilled with the attempted path (`window.location.pathname`)
+
+## 5. Application crash fallback
+
+- [x] 5.1 Create `app/src/components/ErrorBoundary.tsx` (class component, `getDerivedStateFromError` + `componentDidCatch`) with a fallback: heading, Reload, Email us (`buildMailto` + `buildBugContext`), Open a GitHub issue (`buildIssueUrl` + `buildBugContext`)
+- [x] 5.2 Wrap `<App />` in `<ErrorBoundary>` in `app/src/main.tsx`
+- [x] 5.3 Add an `ErrorBoundary` test verifying the crash report links. _Adapted to the project's Node/no-DOM Vitest harness (no testing-library/jsdom — a non-goal to add): tests `getDerivedStateFromError` (the fallback trigger) plus the exported pure `buildCrashLinks` helper, asserting the "Email us" `mailto:` and GitHub-issue hrefs carry context, instead of a DOM render. Added the `@` alias to `app/vitest.config.ts` so component imports resolve._
+
+## 6. Verification
+
+- [x] 6.1 Run `pnpm test` (or the app's test command) and confirm support, notify, notifications, and ErrorBoundary tests pass
+- [x] 6.2 Run `pnpm lint` and `pnpm type-check` clean

--- a/openspec/specs/support-contact/spec.md
+++ b/openspec/specs/support-contact/spec.md
@@ -1,0 +1,101 @@
+# support-contact Specification
+
+## Purpose
+
+In-app paths to reach the support inbox (`hello@protspace.app`) for general contact, bug/error reporting, and privacy/legal requests. Bug reports are prefilled with context and offer a GitHub-issue fallback for users without a configured mail client; a top-level crash fallback replaces the blank-screen failure mode.
+
+## Requirements
+
+### Requirement: Support link construction
+
+The system SHALL provide pure builder functions that construct `mailto:` links, prefilled GitHub-issue links, and bug-report bodies from a single source for the support address (`hello@protspace.app`) and the project's GitHub repository URL.
+
+#### Scenario: Mailto link with subject and body
+
+- **WHEN** a `mailto:` link is built with a subject and body
+- **THEN** the result targets `hello@protspace.app` with `subject` and `body` query parameters, each URL-encoded
+
+#### Scenario: Empty parameters omitted
+
+- **WHEN** a `mailto:` or GitHub-issue link is built with an empty or absent subject or body
+- **THEN** that empty query parameter is omitted from the resulting URL and the URL remains valid
+
+#### Scenario: GitHub issue link is prefilled and labeled
+
+- **WHEN** a GitHub-issue link is built with a title and body
+- **THEN** the result targets the project repository's `/issues/new` endpoint with URL-encoded `title` and `body` and a `bug` label
+
+#### Scenario: Bug context includes technical details
+
+- **WHEN** a bug-report body is built for a given operation and error
+- **THEN** the body contains free-text prompts for what happened and steps to reproduce, plus a technical block listing the operation, the error message, the page URL, and the browser string
+
+#### Scenario: Long error text is truncated
+
+- **WHEN** a bug-report body is built from an error whose message or stack exceeds the length cap
+- **THEN** the error text is truncated below the cap so the resulting link stays within the practical `mailto` length limit
+
+#### Scenario: Non-Error values are tolerated
+
+- **WHEN** a bug-report body is built from a value that is not an `Error` (such as a string or unknown value)
+- **THEN** the builder produces a body without throwing
+
+### Requirement: General contact link in footer
+
+The site footer SHALL present a Contact link that opens a `mailto:` to the support inbox.
+
+#### Scenario: Footer contact link present
+
+- **WHEN** a page that renders the footer is displayed
+- **THEN** a "Contact" link is shown alongside the existing footer links, and its target is a `mailto:` to `hello@protspace.app`
+
+### Requirement: Privacy contact section
+
+The Privacy page SHALL provide a contact path for privacy and data requests.
+
+#### Scenario: Privacy page exposes a contact
+
+- **WHEN** the Privacy page is displayed
+- **THEN** it includes a contact section with a `mailto:` to `hello@protspace.app` whose subject identifies a privacy request
+
+### Requirement: Bug report action on failure notifications
+
+Dataset-import and export failure notifications SHALL offer an action that opens a prefilled support email.
+
+#### Scenario: Report action on import/export failure
+
+- **WHEN** a dataset-import or export failure notification is shown
+- **THEN** it includes a "Report this" action whose target is a `mailto:` prefilled with a bug subject and a bug-report body describing the failing operation and its error
+
+#### Scenario: Notification action opens its target
+
+- **WHEN** a notification's report action is activated
+- **THEN** the action's `mailto:` target is opened in the current window
+
+#### Scenario: Notifications without an action are unaffected
+
+- **WHEN** a notification that defines no action is shown
+- **THEN** it renders as before with no action button and existing deduplication behavior unchanged
+
+### Requirement: Application crash fallback
+
+The application SHALL render a recovery fallback instead of a blank screen when a render-time error escapes to the top level.
+
+#### Scenario: Render crash shows fallback
+
+- **WHEN** a render-time error propagates to the top-level error boundary
+- **THEN** a fallback screen is shown with a Reload action, an "Email us" action, and an "Open a GitHub issue" action
+
+#### Scenario: Crash report links carry context
+
+- **WHEN** the crash fallback is shown
+- **THEN** the "Email us" target is a `mailto:` and the "Open a GitHub issue" target is a GitHub-issue link, each prefilled with the current page and a truncated error/stack
+
+### Requirement: Broken-link contact on not-found page
+
+The 404 page SHALL offer a contact path prefilled with the attempted path.
+
+#### Scenario: Not-found page offers email
+
+- **WHEN** the 404 page is displayed
+- **THEN** it includes a line linking to a `mailto:` whose body includes the attempted path

--- a/openspec/specs/support-contact/spec.md
+++ b/openspec/specs/support-contact/spec.md
@@ -49,6 +49,15 @@ The site footer SHALL present a Contact link that opens a `mailto:` to the suppo
 - **WHEN** a page that renders the footer is displayed
 - **THEN** a "Contact" link is shown alongside the existing footer links, and its target is a `mailto:` to `hello@protspace.app`
 
+### Requirement: Feedback action in header
+
+The site header SHALL present a prominent Feedback button that opens a `mailto:` to the support inbox, available on both desktop and mobile navigation.
+
+#### Scenario: Header feedback button present
+
+- **WHEN** a page that renders the header is displayed
+- **THEN** a "Feedback" button is shown in the navigation, and its target is a `mailto:` to `hello@protspace.app` whose subject identifies feedback
+
 ### Requirement: Privacy contact section
 
 The Privacy page SHALL provide a contact path for privacy and data requests.


### PR DESCRIPTION
Closes #261.

Surfaces the support inbox `hello@protspace.app` (and a prefilled GitHub-issue fallback) throughout the UI so users can reach the team for general contact, bug/error reporting, and privacy requests — directly addressing the feedback-link request in #261.

## What's included

- **`app/src/lib/support.ts`** — single source for the address + pure builders: `buildMailto`, `buildIssueUrl` (prefilled, `bug`-labelled), and `buildBugContext` (operation/error/page/browser, with error/stack truncated below the practical `mailto` limit).
- **Notifications** — `NotifyOptions` gains an optional `action`, forwarded to sonner (`mailto:` → same window, web → new tab). Explore import/export failure toasts now carry a prefilled **"Report this"** action.
- **Static surfaces** — Footer **Contact** link, Privacy page contact email (subject: privacy request), NotFound **"broken link? Email us"** line prefilled with the attempted path.
- **Crash fallback** — new `ErrorBoundary` wrapping `<App>` replaces the blank-screen crash with Reload / **Email us** / **Open a GitHub issue** (both prefilled with route + truncated stack).
- **Test infra** — added the `@` alias to `app/vitest.config.ts` so component tests resolve imports.

## Design choices

- Email is the primary channel; toasts fit one action (email), while the roomier crash screen offers both email and a GitHub issue (works without a configured mail client).
- Builders are pure with injected context (page/userAgent) for testability.

## Verification

- `pnpm test`: 128 passed, 1 skipped (all suites green).
- `pnpm type-check`, `knip`, and `docs:build` clean (pre-commit hook passed).
- New tests: `support.test.ts` (encoding, omission, truncation, non-Error), `notify` action forwarding, notification report actions, and `ErrorBoundary` (state transition + crash links).

OpenSpec change `support-mailto-integration` is included and archived under `openspec/changes/archive/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)