### PR TITLE
fix: correct PyPI README source link (protspace_web → protspace)

### DIFF
--- a/apps/protspace/README.md
+++ b/apps/protspace/README.md
@@ -17,7 +17,7 @@ ProtSpace is a visualization tool for exploring **protein embeddings** or **simi
 
 ## 🌐 Try Online
 
-**[ProtSpace Web](https://protspace.app/explore)**: Fast 2D explorer optimized for large datasets — drag & drop `.parquetbundle` files ([source](https://github.com/tsenoner/protspace_web))
+**[ProtSpace Web](https://protspace.app/explore)**: Fast 2D explorer optimized for large datasets — drag & drop `.parquetbundle` files ([source](https://github.com/tsenoner/protspace))
 
 ## 🚀 Google Colab Notebooks
 


### PR DESCRIPTION
**Release smoke-test.** A genuine one-line `fix:` under `apps/protspace/`: the PyPI README's "ProtSpace Web" source link still pointed at the pre-rename `protspace_web` repo.

Merging this (after the release bot is armed) should:
1. trigger `protspace-release` → semantic-release cuts **4.7.2** (patch, from this `fix:`),
2. trigger `protspace-publish` → uploads protspace + protlabel 4.7.2 wheels to PyPI + the Docker image to GHCR.

⚠️ Merge only **after** the release App is armed (secrets + install + PyPI trusted publishers), otherwise `protspace-release` just fails harmlessly and no release is cut.