### PR TITLE
docs(ci-migration): protlabel needs its own PyPI trusted publisher

### DIFF
--- a/openspec/changes/merge-protspace-monorepo/ci-migration.md
+++ b/openspec/changes/merge-protspace-monorepo/ci-migration.md
@@ -42,9 +42,10 @@ Publishing uses OIDC (`id-token: write`), not a `PYPI_API_TOKEN`. On PyPI, proje
 | Environment | `pypi`                               |
 
 Remove the legacy repo's stale trusted-publisher entry once the new one is
-verified. (protlabel is published from the same job; if it becomes its own
-PyPI project it needs its own trusted-publisher entry — today it ships under the
-protspace release.)
+verified. **`protlabel` is a separate PyPI project** (also at 4.7.1), uploaded by
+the same publish job — so add the identical trusted publisher (owner `tsenoner`,
+repo `protspace`, workflow `protspace-publish.yml`, env `pypi`) on the
+[`protlabel`](https://pypi.org/project/protlabel/) project as well.
 
 ## GHCR image — no secret to move
 


### PR DESCRIPTION
Corrects the CI-migration runbook: `protlabel` is a separate PyPI project (both it and `protspace` are at 4.7.1), and the publish job uploads both wheels — so each needs its own trusted-publisher entry. Docs-only; does not touch `apps/protspace/`, so it does not trigger a release.