### PR TITLE
ci(release): PSR v10 + scope protspace releases to apps/protspace

### DIFF
--- a/.github/workflows/protspace-release.yml
+++ b/.github/workflows/protspace-release.yml
@@ -61,12 +61,12 @@ jobs:
         uses: actions/cache@v5
         with:
           path: /tmp/.uv-tools
-          key: uv-tools-${{ runner.os }}-psr-v9.11.1
+          key: uv-tools-${{ runner.os }}-psr-v10.6.1
           restore-keys: |
             uv-tools-${{ runner.os }}
 
       - name: Install Python Semantic Release
-        run: uv tool install python-semantic-release@v9.11.1
+        run: uv tool install python-semantic-release@v10.6.1
 
       - name: Run Semantic Release
         id: semantic_release

--- a/apps/protspace/pyproject.toml
+++ b/apps/protspace/pyproject.toml
@@ -139,6 +139,12 @@ known-first-party = ["protspace", "protlabel"]
 # and does not build (publishing is handled by protspace-publish.yml); it only bumps
 # the versions. protspace + protlabel stay lock-step (same bump).
 [tool.semantic_release]
+# Monorepo scoping (requires python-semantic-release >= 10, pinned in
+# protspace-release.yml): count ONLY commits that touch this package dir
+# (apps/protspace) so unrelated web/frontend feat/fix commits don't inflate
+# protspace's version or changelog. tag_format stays the repo-wide default
+# `v{version}` (protspace is the primary package; protlabel ships lock-step).
+commit_parser = "conventional-monorepo"
 assets = []
 build_command = ""
 version_toml = [
@@ -146,6 +152,14 @@ version_toml = [
     "packages/protlabel/pyproject.toml:project.version",
 ]
 version_variables = ["src/protspace/__init__.py:__version__"]
+
+[tool.semantic_release.commit_parser_options]
+path_filters = ["."]
+
+[tool.semantic_release.changelog]
+# Keep the v9 full-regenerate behavior; the existing CHANGELOG has no v10
+# update-mode insertion marker.
+mode = "init"
 
 
 [build-system]


### PR DESCRIPTION
Closes the monorepo release-scoping gap: with the default parser, a protspace release counts **all** conventional commits since the last tag (repo-wide), so a stray web `feat:`/`fix:` could inflate protspace's version/changelog.

**Changes**
- `protspace-release.yml`: python-semantic-release `v9.11.1 → v10.6.1` (the monorepo parser needs v10).
- `apps/protspace/pyproject.toml`: `commit_parser = "conventional-monorepo"` + `path_filters = ["."]` → only commits touching `apps/protspace` count. `changelog.mode = "init"` preserves current behavior.

**Validated locally:** v10.6.1 loads the config and accepts the `conventional-monorepo` parser. Real confirmation is on the next release.

⚠️ **Merge AFTER the 4.7.2 smoke-test (PR #327).** Do the smoke-test under the known-good v9.11.1 first to validate the publish pipeline in isolation; then this upgrade rides the next release (4.7.3).