### PR TITLE
feat(errors): add trace id to bug reports and distinguish too-few sequences

### DIFF
--- a/app/src/explore/notifications.test.ts
+++ b/app/src/explore/notifications.test.ts
@@ -98,6 +98,24 @@ describe('explore notifications', () => {
     expect(notification.dedupeKey).toBe('data-error:TOO_MANY_SEQUENCES');
   });
 
+  it('surfaces the floor for a TOO_FEW_SEQUENCES failure without calling it "empty"', () => {
+    const detail = dataError(
+      'Need at least 20 sequences; got 5.',
+      new FastaPrepError('Need at least 20 sequences; got 5.', {
+        code: 'TOO_FEW_SEQUENCES',
+        jobId: 'job-few',
+      }),
+    );
+
+    const notification = getDataLoadFailureNotification(detail);
+    expect(notification.title).toBe('Dataset import failed.');
+    // No curated copy for this code, so the raw message shows through — it
+    // already names the 20-sequence floor and never says "empty".
+    expect(notification.description).toMatch(/20/);
+    expect(notification.description).not.toMatch(/empty/i);
+    expect(notification.dedupeKey).toBe('data-error:TOO_FEW_SEQUENCES');
+  });
+
   it('routes a BIOCENTRAL_UNAVAILABLE failure to Colab with copy and an action', () => {
     const detail = dataError(
       'biocentral down',
@@ -177,6 +195,19 @@ describe('explore notifications', () => {
     expect(action?.label).toBe('Report this');
     expect(action?.href).toMatch(/^mailto:hello@protspace\.app\?/);
     expect(action?.href).toContain('subject=%5BBug%5D%20Dataset%20import%20failed');
+  });
+
+  it('includes the trace id in the "Report this" email body for backend failures', () => {
+    const detail = dataError(
+      'Lost connection to the prep backend.',
+      new FastaPrepError('Lost connection to the prep backend.', { jobId: 'job-xyz' }),
+    );
+
+    const action = getDataLoadFailureNotification(detail).action;
+
+    expect(action?.label).toBe('Report this');
+    // "Trace ID: job-xyz" survives mailto encoding (space → %20, ':' → %3A).
+    expect(action?.href).toContain('Trace%20ID%3A%20job-xyz');
   });
 
   it('attaches a "Report this" mailto action to the export failure notification', () => {

--- a/app/src/explore/notifications.ts
+++ b/app/src/explore/notifications.ts
@@ -12,12 +12,16 @@ import { COLAB_NOTEBOOK_URL, MAX_UPLOAD_LABEL, MAX_SEQUENCES } from './fasta-pre
  * Build a "Report this" toast action that opens a prefilled support email
  * describing the failing operation and its error.
  */
-function buildReportAction(operation: string, error: unknown): NotifyOptions['action'] {
+function buildReportAction(
+  operation: string,
+  error: unknown,
+  traceId?: string,
+): NotifyOptions['action'] {
   return {
     label: 'Report this',
     href: buildMailto({
       subject: `[Bug] ${operation} failed`,
-      body: buildBugContext({ operation, error, ...clientContext() }),
+      body: buildBugContext({ operation, error, traceId, ...clientContext() }),
     }),
   };
 }
@@ -127,7 +131,7 @@ export function getDataLoadFailureNotification(detail: DataErrorEventDetail): No
     action:
       code === 'BIOCENTRAL_UNAVAILABLE'
         ? { label: 'Open in Colab ↗', href: COLAB_NOTEBOOK_URL }
-        : buildReportAction('Dataset import', prepError ?? detail.message),
+        : buildReportAction('Dataset import', prepError ?? detail.message, jobId),
   };
 }
 

--- a/app/src/explore/runtime.ts
+++ b/app/src/explore/runtime.ts
@@ -100,7 +100,7 @@ export async function initializeExploreRuntime(): Promise<ExploreController> {
       if (seqCount > 0 && seqCount < MIN_SEQUENCES) {
         throw new FastaPrepError(
           `This FASTA has only ${seqCount} sequence${seqCount === 1 ? '' : 's'}; the prep backend needs at least ${MIN_SEQUENCES}.`,
-          { code: 'EMPTY_FASTA' },
+          { code: 'TOO_FEW_SEQUENCES' },
         );
       }
 

--- a/app/src/lib/support.test.ts
+++ b/app/src/lib/support.test.ts
@@ -67,6 +67,22 @@ describe('buildBugContext', () => {
     expect((errorLine as string).length).toBeLessThan(MAX_ERROR_CHARS + 40);
   });
 
+  it('includes the trace id in the technical block when provided', () => {
+    const body = buildBugContext({
+      operation: 'Dataset import',
+      error: new Error('boom'),
+      traceId: 'job-123',
+    });
+
+    expect(body).toContain('Trace ID: job-123');
+  });
+
+  it('omits the trace id line when no trace id is provided', () => {
+    const body = buildBugContext({ operation: 'Export', error: new Error('boom') });
+
+    expect(body).not.toContain('Trace ID:');
+  });
+
   it('tolerates non-Error values without throwing', () => {
     expect(() => buildBugContext({ operation: 'Export', error: 'plain string' })).not.toThrow();
     expect(buildBugContext({ operation: 'Export', error: 'plain string' })).toContain(

--- a/app/src/lib/support.ts
+++ b/app/src/lib/support.ts
@@ -42,6 +42,8 @@ interface BugContextParams {
   page?: string;
   /** Reporter's browser string (e.g. `navigator.userAgent`). */
   userAgent?: string;
+  /** Backend trace id (the prep `job_id`) to correlate the report with logs. */
+  traceId?: string;
 }
 
 /**
@@ -111,7 +113,13 @@ export function buildIssueUrl({ title, body }: IssueParams = {}): string {
  * Build a bug-report body: free-text prompts for the reporter followed by a
  * technical block. The error/stack is truncated to {@link MAX_ERROR_CHARS}.
  */
-export function buildBugContext({ operation, error, page, userAgent }: BugContextParams): string {
+export function buildBugContext({
+  operation,
+  error,
+  page,
+  userAgent,
+  traceId,
+}: BugContextParams): string {
   const errorText = truncate(describeError(error), MAX_ERROR_CHARS);
 
   return [
@@ -123,6 +131,9 @@ export function buildBugContext({ operation, error, page, userAgent }: BugContex
     '',
     '--- technical details (please keep) ---',
     `Operation: ${operation}`,
+    // Only backend failures carry a trace id; omit the line entirely otherwise
+    // so client-only reports stay clean.
+    ...(traceId ? [`Trace ID: ${traceId}`] : []),
     `Error: ${errorText}`,
     `Page: ${page ?? ''}`,
     `Browser: ${userAgent ?? ''}`,

--- a/services/protspace-prep/src/protspace_prep/validation.py
+++ b/services/protspace-prep/src/protspace_prep/validation.py
@@ -10,6 +10,7 @@ from .config import Settings
 
 class ValidationCode(str, enum.Enum):
     EMPTY_FASTA = "EMPTY_FASTA"
+    TOO_FEW_SEQUENCES = "TOO_FEW_SEQUENCES"
     TOO_MANY_SEQUENCES = "TOO_MANY_SEQUENCES"
     SEQUENCE_TOO_LONG = "SEQUENCE_TOO_LONG"
     MALFORMED_FASTA = "MALFORMED_FASTA"
@@ -84,9 +85,11 @@ def parse_and_validate(text: str, settings: Settings) -> list[FastaRecord]:
             "No sequence data found in FASTA.",
         )
     if len(records) < settings.sequence_min_count:
+        # Non-empty but below the floor is "too few", not "empty" — keep the
+        # codes distinct so the UI can tell the user the actual minimum.
         raise FastaValidationError(
-            ValidationCode.EMPTY_FASTA,
-            f"Need at least {settings.sequence_min_count} sequence(s).",
+            ValidationCode.TOO_FEW_SEQUENCES,
+            f"Need at least {settings.sequence_min_count} sequences; got {len(records)}.",
         )
     if len(records) > settings.sequence_max_count:
         raise FastaValidationError(

--- a/services/protspace-prep/tests/test_validation.py
+++ b/services/protspace-prep/tests/test_validation.py
@@ -41,6 +41,15 @@ def test_rejects_when_no_sequences_only_headers():
     assert exc.value.code is ValidationCode.EMPTY_FASTA
 
 
+def test_rejects_too_few_sequences():
+    # Non-empty input below the minimum is "too few", distinct from empty.
+    text = "".join(f">id{i}\nMKT\n" for i in range(3))
+    with pytest.raises(FastaValidationError) as exc:
+        parse_and_validate(text, settings(sequence_min_count=20))
+    assert exc.value.code is ValidationCode.TOO_FEW_SEQUENCES
+    assert "20" in exc.value.message
+
+
 def test_rejects_too_many_sequences():
     text = "".join(f">id{i}\nMKT\n" for i in range(3))
     with pytest.raises(FastaValidationError) as exc:


### PR DESCRIPTION
## Summary

Two improvements to user-facing error reporting on FASTA prep failures:

- **Trace id in bug reports** — The "Report this" email now embeds the backend trace id (the prep `job_id`)
- **"Too few sequences" instead of "empty"** — Importing fewer than the 20-sequence minimum was reported as *"appears to be empty"*. The backend validator now raises a distinct `TOO_FEW_SEQUENCES` code (separate from `EMPTY_FASTA`), and the client pre-check mirrors it. The message names the actual count and the floor.

Closes #287 