### PR TITLE
feat(embed): local GPU/CPU embedding backend + biocentral/local switch (issue #59)

### DIFF
--- a/apps/protspace/CLAUDE.md
+++ b/apps/protspace/CLAUDE.md
@@ -43,7 +43,7 @@ Single entry point: `protspace = protspace.cli.app:app`
 | Command | Purpose |
 |---------|---------|
 | `protspace prepare` | Full pipeline: embed → reduce → annotate → bundle |
-| `protspace embed` | FASTA → HDF5 embeddings via Biocentral API |
+| `protspace embed` | FASTA → HDF5 embeddings (Biocentral API or local GPU/CPU via `--backend local`) |
 | `protspace project` | HDF5 → dimensionality reduction |
 | `protspace annotate` | Fetch protein annotations |
 | `protspace bundle` | Combine projections + annotations → .parquetbundle |
@@ -59,6 +59,7 @@ protspace prepare -i <input> -m <methods> -o <output> [options]
 
 # From HDF5: protspace prepare -i embeddings.h5 -m pca2,umap2 -o output
 # From FASTA: protspace prepare -i sequences.fasta -e prot_t5 -m pca2 -o output
+# Local GPU/CPU embedding (offline, needs protspace[local]): protspace prepare -i seq.fasta -e prot_t5 --backend local -m pca2 -o output
 # Multi-model: protspace prepare -i seq.fasta -e prot_t5,esm2_3b -m pca2 -o output
 # All 12 pLMs: protspace prepare -i seq.fasta -e prot_t5,prost_t5,esm2_8m,esm2_35m,esm2_150m,esm2_650m,esm2_3b,ankh_base,ankh_large,ankh3_large,esmc_300m,esmc_600m -m pca2 -o output
 # Combine datasets (same name → union): protspace prepare -i species_a.h5:prot_t5 -i species_b.h5:prot_t5 -m umap2 -o output
@@ -144,7 +145,8 @@ src/protspace/
 │   │   ├── settings_converter.py # Settings table conversion
 │   │   └── writers.py          # Annotation output writers
 │   ├── embedding/
-│   │   └── biocentral.py       # Biocentral API client, model shortcut mappings
+│   │   ├── biocentral.py       # Biocentral API client, model shortcut mappings
+│   │   └── local.py            # Local GPU/CPU backend (HF transformers, [local] extra)
 │   ├── parsers/
 │   │   └── uniprot_parser.py   # UniProt XML/TSV parsing
 │   └── processors/
@@ -265,6 +267,8 @@ uv run pytest --cov=src/protspace --cov=packages/protlabel/src/protlabel  # With
 | `test_annotation_select.py` | 6 | Annotation selection: suitability filter (cardinality/numeric/id-like exclusion), `auto` vs explicit-list label building (explicit names bypass the heuristic), missing-value dropping |
 | `test_annotation_validity.py` | 6 | `AnnotationValidityStatistic`: silhouette/DBI/CH scored per annotation on `ctx.coords`, embedding vs. projection `space_kind`, missing-value exclusion, single-category no-op, id-canonical subsample determinism |
 | `test_biocentral_embedder.py` | 23 | Biocentral API client, embedding flow |
+| `test_backend_switch.py` | 10 | Embedding backend switch: `resolve_default_backend` (Colab+GPU→local), `embed_fasta` local/biocentral dispatch (short key vs resolved name), `protspace embed --backend` CLI wiring + enum validation + non-positive batch_size rejection |
+| `test_local_embedder.py` | 21 | Local embedding backend: checkpoint resolution (12 short keys, Synthyra ESM-C), per-family preprocessing/residue pooling, `/`-in-header guard, LocalEmbedConfig validation, empty-output guard, esm2_8m end-to-end + resume (slow) |
 | `test_fasta.py` | 17 | FASTA parsing, edge cases, CSV annotation loading |
 | `test_biocentral_retriever.py` | 14 | Biocentral prediction retriever (TMbed parsing, per-sequence) |
 | `test_taxonomy_annotation_retriever.py` | 15 | Taxonomy via UniProt Taxonomy API (mocked + integration) |
@@ -295,6 +299,8 @@ Located in `notebooks/`:
 **Core:** h5py, scikit-learn, umap-learn, pacmap (includes annoy), numpy, pandas, pyarrow, tqdm, requests, pymmseqs, biocentral-api, typer, rich
 
 **Frontend (optional):** dash, plotly, dash-bootstrap-components, dash-molstar, gunicorn
+
+**Local embedding (optional, `[local]` extra):** torch, transformers, sentencepiece, protobuf, einops — enables on-device embedding via `protspace.data.embedding.local` (issue #59; alternative to the Biocentral API). Install with `pip install "protspace[local]"`.
 
 **Dev:** pytest, pytest-cov, ruff
 

--- a/apps/protspace/docs/cli.md
+++ b/apps/protspace/docs/cli.md
@@ -60,12 +60,15 @@ protspace prepare -i emb.h5 -m "pca2,umap2:n_neighbors=50;min_dist=0.3,tsne2" -o
 
 | Flag | Description | Default |
 | ---- | ----------- | ------- |
-| `-e, --embedder` | Biocentral model shortcut (comma-separated for multi-model). | `prot_t5` |
-| `--batch-size` | Sequences per API call. | `1000` |
+| `-e, --embedder` | Model shortcut (comma-separated for multi-model). | `prot_t5` |
+| `-b, --backend` | Embedding engine: `biocentral` (remote API) or `local` (on-device GPU/CPU). | `biocentral` |
+| `--batch-size` | Sequences per batch. Backend default when unset: 1000 (API call) or 8 (local GPU micro-batch). | — |
 
 **Available embedders:** `prot_t5`, `prost_t5`, `esm2_8m`, `esm2_35m`, `esm2_150m`, `esm2_650m`, `esm2_3b`, `ankh_base`, `ankh_large`, `ankh3_large`, `esmc_300m`, `esmc_600m`
 
 > **Licensing:** `ankh_base`, `ankh_large`, `ankh3_large` (CC-BY-NC-SA-4.0), `esmc_600m` (Cambrian Non-Commercial). All others are permissively licensed.
+
+> **Local backend (`--backend local`):** computes embeddings on a local GPU/CPU via HuggingFace `transformers` instead of the remote Biocentral API — useful when the API is unavailable, or in Colab. Requires the extra: `pip install "protspace[local]"`. ESM-C uses the Synthyra ESM++ checkpoints for consistency with the API path. `esm2_3b` may exceed a free Colab T4 (16 GB) — prefer an L4/A100 runtime for it.
 
 #### Projection
 
@@ -140,10 +143,14 @@ This produces three projections: `ProtT5 — PCA 2`, `ProtT5 — UMAP 2 (n=15)`,
 
 ## `protspace embed`
 
-Generate HDF5 embeddings from FASTA via the Biocentral API.
+Generate HDF5 embeddings from FASTA, via the remote Biocentral API (default) or a local GPU/CPU (`--backend local`, needs `pip install "protspace[local]"`).
 
 ```bash
+# Remote Biocentral API (default)
 protspace embed -i sequences.fasta -e prot_t5 -e esm2_3b -o embeddings/
+
+# On-device GPU/CPU — works offline / when Biocentral is down
+protspace embed -i sequences.fasta -e prot_t5 -o embeddings/ --backend local
 ```
 
 ## `protspace project`

--- a/apps/protspace/docs/superpowers/plans/2026-07-13-colab-biocentral-independence.md
+++ b/apps/protspace/docs/superpowers/plans/2026-07-13-colab-biocentral-independence.md
@@ -1,0 +1,86 @@
+# Colab / Biocentral independence (issue #59)
+
+**Issue:** [tsenoner/protspace#59](https://github.com/tsenoner/protspace/issues/59) — "The Google
+Colab notebook should be independent of Biocentral."
+
+**Goal:** the Colab notebooks (and the CLI) must be able to generate embeddings even when the
+remote Biocentral API is down — by embedding on the local Colab GPU — while still allowing
+Biocentral as an explicit choice. Secondary: surface the newer EAT (`protspace transfer`) and
+statistics (`prepare --stats`) features in the notebooks.
+
+Investigation done 2026-07-13 (multi-agent research workflow). This plan was ported into the
+`protspace_web` monorepo (`apps/protspace`) on 2026-07-14 when the Python backend and web
+frontend were merged into a single repo; PR1 + PR2 below were originally opened against the
+standalone `tsenoner/protspace` repo (#73, #74) and re-landed here as one consolidated PR.
+
+## Key findings
+
+- `notebooks/ClickThrough_GenerateEmbeddings.ipynb` **already** embeds locally on the Colab GPU
+  (12 models, HF transformers + native ESM) — the #59 capability exists but was siloed in a
+  notebook and H5-only. This is a consolidation problem, not a greenfield one.
+- `notebooks/ProtSpace_Preparation.ipynb` FASTA + UniProt-query tabs are the **only** Biocentral
+  chokepoint, via `embed_fasta()` → `biocentral.embed_sequences()`.
+- **Statistics is documented-but-dead** in the Preparation notebook: the `_on_gen` handler never
+  calls `pipeline._compute_statistics` (which exists and is used by `run()`). `save_output`
+  already accepts `statistics=` / `settings=`. Wiring it is a ~3-edit fix, no signature changes.
+- EAT lives in a standalone `ProtSpace_Transfer.ipynb`.
+
+## Recommended approach (Option B — chosen)
+
+New `src/protspace/data/embedding/local.py` with the **same signature** as
+`biocentral.embed_sequences`; thread `backend={local,biocentral}` through the single seam
+`embed_fasta()` + add `protspace embed --backend local`; ship as an optional extra
+`protspace[local]` (lazy torch/transformers imports, mirroring the `[frontend]` extra). Default
+backend = local when running on Colab **and** CUDA is available, else biocentral.
+
+Rejected alternatives:
+- Notebook-only inlining — silos the logic, untestable.
+- Running `biocentral-api` locally — it is a strict REST client; would need a self-hosted
+  `biocentral_server` with GPU + docker.
+
+Additional decisions baked in:
+- **Pin Synthyra ESM++ for `esmc_*`** (not native EvolutionaryScale) — ungated, plain
+  transformers, MSE ≈ 7.7e-10 vs native.
+- Per-family special-token strip + mean-pool. **Ankh must NOT be space-joined**: its vocab has a
+  bare `M`=19 but `▁M`=`<unk>`, so raw-string tokenization is correct; `is_split_into_words` /
+  space-joining injects `<unk>` before every residue.
+- All 12 models fit the free T4 **except** `esm2_3b` (marginal → L4/A100). None of the
+  recommended checkpoints are HF-gated.
+
+## PR roadmap
+
+| PR | Scope | Status |
+|----|-------|--------|
+| PR1 | `local.py` + `[local]` extra + `test_local_embedder.py` | ✅ done (was #73) |
+| PR2 | `-b/--backend {biocentral,local}` switch on `embed` + `prepare`, `embed_fasta(backend=)` dispatch, `resolve_default_backend()`, backend-aware `--batch-size`, `test_backend_switch.py` | ✅ done (was #74) |
+| PR3 | Empirical local-vs-Biocentral pooling parity cross-check + docs (resolves the deferred Ankh-pooling / `reduce=True` server black-box question) | ⬜ next |
+| PR4 | Notebook: default to local-in-Colab via `resolve_default_backend()` | ⬜ |
+| PR5 | Wire the dead `--stats` toggle into the Preparation notebook | ⬜ |
+| PR6 | Append optional EAT to the Preparation notebook | ⬜ |
+
+**#59 is functionally addressed once PR1 → PR2 → PR4 land** — the CLI can already embed fully
+offline today. PR3, PR5, PR6 are hardening + notebook/UX surface.
+
+## Decisions still owed by the maintainer (don't assume)
+
+1. Confirm Synthyra-for-ESM-C.
+2. Run + set a tolerance for the Biocentral-vs-local pooling cross-check (`reduce=True` is a
+   server-side black box — the one unverified parity item).
+3. `esm2_3b` free-tier policy (gate / warn / hide).
+4. `ankh3_large` `[NLU]` vs `[S2S]` prefix.
+5. Scope #59 to embeddings only, or also the `predicted_*` annotation server dep
+   (`biocentral_retriever.py`).
+6. Local backend micro-batch config (Biocentral's `batch_size=1000` is an API-request batch, not
+   a GPU micro-batch) — addressed in PR2 via `LocalEmbedConfig` (default 8).
+
+## Adversarial-review fixes already applied (PR1/PR2)
+
+- Empty-`.h5` guard: `embed_sequences` raises if all sequences were skipped, instead of returning
+  a path to an absent/empty file that later crashes `load_h5`.
+- VRAM release: inline `del model, tokenizer; gc.collect(); torch.cuda.empty_cache()` in the
+  caller frame (a `_cleanup(model)` helper did not drop the caller's reference, so
+  `empty_cache()` freed nothing).
+- Non-positive `--batch-size` hang: `min=1` on the shared option + `LocalEmbedConfig.__post_init__`
+  validation (a `0`/negative micro-batch would spin forever after loading the model).
+- **Ankh space-join finding REFUTED** — see the per-family note above; do not "fix" Ankh to
+  space-join.

--- a/apps/protspace/pyproject.toml
+++ b/apps/protspace/pyproject.toml
@@ -36,6 +36,13 @@ frontend = [
     "dash-molstar>=1.3.0",
     "requests>=2.32.4",
 ]
+local = [
+    "einops>=0.8.2",
+    "protobuf>=7.35.1",
+    "sentencepiece>=0.2.2",
+    "torch>=2.4",
+    "transformers>=5.13.1",
+]
 
 [project.scripts]
 protspace = "protspace.cli.app:app"

--- a/apps/protspace/src/protspace/cli/common_options.py
+++ b/apps/protspace/src/protspace/cli/common_options.py
@@ -24,6 +24,13 @@ class ClusterSelection(str, Enum):
     both = "both"  # emit both clusterings
 
 
+class Backend(str, Enum):
+    """Which engine computes the embeddings from FASTA sequences."""
+
+    biocentral = "biocentral"  # remote Biocentral API (default)
+    local = "local"  # on-device GPU/CPU via transformers ([local] extra)
+
+
 # ---------------------------------------------------------------------------
 # Shared option types
 # ---------------------------------------------------------------------------
@@ -126,10 +133,28 @@ Opt_Eps = Annotated[
 ]
 
 # Embedding options (shared by prepare and embed)
-Opt_BatchSize = Annotated[
-    int,
+Opt_Backend = Annotated[
+    Backend,
     typer.Option(
-        help="Sequences per Biocentral API call.", rich_help_panel="Embedding"
+        "-b",
+        "--backend",
+        help=(
+            "Embedding engine: 'biocentral' (remote API, default) or 'local' "
+            "(on-device GPU/CPU; needs `pip install protspace[local]`)."
+        ),
+        rich_help_panel="Embedding",
+    ),
+]
+
+Opt_BatchSize = Annotated[
+    int | None,
+    typer.Option(
+        min=1,
+        help=(
+            "Sequences per batch. Backend default when unset: 1000 "
+            "(Biocentral API call) or 8 (local GPU micro-batch)."
+        ),
+        rich_help_panel="Embedding",
     ),
 ]
 

--- a/apps/protspace/src/protspace/cli/embed.py
+++ b/apps/protspace/src/protspace/cli/embed.py
@@ -7,7 +7,12 @@ from typing import Annotated
 import typer
 
 from protspace.cli.app import PANEL_STAGES, app, setup_logging
-from protspace.cli.common_options import Opt_BatchSize, Opt_Verbose
+from protspace.cli.common_options import (
+    Backend,
+    Opt_Backend,
+    Opt_BatchSize,
+    Opt_Verbose,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -41,24 +46,21 @@ def embed(
         Path,
         typer.Option("-o", "--output", help="Output directory (one H5 per model)."),
     ],
-    batch_size: Opt_BatchSize = 1000,
+    backend: Opt_Backend = Backend.biocentral,
+    batch_size: Opt_BatchSize = None,
     verbose: Opt_Verbose = 0,
 ) -> None:
-    """FASTA → per-model HDF5 embeddings (Biocentral API).
+    """FASTA → per-model HDF5 embeddings.
 
     \b
-    Creates one HDF5 file per model in the output directory, with
-    model_name written to the H5 root attributes.
+    Creates one HDF5 file per model in the output directory, with model_name
+    written to the H5 root attributes. Embeddings are computed via the remote
+    Biocentral API (default) or on a local GPU/CPU with --backend local.
     """
     setup_logging(verbose)
 
     import h5py
 
-    from protspace.data.embedding.biocentral import (
-        EmbedConfig,
-        embed_sequences,
-        resolve_embedder,
-    )
     from protspace.data.io.fasta import parse_fasta
 
     sequences = parse_fasta(input)
@@ -66,16 +68,39 @@ def embed(
         raise typer.BadParameter(f"No sequences found in {input}")
 
     output.mkdir(parents=True, exist_ok=True)
-    embed_config = EmbedConfig(batch_size=batch_size)
+
+    if backend == Backend.local:
+        from protspace.data.embedding.local import LocalEmbedConfig, embed_sequences
+
+        embed_config = (
+            LocalEmbedConfig(batch_size=batch_size)
+            if batch_size is not None
+            else LocalEmbedConfig()
+        )
+
+        def resolve(name: str) -> str:
+            return name  # local backend takes the short key directly
+    else:
+        from protspace.data.embedding.biocentral import (
+            EmbedConfig,
+            embed_sequences,
+            resolve_embedder,
+        )
+
+        embed_config = (
+            EmbedConfig(batch_size=batch_size)
+            if batch_size is not None
+            else EmbedConfig()
+        )
+        resolve = resolve_embedder
 
     for model_name in embedder:
-        resolved = resolve_embedder(model_name)
         h5_path = output / f"{model_name}.h5"
 
-        logger.info(f"Embedding with {model_name} → {h5_path}")
+        logger.info(f"Embedding with {model_name} ({backend.value}) → {h5_path}")
         embed_sequences(
             sequences,
-            resolved,
+            resolve(model_name),
             h5_path,
             embed_config=embed_config,
         )

--- a/apps/protspace/src/protspace/cli/prepare.py
+++ b/apps/protspace/src/protspace/cli/prepare.py
@@ -12,14 +12,17 @@ from typing import TYPE_CHECKING, Annotated
 
 if TYPE_CHECKING:
     from protspace.data.embedding.biocentral import EmbedConfig
+    from protspace.data.embedding.local import LocalEmbedConfig
     from protspace.data.processors.pipeline import PipelineConfig
 
 import typer
 
 from protspace.cli.app import PANEL_START, app, setup_logging
 from protspace.cli.common_options import (
+    Backend,
     ClusterSelection,
     Metric,
+    Opt_Backend,
     Opt_BatchSize,
     Opt_Eps,
     Opt_Fasta,
@@ -250,9 +253,10 @@ def _embed_all(
     embedders: list[str],
     fasta_path: Path,
     cache_dir: Path | None,
-    embed_config: EmbedConfig | None,
+    embed_config: EmbedConfig | LocalEmbedConfig | None,
     embedding_sets: list,
     *,
+    backend: str = "biocentral",
     force_reembed: bool = False,
 ) -> list[str]:
     """Embed all models, return list of cache-hit model names."""
@@ -270,6 +274,7 @@ def _embed_all(
         emb_set = embed_fasta(
             fasta_path,
             emb_name,
+            backend=backend,
             embed_config=embed_config,
             embedding_cache=emb_cache,
         )
@@ -302,7 +307,8 @@ def prepare(
     fasta: Opt_Fasta = None,
     # Embedding
     embedder: Opt_Embedder = None,
-    batch_size: Opt_BatchSize = 1000,
+    backend: Opt_Backend = Backend.biocentral,
+    batch_size: Opt_BatchSize = None,
     # Projection
     methods: Opt_Methods = None,
     similarity: Opt_Similarity = False,
@@ -413,7 +419,6 @@ def prepare(
         return
 
     # --- Build embedding sets ---
-    from protspace.data.embedding.biocentral import EmbedConfig
     from protspace.data.loaders import EmbeddingSet, load_h5
     from protspace.data.loaders.h5 import EMBEDDING_EXTENSIONS
     from protspace.data.loaders.query import (
@@ -421,7 +426,22 @@ def prepare(
         query_uniprot,
     )
 
-    embed_config = EmbedConfig(batch_size=batch_size)
+    if backend == Backend.local:
+        from protspace.data.embedding.local import LocalEmbedConfig
+
+        embed_config = (
+            LocalEmbedConfig(batch_size=batch_size)
+            if batch_size is not None
+            else LocalEmbedConfig()
+        )
+    else:
+        from protspace.data.embedding.biocentral import EmbedConfig
+
+        embed_config = (
+            EmbedConfig(batch_size=batch_size)
+            if batch_size is not None
+            else EmbedConfig()
+        )
     embedding_sets: list[EmbeddingSet] = []
     fasta_for_similarity: Path | None = fasta
 
@@ -456,6 +476,7 @@ def prepare(
                 cache_dir,
                 embed_config,
                 embedding_sets,
+                backend=backend.value,
                 force_reembed="embed" in refetch_stages,
             )
             fasta_for_similarity = fasta_path
@@ -483,6 +504,7 @@ def prepare(
                         cache_dir,
                         embed_config,
                         embedding_sets,
+                        backend=backend.value,
                         force_reembed="embed" in refetch_stages,
                     )
                     fasta_for_similarity = path
@@ -631,7 +653,7 @@ def _write_run_log(
     query: str | None,
     input_specs: list[tuple[Path, str | None]],
     embedders: list[str],
-    embed_config: EmbedConfig,
+    embed_config: EmbedConfig | LocalEmbedConfig,
     pipeline_config: PipelineConfig,
     similarity: bool,
     scores: bool,

--- a/apps/protspace/src/protspace/data/embedding/local.py
+++ b/apps/protspace/src/protspace/data/embedding/local.py
@@ -1,0 +1,364 @@
+"""Local (on-device / Colab-GPU) protein embedding backend.
+
+A drop-in alternative to :mod:`protspace.data.embedding.biocentral` that
+computes per-protein embeddings with a local GPU (or CPU) via HuggingFace
+``transformers`` instead of the remote Biocentral API — so the pipeline keeps
+working when Biocentral is down (issue #59).
+
+``embed_sequences`` keeps the Biocentral function's positional signature and
+HDF5 output contract (one float32 per-protein vector per dataset, resume-by-key),
+so the rest of the pipeline (``load_h5`` → reduce/annotate/bundle) is unchanged
+regardless of which backend produced the ``.h5``. One deliberate difference: its
+``embedder`` argument is a *short key* (e.g. ``"prot_t5"``), resolved to a
+checkpoint locally — not the full model name the Biocentral backend expects.
+
+Torch and transformers are heavy and optional — they live in the ``[local]``
+extra (``pip install "protspace[local]"``) and are imported lazily inside the
+functions that need them, so importing this module stays cheap.
+
+Checkpoint choices are deliberately aligned with the Biocentral path for output
+consistency: ESM-C maps to Synthyra's ESM++ reimplementation (same weights as
+native, MSE ~1e-9, ungated, loads via plain transformers), and ProtT5/ProstT5
+use the fp16 encoder exports (T4-friendly, embedding-equivalent). The exact
+numerical parity of local vs. Biocentral pooling is validated separately (a
+cross-check script), not asserted here.
+"""
+
+import logging
+import re
+from dataclasses import dataclass
+from difflib import get_close_matches
+from pathlib import Path
+
+import numpy as np
+from tqdm import tqdm
+
+from protspace.data.embedding.biocentral import load_existing_ids, save_embeddings
+
+logger = logging.getLogger(__name__)
+
+# Short key → (HuggingFace checkpoint, model family). Covers the same 12
+# shortcuts as the Biocentral backend (ALL_SHORT_KEYS).
+LOCAL_CHECKPOINTS: dict[str, tuple[str, str]] = {
+    "prot_t5": ("Rostlab/prot_t5_xl_half_uniref50-enc", "prot_t5"),
+    "prost_t5": ("Rostlab/ProstT5_fp16", "prost_t5"),
+    "esm2_8m": ("facebook/esm2_t6_8M_UR50D", "esm"),
+    "esm2_35m": ("facebook/esm2_t12_35M_UR50D", "esm"),
+    "esm2_150m": ("facebook/esm2_t30_150M_UR50D", "esm"),
+    "esm2_650m": ("facebook/esm2_t33_650M_UR50D", "esm"),
+    "esm2_3b": ("facebook/esm2_t36_3B_UR50D", "esm"),
+    "ankh_base": ("ElnaggarLab/ankh-base", "ankh"),
+    "ankh_large": ("ElnaggarLab/ankh-large", "ankh"),
+    "ankh3_large": ("ElnaggarLab/ankh3-large", "ankh"),
+    "esmc_300m": ("Synthyra/ESMplusplus_small", "esmc"),
+    "esmc_600m": ("Synthyra/ESMplusplus_large", "esmc"),
+}
+
+# Model families whose tokenizer wraps the sequence with a leading special
+# token (CLS / <AA2fold>) as well as a trailing EOS. T5 encoders (ProtT5, Ankh)
+# add only a trailing EOS.
+_STRIP_BOTH_ENDS = frozenset({"esm", "esmc", "prost_t5"})
+
+_RARE_RESIDUES = re.compile(r"[BJOUZ]")
+
+
+@dataclass(frozen=True)
+class LocalEmbedConfig:
+    """Local-backend parameters.
+
+    ``batch_size`` is a *GPU micro-batch* (how many sequences run through the
+    model at once) — distinct from Biocentral's ``EmbedConfig.batch_size``,
+    which is an API-request batch. It auto-halves on GPU OOM.
+    """
+
+    batch_size: int = 8
+    max_length: int = 2000
+
+    def __post_init__(self) -> None:
+        if self.batch_size < 1:
+            raise ValueError(f"batch_size must be >= 1, got {self.batch_size}")
+        if self.max_length < 1:
+            raise ValueError(f"max_length must be >= 1, got {self.max_length}")
+
+
+# ---------------------------------------------------------------------------
+# Pure helpers (torch-free)
+# ---------------------------------------------------------------------------
+
+
+def resolve_default_backend() -> str:
+    """Pick the default embedding backend for the current environment.
+
+    Returns ``"local"`` only inside a Google Colab runtime that also has a CUDA
+    GPU available; otherwise ``"biocentral"``. Torch is optional, so its absence
+    (or any probe failure) falls back to the remote backend.
+    """
+    import sys
+
+    if "google.colab" not in sys.modules:
+        return "biocentral"
+    try:
+        import torch
+
+        if torch.cuda.is_available():
+            return "local"
+    except Exception:  # torch missing or CUDA probe failed
+        pass
+    return "biocentral"
+
+
+def resolve_local_checkpoint(name: str) -> tuple[str, str]:
+    """Resolve a short embedder key to ``(hf_checkpoint, model_family)``.
+
+    Raises :class:`ValueError` (with close-match suggestions) for unknown keys.
+    """
+    if name in LOCAL_CHECKPOINTS:
+        return LOCAL_CHECKPOINTS[name]
+
+    close = get_close_matches(name, LOCAL_CHECKPOINTS.keys(), n=3, cutoff=0.5)
+    msg = f"Unknown local embedder shortcut: '{name}'."
+    if close:
+        msg += f" Did you mean: {', '.join(close)}?"
+    else:
+        msg += f" Available: {', '.join(sorted(LOCAL_CHECKPOINTS))}"
+    raise ValueError(msg)
+
+
+def preprocess_sequence(seq: str, mod_type: str) -> str:
+    """Prepare a raw amino-acid sequence for tokenization by *mod_type*.
+
+    Maps rare residues (B, J, O, U, Z) to X, space-joins residues for the
+    ProtT5/ProstT5 SentencePiece tokenizers, and prepends the ``<AA2fold>``
+    control token for ProstT5.
+
+    Ankh is deliberately NOT space-joined: its T5 vocab has bare single-AA
+    tokens (``"M"``) but maps the word-start form (``"▁M"``) to ``<unk>``, so a
+    raw string tokenizes to clean per-residue tokens whereas space-joining (or
+    ``is_split_into_words=True``) injects a ``<unk>`` before every residue.
+    (Exact pooling parity vs Biocentral is pinned in the PR3 cross-check.)
+    """
+    seq = _RARE_RESIDUES.sub("X", seq)
+    if mod_type in ("prot_t5", "prost_t5"):
+        seq = " ".join(seq)
+    if mod_type == "prost_t5":
+        seq = "<AA2fold> " + seq
+    return seq
+
+
+def pool_residues(hidden: np.ndarray, seq_len: int, mod_type: str) -> np.ndarray:
+    """Mean-pool per-residue hidden states into one per-protein vector.
+
+    *hidden* is ``(padded_len, dim)`` for a single sequence; *seq_len* is the
+    number of real (non-padding) tokens including special tokens. Special
+    tokens are stripped per family before pooling; right-padding beyond
+    *seq_len* is ignored.
+    """
+    if mod_type in _STRIP_BOTH_ENDS:
+        residues = hidden[1 : seq_len - 1]
+    else:  # prot_t5, ankh — no leading special token, strip trailing EOS
+        residues = hidden[: seq_len - 1]
+    return residues.mean(axis=0).astype(np.float32)
+
+
+def validate_headers(ids) -> None:
+    """Raise :class:`ValueError` if any identifier contains ``/``.
+
+    HDF5 treats ``/`` as a group separator, so it cannot appear in a dataset
+    name.
+    """
+    bad = [i for i in ids if "/" in i]
+    if bad:
+        raise ValueError(
+            "Header(s) contain '/', invalid for HDF5 dataset names: " + ", ".join(bad)
+        )
+
+
+# ---------------------------------------------------------------------------
+# Model loading + inference (lazy torch/transformers)
+# ---------------------------------------------------------------------------
+
+
+def setup_model(checkpoint: str, mod_type: str):
+    """Load ``(model, tokenizer, device)`` for *checkpoint* / *mod_type*."""
+    import torch
+    from transformers import (
+        AutoModelForMaskedLM,
+        AutoTokenizer,
+        EsmModel,
+        T5EncoderModel,
+        T5Tokenizer,
+    )
+
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    logger.info("Loading %s (%s) on %s", checkpoint, mod_type, device)
+
+    if mod_type == "esm":
+        tokenizer = AutoTokenizer.from_pretrained(checkpoint)
+        model = EsmModel.from_pretrained(checkpoint)
+    elif mod_type == "esmc":
+        # Synthyra ESM++: custom modeling code, tokenizer attached to model.
+        model = AutoModelForMaskedLM.from_pretrained(checkpoint, trust_remote_code=True)
+        tokenizer = model.tokenizer
+    elif mod_type == "ankh":
+        tokenizer = AutoTokenizer.from_pretrained(checkpoint)
+        model = T5EncoderModel.from_pretrained(checkpoint)
+    elif mod_type in ("prot_t5", "prost_t5"):
+        # fp16 on GPU (matches the half-precision checkpoints); fp32 on CPU,
+        # where half-precision matmul is unsupported/slow.
+        dtype = torch.float16 if device.type == "cuda" else torch.float32
+        tokenizer = T5Tokenizer.from_pretrained(
+            checkpoint, do_lower_case=(mod_type == "prot_t5")
+        )
+        model = T5EncoderModel.from_pretrained(checkpoint, torch_dtype=dtype)
+    else:  # pragma: no cover - guarded by resolve_local_checkpoint
+        raise ValueError(f"Unknown model family: {mod_type}")
+
+    return model.to(device).eval(), tokenizer, device
+
+
+def _embed_batch(
+    processed: list[str], mod_type: str, model, tokenizer, device, max_length: int
+) -> list[np.ndarray]:
+    """Embed a batch of pre-processed sequences → list of per-protein vectors."""
+    import torch
+
+    if mod_type == "esmc":
+        # ESM++'s custom tokenizer takes only the basic call signature.
+        inputs = tokenizer(processed, return_tensors="pt", padding=True)
+    else:
+        inputs = tokenizer(
+            processed,
+            return_tensors="pt",
+            padding=True,
+            truncation=True,
+            max_length=max_length + 2,  # room for the special tokens
+            add_special_tokens=True,
+        )
+    inputs = {k: v.to(device) for k, v in inputs.items()}
+
+    with torch.inference_mode():
+        hidden = model(**inputs).last_hidden_state
+
+    hidden_np = hidden.cpu().float().numpy()
+    attn = inputs.get("attention_mask")
+    if attn is not None:
+        lengths = attn.sum(dim=1).tolist()
+    else:  # fallback: assume no padding
+        lengths = [hidden_np.shape[1]] * len(processed)
+
+    return [
+        pool_residues(hidden_np[j], int(lengths[j]), mod_type)
+        for j in range(len(processed))
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Orchestrator
+# ---------------------------------------------------------------------------
+
+
+def embed_sequences(
+    sequences: dict[str, str],
+    embedder: str,
+    h5_path: Path,
+    embed_config: LocalEmbedConfig | None = None,
+) -> Path:
+    """Embed *sequences* locally and append them to *h5_path*.
+
+    Mirrors :func:`protspace.data.embedding.biocentral.embed_sequences`:
+    resumes by skipping IDs already present, writes one float32 per-protein
+    vector per dataset, and returns *h5_path*. *embedder* is a short key
+    (e.g. ``"prot_t5"``); it is resolved to a HuggingFace checkpoint locally.
+    """
+    cfg = embed_config or LocalEmbedConfig()
+    checkpoint, mod_type = resolve_local_checkpoint(embedder)
+    validate_headers(sequences.keys())
+
+    if embedder == "esm2_3b":
+        logger.warning(
+            "esm2_3b (3B params) may exceed a free Colab T4 (~15 GB VRAM). "
+            "If it OOMs, switch to an L4/A100 runtime or a smaller model."
+        )
+
+    h5_path = Path(h5_path)
+    existing = load_existing_ids(h5_path)
+    remaining = {k: v for k, v in sequences.items() if k not in existing}
+    if existing:
+        logger.info("Resuming: %d already embedded in %s", len(existing), h5_path)
+
+    # Drop sequences over the length cap; on-device attention is O(L^2) and
+    # long sequences OOM. Unlike the Biocentral backend (no cap), name the
+    # skipped IDs so the completeness difference is visible, not a bare count.
+    too_long = {k for k, v in remaining.items() if len(v) > cfg.max_length}
+    if too_long:
+        preview = ", ".join(sorted(too_long)[:5])
+        if len(too_long) > 5:
+            preview += ", ..."
+        logger.warning(
+            "Skipping %d sequence(s) longer than max_length=%d aa: %s",
+            len(too_long),
+            cfg.max_length,
+            preview,
+        )
+        remaining = {k: v for k, v in remaining.items() if k not in too_long}
+
+    if remaining:
+        import torch
+
+        # Shortest-first: efficient padding, and once a batch OOMs we never
+        # need to grow the batch size back.
+        ordered_ids = sorted(remaining, key=lambda k: len(remaining[k]))
+        logger.info("Embedding %d sequence(s) with %s", len(ordered_ids), embedder)
+
+        model, tokenizer, device = setup_model(checkpoint, mod_type)
+        try:
+            i = 0
+            bs = cfg.batch_size
+            pbar = tqdm(total=len(ordered_ids), desc="Embedding", unit="seq")
+            while i < len(ordered_ids):
+                batch_ids = ordered_ids[i : i + bs]
+                processed = [
+                    preprocess_sequence(remaining[pid], mod_type) for pid in batch_ids
+                ]
+                try:
+                    vecs = _embed_batch(
+                        processed, mod_type, model, tokenizer, device, cfg.max_length
+                    )
+                    save_embeddings(h5_path, dict(zip(batch_ids, vecs, strict=True)))
+                    i += bs
+                    pbar.update(len(batch_ids))
+                except torch.cuda.OutOfMemoryError:
+                    torch.cuda.empty_cache()
+                    if bs > 1:
+                        bs = max(1, bs // 2)
+                        logger.warning("GPU OOM — reducing batch size to %d", bs)
+                    else:
+                        logger.warning(
+                            "Skipping %s (len=%d, OOM at batch_size=1)",
+                            batch_ids[0],
+                            len(remaining[batch_ids[0]]),
+                        )
+                        i += 1
+                        pbar.update(1)
+            pbar.close()
+        finally:
+            # Release GPU memory. The `del` must run in this frame (not a
+            # helper) so the caller's references drop before empty_cache;
+            # gc.collect() breaks the esmc tokenizer<->model reference cycle.
+            import gc
+
+            del model, tokenizer
+            gc.collect()
+            if torch.cuda.is_available():
+                torch.cuda.empty_cache()
+
+    # A finished .h5 must hold at least one embedding, else downstream load_h5
+    # fails on an empty file. Fail loudly instead of returning a path to an
+    # empty/absent file (every sequence too long, or all OOM-skipped).
+    if not load_existing_ids(h5_path):
+        raise ValueError(
+            f"No embeddings were produced for {h5_path}: all {len(sequences)} "
+            f"sequence(s) were skipped (longer than max_length={cfg.max_length} "
+            f"aa, or GPU OOM at batch size 1)."
+        )
+    return h5_path

--- a/apps/protspace/src/protspace/data/loaders/fasta.py
+++ b/apps/protspace/src/protspace/data/loaders/fasta.py
@@ -14,6 +14,7 @@ from protspace.data.loaders.h5 import load_h5, parse_identifier
 
 if TYPE_CHECKING:
     from protspace.data.embedding.biocentral import EmbedConfig
+    from protspace.data.embedding.local import LocalEmbedConfig
 
 logger = logging.getLogger(__name__)
 
@@ -22,39 +23,58 @@ def embed_fasta(
     fasta_path: Path,
     embedder: str,
     *,
-    embed_config: EmbedConfig | None = None,
+    backend: str = "biocentral",
+    embed_config: EmbedConfig | LocalEmbedConfig | None = None,
     embedding_cache: Path | None = None,
 ) -> EmbeddingSet:
-    """Parse FASTA, embed via Biocentral API, return EmbeddingSet.
+    """Parse FASTA, embed via the chosen *backend*, return an EmbeddingSet.
 
-    FASTA headers are parsed to extract UniProt accessions before embedding,
-    so H5 keys are clean identifiers (e.g. P12345 instead of sp|P12345|NAME).
-    The model_name attribute is written to H5 root attrs.
+    FASTA headers are parsed to extract UniProt accessions before embedding
+    (regardless of backend), so H5 keys are clean identifiers (e.g. P12345
+    instead of sp|P12345|NAME). The model_name attribute is written to H5 root
+    attrs.
+
+    *backend* is ``"biocentral"`` (remote API) or ``"local"`` (on-device GPU/CPU
+    via the ``[local]`` extra). *embed_config* must match the backend
+    (``EmbedConfig`` vs ``LocalEmbedConfig``); when None each backend uses its
+    own default.
     """
-    from protspace.data.embedding.biocentral import (
-        derive_h5_cache_path,
-        embed_sequences,
-        resolve_embedder,
-    )
+    if backend not in ("biocentral", "local"):
+        raise ValueError(f"Unknown backend {backend!r}; use 'local' or 'biocentral'.")
+
+    from protspace.data.embedding.biocentral import derive_h5_cache_path
     from protspace.data.io.fasta import parse_fasta
 
     raw_sequences = parse_fasta(fasta_path)
     if not raw_sequences:
         raise ValueError(f"No sequences found in {fasta_path}")
 
-    # Remap keys: sp|P12345|NAME → P12345
+    # Remap keys: sp|P12345|NAME → P12345 (shared by both backends).
     sequences = {parse_identifier(header): seq for header, seq in raw_sequences.items()}
 
-    resolved = resolve_embedder(embedder)
+    if backend == "local":
+        from protspace.data.embedding.local import embed_sequences
+
+        # The local backend takes the short key and resolves it internally.
+        model_id = embedder
+    else:
+        from protspace.data.embedding.biocentral import (
+            embed_sequences,
+            resolve_embedder,
+        )
+
+        # Biocentral wants the resolved full model name.
+        model_id = resolve_embedder(embedder)
+
     h5_path = (
         Path(embedding_cache)
         if embedding_cache
-        else derive_h5_cache_path(fasta_path, resolved)
+        else derive_h5_cache_path(fasta_path, model_id)
     )
 
     h5_path = embed_sequences(
         sequences,
-        resolved,
+        model_id,
         h5_path,
         embed_config=embed_config,
     )

--- a/apps/protspace/tests/test_backend_switch.py
+++ b/apps/protspace/tests/test_backend_switch.py
@@ -1,0 +1,208 @@
+"""Tests for the embedding-backend switch (local vs biocentral) — PR2.
+
+Covers ``resolve_default_backend``, the ``backend`` dispatch in
+``embed_fasta``, and the ``--backend`` CLI wiring — all without loading a
+real model (the backend ``embed_sequences`` is replaced by a fake that writes
+a tiny HDF5).
+"""
+
+import sys
+import types
+from pathlib import Path
+
+import h5py
+import numpy as np
+import pytest
+from typer.testing import CliRunner
+
+from protspace.cli.app import app
+from protspace.data.embedding import local
+from protspace.data.embedding.biocentral import resolve_embedder
+from protspace.data.loaders.fasta import embed_fasta
+
+
+def _fake_embed(captured):
+    """A stand-in for ``embed_sequences`` that records its args and writes a
+    minimal valid HDF5 so the surrounding load_h5 machinery still works."""
+
+    def fake(sequences, embedder, h5_path, embed_config=None):
+        with h5py.File(h5_path, "a") as f:
+            for pid in sequences:
+                if pid not in f:
+                    f.create_dataset(pid, data=np.ones(4, dtype=np.float32))
+        captured["embedder"] = embedder
+        captured["ids"] = list(sequences)
+        captured["config"] = embed_config
+        return Path(h5_path)
+
+    return fake
+
+
+# ---------------------------------------------------------------------------
+# resolve_default_backend
+# ---------------------------------------------------------------------------
+
+
+def test_default_backend_is_biocentral_outside_colab(monkeypatch):
+    monkeypatch.delitem(sys.modules, "google.colab", raising=False)
+    assert local.resolve_default_backend() == "biocentral"
+
+
+def test_default_backend_is_biocentral_in_colab_without_gpu(monkeypatch):
+    monkeypatch.setitem(sys.modules, "google.colab", types.ModuleType("google.colab"))
+    import torch
+
+    monkeypatch.setattr(torch.cuda, "is_available", lambda: False)
+    assert local.resolve_default_backend() == "biocentral"
+
+
+def test_default_backend_is_local_in_colab_with_gpu(monkeypatch):
+    monkeypatch.setitem(sys.modules, "google.colab", types.ModuleType("google.colab"))
+    import torch
+
+    monkeypatch.setattr(torch.cuda, "is_available", lambda: True)
+    assert local.resolve_default_backend() == "local"
+
+
+# ---------------------------------------------------------------------------
+# embed_fasta dispatch
+# ---------------------------------------------------------------------------
+
+
+def test_embed_fasta_local_passes_short_key_and_remapped_ids(tmp_path, monkeypatch):
+    fasta = tmp_path / "s.fasta"
+    fasta.write_text(">sp|P12345|SOME_NAME\nMKVLAAG\n")
+    captured = {}
+    monkeypatch.setattr(
+        "protspace.data.embedding.local.embed_sequences", _fake_embed(captured)
+    )
+
+    result = embed_fasta(
+        fasta, "prot_t5", backend="local", embedding_cache=tmp_path / "e.h5"
+    )
+
+    assert captured["embedder"] == "prot_t5"  # SHORT key, resolved locally
+    assert captured["ids"] == ["P12345"]  # header remapped to bare accession
+    assert result is not None
+
+
+def test_embed_fasta_biocentral_passes_resolved_full_name(tmp_path, monkeypatch):
+    fasta = tmp_path / "s.fasta"
+    fasta.write_text(">P12345\nMKVLAAG\n")
+    captured = {}
+    monkeypatch.setattr(
+        "protspace.data.embedding.biocentral.embed_sequences", _fake_embed(captured)
+    )
+
+    embed_fasta(
+        fasta, "prot_t5", backend="biocentral", embedding_cache=tmp_path / "e.h5"
+    )
+
+    assert captured["embedder"] == resolve_embedder("prot_t5")  # full model name
+
+
+def test_embed_fasta_defaults_to_biocentral(tmp_path, monkeypatch):
+    fasta = tmp_path / "s.fasta"
+    fasta.write_text(">P12345\nMKVLAAG\n")
+    captured = {}
+    monkeypatch.setattr(
+        "protspace.data.embedding.biocentral.embed_sequences", _fake_embed(captured)
+    )
+
+    embed_fasta(fasta, "prot_t5", embedding_cache=tmp_path / "e.h5")  # no backend arg
+
+    assert captured["embedder"] == resolve_embedder("prot_t5")
+
+
+def test_embed_fasta_unknown_backend_raises(tmp_path):
+    fasta = tmp_path / "s.fasta"
+    fasta.write_text(">P12345\nMKVLAAG\n")
+    with pytest.raises(ValueError, match="backend"):
+        embed_fasta(fasta, "prot_t5", backend="nope", embedding_cache=tmp_path / "e.h5")
+
+
+# ---------------------------------------------------------------------------
+# CLI wiring
+# ---------------------------------------------------------------------------
+
+
+def test_embed_cli_backend_local_dispatches_to_local(tmp_path, monkeypatch):
+    fasta = tmp_path / "s.fasta"
+    fasta.write_text(">P12345\nMKVLAAG\n")
+    captured = {}
+    monkeypatch.setattr(
+        "protspace.data.embedding.local.embed_sequences", _fake_embed(captured)
+    )
+
+    result = CliRunner().invoke(
+        app,
+        [
+            "embed",
+            "-i",
+            str(fasta),
+            "-e",
+            "prot_t5",
+            "-o",
+            str(tmp_path / "out"),
+            "--backend",
+            "local",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert captured["embedder"] == "prot_t5"  # local gets the short key
+    # local backend must build a LocalEmbedConfig, not a Biocentral EmbedConfig
+    assert type(captured["config"]).__name__ == "LocalEmbedConfig"
+
+
+def test_embed_cli_rejects_nonpositive_batch_size(tmp_path, monkeypatch):
+    """--batch-size 0 must be rejected up front (it would otherwise infinite-loop
+    the local backend after loading the model)."""
+    fasta = tmp_path / "s.fasta"
+    fasta.write_text(">P12345\nMKVLAAG\n")
+    # Guard against regressions: even if validation were skipped, don't let a
+    # real model load / hang.
+    monkeypatch.setattr(
+        "protspace.data.embedding.local.embed_sequences", _fake_embed({})
+    )
+
+    result = CliRunner().invoke(
+        app,
+        [
+            "embed",
+            "-i",
+            str(fasta),
+            "-e",
+            "prot_t5",
+            "-o",
+            str(tmp_path / "out"),
+            "--backend",
+            "local",
+            "--batch-size",
+            "0",
+        ],
+    )
+
+    assert result.exit_code != 0
+
+
+def test_embed_cli_rejects_unknown_backend(tmp_path):
+    fasta = tmp_path / "s.fasta"
+    fasta.write_text(">P12345\nMKVLAAG\n")
+
+    result = CliRunner().invoke(
+        app,
+        [
+            "embed",
+            "-i",
+            str(fasta),
+            "-e",
+            "prot_t5",
+            "-o",
+            str(tmp_path / "out"),
+            "--backend",
+            "bogus",
+        ],
+    )
+
+    assert result.exit_code != 0

--- a/apps/protspace/tests/test_local_embedder.py
+++ b/apps/protspace/tests/test_local_embedder.py
@@ -1,0 +1,194 @@
+"""Tests for the local (Colab-GPU) embedding backend.
+
+The pure helpers (checkpoint resolution, sequence preprocessing, residue
+pooling, header validation) are torch-free and always run. The end-to-end
+``embed_sequences`` test needs the optional ``[local]`` extra (torch +
+transformers) and downloads a small ESM2 model, so it is marked ``slow``.
+"""
+
+import numpy as np
+import pytest
+
+from protspace.data.embedding import local
+from protspace.data.embedding.biocentral import ALL_SHORT_KEYS
+
+# ---------------------------------------------------------------------------
+# resolve_local_checkpoint
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_prot_t5_uses_half_encoder_checkpoint():
+    checkpoint, mod_type = local.resolve_local_checkpoint("prot_t5")
+    assert checkpoint == "Rostlab/prot_t5_xl_half_uniref50-enc"
+    assert mod_type == "prot_t5"
+
+
+def test_resolve_esmc_uses_synthyra_not_native():
+    checkpoint, mod_type = local.resolve_local_checkpoint("esmc_300m")
+    assert checkpoint == "Synthyra/ESMplusplus_small"
+    assert mod_type == "esmc"
+
+
+def test_resolve_covers_every_cli_short_key():
+    """The local backend must support the same 12 shortcuts as Biocentral."""
+    for key in ALL_SHORT_KEYS:
+        checkpoint, mod_type = local.resolve_local_checkpoint(key)
+        assert checkpoint, f"no checkpoint for {key}"
+        assert mod_type in {"prot_t5", "prost_t5", "esm", "ankh", "esmc"}
+
+
+def test_resolve_unknown_raises_with_suggestion():
+    with pytest.raises(ValueError, match="esm2_8m"):
+        local.resolve_local_checkpoint("esm2_8")
+
+
+# ---------------------------------------------------------------------------
+# preprocess_sequence
+# ---------------------------------------------------------------------------
+
+
+def test_preprocess_maps_rare_residues_to_x():
+    # B, J, O, U, Z -> X; standard residues untouched.
+    assert local.preprocess_sequence("ABJOUZ", "esm") == "AXXXXX"
+
+
+def test_preprocess_t5_inserts_spaces_between_residues():
+    assert local.preprocess_sequence("MKV", "prot_t5") == "M K V"
+
+
+def test_preprocess_prostt5_prefixes_control_token_and_spaces():
+    assert local.preprocess_sequence("MKV", "prost_t5") == "<AA2fold> M K V"
+
+
+def test_preprocess_esm_leaves_sequence_unspaced():
+    assert local.preprocess_sequence("MKV", "esm") == "MKV"
+
+
+def test_preprocess_ankh_leaves_sequence_unspaced():
+    assert local.preprocess_sequence("MKV", "ankh") == "MKV"
+
+
+# ---------------------------------------------------------------------------
+# pool_residues
+# ---------------------------------------------------------------------------
+
+
+def test_pool_esm_strips_cls_and_eos_then_means():
+    # rows: [CLS, r1, r2, r3, EOS]
+    hidden = np.array([[9, 9], [1, 1], [2, 2], [3, 3], [9, 9]], dtype=np.float32)
+    pooled = local.pool_residues(hidden, seq_len=5, mod_type="esm")
+    np.testing.assert_allclose(pooled, [2, 2])
+
+
+def test_pool_prot_t5_strips_only_trailing_eos():
+    # rows: [r1, r2, r3, EOS]  (T5 has no leading special token)
+    hidden = np.array([[1, 1], [2, 2], [3, 3], [9, 9]], dtype=np.float32)
+    pooled = local.pool_residues(hidden, seq_len=4, mod_type="prot_t5")
+    np.testing.assert_allclose(pooled, [2, 2])
+
+
+def test_pool_esmc_strips_both_ends_like_esm():
+    hidden = np.array([[9, 9], [1, 1], [3, 3], [9, 9]], dtype=np.float32)
+    pooled = local.pool_residues(hidden, seq_len=4, mod_type="esmc")
+    np.testing.assert_allclose(pooled, [2, 2])
+
+
+def test_pool_ignores_right_padding_beyond_seq_len():
+    # rows: [CLS, r1, r2, EOS, PAD, PAD]; seq_len counts real tokens only.
+    hidden = np.array(
+        [[9, 9], [1, 1], [3, 3], [9, 9], [0, 0], [0, 0]], dtype=np.float32
+    )
+    pooled = local.pool_residues(hidden, seq_len=4, mod_type="esm")
+    np.testing.assert_allclose(pooled, [2, 2])
+
+
+def test_pool_returns_float32():
+    hidden = np.ones((4, 3), dtype=np.float32)
+    assert local.pool_residues(hidden, 4, "esm").dtype == np.float32
+
+
+# ---------------------------------------------------------------------------
+# validate_headers  (HDF5 dataset names cannot contain '/')
+# ---------------------------------------------------------------------------
+
+
+def test_validate_headers_rejects_slash():
+    with pytest.raises(ValueError, match="/"):
+        local.validate_headers(["P12345", "bad/name"])
+
+
+def test_validate_headers_accepts_clean_ids():
+    local.validate_headers(["P12345", "A0A2P1BSS8"])  # no raise
+
+
+# ---------------------------------------------------------------------------
+# embed_sequences guards (torch-free: return before any model is loaded)
+# ---------------------------------------------------------------------------
+
+
+def test_local_embed_config_rejects_nonpositive_batch_size():
+    with pytest.raises(ValueError, match="batch_size"):
+        local.LocalEmbedConfig(batch_size=0)
+
+
+def test_local_embed_config_rejects_nonpositive_max_length():
+    with pytest.raises(ValueError, match="max_length"):
+        local.LocalEmbedConfig(max_length=0)
+
+
+def test_embed_sequences_raises_when_all_sequences_dropped(tmp_path):
+    """All sequences over max_length → no embeddings → a clear error, not a
+    silently-empty/absent .h5 that later crashes load_h5."""
+    out = tmp_path / "emb.h5"
+    with pytest.raises(ValueError, match="No embeddings"):
+        local.embed_sequences(
+            {"p1": "MKVLAAGILT"},
+            "esm2_8m",
+            out,
+            local.LocalEmbedConfig(max_length=3),
+        )
+
+
+# ---------------------------------------------------------------------------
+# End-to-end (needs [local] extra; downloads esm2_8m ~30 MB)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.slow
+def test_embed_sequences_esm2_8m_end_to_end(tmp_path):
+    pytest.importorskip("torch")
+    pytest.importorskip("transformers")
+    import h5py
+
+    sequences = {"prot1": "MKVLAAG", "prot2": "MSEQWENCE"}
+    out = tmp_path / "emb.h5"
+
+    result = local.embed_sequences(sequences, "esm2_8m", out)
+
+    assert result == out and out.exists()
+    with h5py.File(out, "r") as f:
+        assert set(f.keys()) == {"prot1", "prot2"}
+        vec = f["prot1"][:]
+        assert vec.shape == (320,)  # esm2_8m hidden dim
+        assert vec.dtype == np.float32
+        assert np.isfinite(vec).all()
+
+
+@pytest.mark.slow
+def test_embed_sequences_resumes_and_skips_existing(tmp_path):
+    pytest.importorskip("torch")
+    pytest.importorskip("transformers")
+    import h5py
+
+    sequences = {"prot1": "MKVLAAG"}
+    out = tmp_path / "emb.h5"
+
+    local.embed_sequences(sequences, "esm2_8m", out)
+    with h5py.File(out, "r") as f:
+        first = f["prot1"][:].copy()
+
+    # Second run must not fail and must not alter the existing embedding.
+    local.embed_sequences({"prot1": "MKVLAAG", "prot2": "MSEQWENCE"}, "esm2_8m", out)
+    with h5py.File(out, "r") as f:
+        assert set(f.keys()) == {"prot1", "prot2"}
+        np.testing.assert_array_equal(f["prot1"][:], first)

--- a/uv.lock
+++ b/uv.lock
@@ -1001,6 +1001,15 @@ wheels = [
 ]
 
 [[package]]
+name = "einops"
+version = "0.8.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/2c/77/850bef8d72ffb9219f0b1aac23fbc1bf7d038ee6ea666f331fa273031aa2/einops-0.8.2.tar.gz", hash = "sha256:609da665570e5e265e27283aab09e7f279ade90c4f01bcfca111f3d3e13f2827", size = 56261, upload-time = "2026-01-26T04:13:17.638Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2a/09/f8d8f8f31e4483c10a906437b4ce31bdf3d6d417b73fe33f1a8b59e34228/einops-0.8.2-py3-none-any.whl", hash = "sha256:54058201ac7087911181bfec4af6091bb59380360f069276601256a76af08193", size = 65638, upload-time = "2026-01-26T04:13:18.546Z" },
+]
+
+[[package]]
 name = "email-validator"
 version = "2.3.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1342,6 +1351,38 @@ wheels = [
 ]
 
 [[package]]
+name = "hf-xet"
+version = "1.5.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/4b/2d/57fd21d84d93efb4bd0b962383790e19dd1bc053501b4264c97903b4e83e/hf_xet-1.5.1.tar.gz", hash = "sha256:51ef4500dab3764b41135ee1381a4b62ce56fc54d4c92b719b59e597d6df5bf6", size = 876636, upload-time = "2026-06-08T23:02:53.897Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/64/ee/dd9ba7beae1005e54131b7d45263cc74c8a066d47d354e6d58ae9445a388/hf_xet-1.5.1-cp313-cp313t-macosx_10_12_x86_64.whl", hash = "sha256:dbf48c0d02cf0b2e568944330c60d9120c272dabe013bd892d48e25bc6797577", size = 4069485, upload-time = "2026-06-08T23:02:13.193Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/bc/9cae6cfeb4e03070874e73e5c97c66eb90369d3206b6a2b1ef5f96520888/hf_xet-1.5.1-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:e78e4e5192ad2b674c2e1160b651cb9134db974f8ae1835bdfbfb0166b894a43", size = 3838493, upload-time = "2026-06-08T23:02:15.282Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/b4/d5c01e0eb6d9f2ca2dacd84d0d1b71e6cfbb2ef3208c968528e010e9b3d7/hf_xet-1.5.1-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:6f7a04a8ad962422e225bc49fbbac99dc1806764b1f3e54dbd154bffa7593947", size = 4505658, upload-time = "2026-06-08T23:02:17.196Z" },
+    { url = "https://files.pythonhosted.org/packages/76/c5/29a7598c0c6383c523dc22186d577f4e04267a626cd95ae60f67c00bfe66/hf_xet-1.5.1-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:d48199c2bf4f8df0adc55d31d1368b6ec0e4d4f45bc86b08038089c23db0bed8", size = 4292822, upload-time = "2026-06-08T23:02:18.608Z" },
+    { url = "https://files.pythonhosted.org/packages/04/9a/dceaf6ca69390126b86ea825fb354b93d01163199070b7bd849225de9468/hf_xet-1.5.1-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:97f212a88d14bbf573619a74b7fecb238de77d08fc702e54dec6f78276ca3283", size = 4491255, upload-time = "2026-06-08T23:02:20.124Z" },
+    { url = "https://files.pythonhosted.org/packages/48/a7/e5a7afaacf6c1791fdbeeac42951fb81c3d2bc482992b115dedcc86d963e/hf_xet-1.5.1-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:f61e3665892a6c8c5e765395838b8ddf36185da835253d4bc4509a81e49fb342", size = 4711062, upload-time = "2026-06-08T23:02:21.863Z" },
+    { url = "https://files.pythonhosted.org/packages/53/49/2802f8433c9742ce281bddc1e65c02c32268ca3098d66828b05e12e45ee2/hf_xet-1.5.1-cp313-cp313t-win_amd64.whl", hash = "sha256:f4ad3ebd4c32dd2b27099d69dc7b2df821e30767e46fb6ee6a0713778243b8ff", size = 4017205, upload-time = "2026-06-08T23:02:23.495Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/5a/50c71195b9fb883659f596e7252faf4c18c58e753a9013bdbf9bac5d2250/hf_xet-1.5.1-cp313-cp313t-win_arm64.whl", hash = "sha256:8298485c1e36e7e67cbd01eeb1376619b7af43d4f1ec245caae306f890a8a32d", size = 3845426, upload-time = "2026-06-08T23:02:25.124Z" },
+    { url = "https://files.pythonhosted.org/packages/05/24/5e0c28f80371c17d49fed004597d9d132cb75c1f6f53db2cb95f459d2312/hf_xet-1.5.1-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:3474760d10e3bb6f92ff3f024fcb00c0b3e4001e9b035c7483e49a5dd17aa70f", size = 4069676, upload-time = "2026-06-08T23:02:26.759Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/17/261ba565b6a4d960fb478f61fdf919c0be5824645aaf1c319eca660c1611/hf_xet-1.5.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:6762d89b9e3267dfd502b29b2a327b4525f33b17e7b509a78d94e2151a30ce30", size = 3838509, upload-time = "2026-06-08T23:02:28.573Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/44/7ffdc2e184b0d41fc0f683ba3936ef669ab63cf242cf36ef50e57d683668/hf_xet-1.5.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:bf67e6ed10260cef62e852789dc91ebb03f382d5bdc4b1dbeb64763ea275e7d6", size = 4505881, upload-time = "2026-06-08T23:02:30.257Z" },
+    { url = "https://files.pythonhosted.org/packages/63/b6/788060d5aa4d5e671f1a31bf69624c314eb2d8babab3aa562f9e5d53444e/hf_xet-1.5.1-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:c6b6cd08ca095058780b50b8ce4d6cbf6787bcf27841705d58a9d32246e3e47a", size = 4292995, upload-time = "2026-06-08T23:02:31.993Z" },
+    { url = "https://files.pythonhosted.org/packages/22/93/c5540cbd6b55529b7dc42f6734e88cebee21aefbea34128b66229df56c57/hf_xet-1.5.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:e1af0de8ca6f190d4294a28b88023db64a1e2d1d719cab044baf75bec569e7a9", size = 4491570, upload-time = "2026-06-08T23:02:33.86Z" },
+    { url = "https://files.pythonhosted.org/packages/03/f3/9d8ceab30f44f36c1679b1b8683054c71a0dadc787dbf07421891742d3ca/hf_xet-1.5.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:4f561cbbb92f80960772059864b7fb07eae879adde1b2e781ec6f86f6ac26c59", size = 4711565, upload-time = "2026-06-08T23:02:35.454Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/54/27ed9a5e2cc583b4df82f75a03a4df8dbf55f5a9fa1f47f1fadfb20dbeac/hf_xet-1.5.1-cp314-cp314t-win_amd64.whl", hash = "sha256:e7dbb40617410f432182d918e37c12303fe6700fd6aa6c5964e30a535a4461d6", size = 4017343, upload-time = "2026-06-08T23:02:37.14Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/12/ecb2fc8d45e767580e3a37faa97cb895608b614965567efb4f18cff67e27/hf_xet-1.5.1-cp314-cp314t-win_arm64.whl", hash = "sha256:6071d5ccb4d8d2cbd5fea5cc798da4f0ba3f44e25369591c4e89a4987050e61d", size = 3845716, upload-time = "2026-06-08T23:02:39.073Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/d8/5e54cf37434759d1f4f2ba9b66077ff9d4c4e1f37b6bd7975da5c40d94ab/hf_xet-1.5.1-cp37-abi3-macosx_10_12_x86_64.whl", hash = "sha256:6abd35c3221eff63836618ddfb954dcf84798603f71d8e33e3ed7b04acfdbe6e", size = 4077794, upload-time = "2026-06-08T23:02:40.656Z" },
+    { url = "https://files.pythonhosted.org/packages/35/94/4b2ecfbad8f8b04701a23aefb62f540b9137d058b7e1dbef16a32676f0e9/hf_xet-1.5.1-cp37-abi3-macosx_11_0_arm64.whl", hash = "sha256:94e761bbd266bf4c03cee73753916062665ce8365aa40ed321f45afcb934b41e", size = 3845354, upload-time = "2026-06-08T23:02:42.702Z" },
+    { url = "https://files.pythonhosted.org/packages/de/cc/f99f4bc7295023d7bd9ebbfd51f75cc530ca262c1227666268b8208f4b77/hf_xet-1.5.1-cp37-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:892e3a3a3aecc12aded8b93cf4f9cd059282c7de0732f7d55026f3abdf474350", size = 4514864, upload-time = "2026-06-08T23:02:44.497Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/6e/21f7e5a2381278bd3b7b7a5a4d90038518bb6308a0c1daf5d9f8268bb178/hf_xet-1.5.1-cp37-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:a93df2039190502835b1db8cd7e178b0b7b889fe9ab51299d5ced26e0dd879a4", size = 4303784, upload-time = "2026-06-08T23:02:46.203Z" },
+    { url = "https://files.pythonhosted.org/packages/35/0e/f992bb6927ac1cb30ef74e62268f551f338bc32b2191f7c96a44c6f7283e/hf_xet-1.5.1-cp37-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:0c97106032ef70467b4f6bc2d0ccc266d7613ee076afc56516c502f87ce1c4a6", size = 4500703, upload-time = "2026-06-08T23:02:47.628Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/d1/90a498d05447980b977b1669246eeeeae4cfb0ea3e7a286eaba627f91bf9/hf_xet-1.5.1-cp37-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:6208adb15d192b90e4c2ad2a27ed864359b2cb0f2494eb6d7c7f3699ac02e2bf", size = 4719498, upload-time = "2026-06-08T23:02:49.268Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/b6/20f99cfe97cc663a711f7b33cc21d4793e51968e9a26125b4afcd77315ba/hf_xet-1.5.1-cp37-abi3-win_amd64.whl", hash = "sha256:f7b3002f95d1c13e24bcb4537baa8f0eb3838957067c91bb4959bc004a6435f5", size = 4026419, upload-time = "2026-06-08T23:02:50.829Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/fa/77453694888f03e5a8c8852d1514a0894d8e81c622d39edbaf308ea0dcf4/hf_xet-1.5.1-cp37-abi3-win_arm64.whl", hash = "sha256:93d090b57b211133f6c0dab0205ef5cb6d89162979ba75a74845045cc3063b8e", size = 3855178, upload-time = "2026-06-08T23:02:52.452Z" },
+]
+
+[[package]]
 name = "holoviews"
 version = "1.23.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1423,6 +1464,26 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/b1/df/48c586a5fe32a0f01324ee087459e112ebb7224f646c0b5023f5e79e9956/httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc", size = 141406, upload-time = "2024-12-06T15:37:23.222Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad", size = 73517, upload-time = "2024-12-06T15:37:21.509Z" },
+]
+
+[[package]]
+name = "huggingface-hub"
+version = "1.23.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "filelock" },
+    { name = "fsspec" },
+    { name = "hf-xet", marker = "platform_machine == 'AMD64' or platform_machine == 'aarch64' or platform_machine == 'amd64' or platform_machine == 'arm64' or platform_machine == 'x86_64'" },
+    { name = "httpx" },
+    { name = "packaging" },
+    { name = "pyyaml" },
+    { name = "tqdm" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1a/8f/999e4dda11c6187c78f090eac00895a47e11a0049308f07579bcb7aa3aa2/huggingface_hub-1.23.0.tar.gz", hash = "sha256:c04997fb8bbdace1e57b7703d30ed7678af51f70d00d241819ff411b92ae9a88", size = 919163, upload-time = "2026-07-09T14:49:32.315Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f1/ce/13b2ba57838b8db1e6bd033c1b21ce0b9f6153b87d4e4939f77074e41eb0/huggingface_hub-1.23.0-py3-none-any.whl", hash = "sha256:b1d604788f5adc7f0eb246e03e0ec19011ca06e38400218c347dccc3dffa64a2", size = 770336, upload-time = "2026-07-09T14:49:30.597Z" },
 ]
 
 [[package]]
@@ -3213,7 +3274,7 @@ wheels = [
 
 [[package]]
 name = "protlabel"
-version = "4.7.1"
+version = "4.7.2"
 source = { editable = "apps/protspace/packages/protlabel" }
 dependencies = [
     { name = "numpy" },
@@ -3223,8 +3284,23 @@ dependencies = [
 requires-dist = [{ name = "numpy", specifier = ">=1.23.0" }]
 
 [[package]]
+name = "protobuf"
+version = "7.35.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/da/01/9ef0afd7999eb9badb3a768b4aedd78c86d4c65cfaf1958ab276199e76b4/protobuf-7.35.1.tar.gz", hash = "sha256:ce115a26fe0c39a2c29973d914d327e516a6455464489fe3cd1e51a1b354f81a", size = 458717, upload-time = "2026-06-11T21:55:40.257Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/10/03/8aeeb7458d22546bf64b5250ca1daeb5ff757d900e8e4a7476c6f0db843e/protobuf-7.35.1-cp310-abi3-macosx_10_9_universal2.whl", hash = "sha256:24f857477359a85c0c235261b8ba905fd51b2562f4a64ca1df5473f29850cbf6", size = 433226, upload-time = "2026-06-11T21:55:31.719Z" },
+    { url = "https://files.pythonhosted.org/packages/37/4b/dfb89eb0e652a1ff073c39a59fb5e3a83cfe9b57a2c83fa6d78270101767/protobuf-7.35.1-cp310-abi3-manylinux2014_aarch64.whl", hash = "sha256:11d6b0ec246892d85215b0a13ca6e0233cf5284b68f0ac02646427f4ff88a799", size = 328847, upload-time = "2026-06-11T21:55:34.035Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/58/dc12f2cd484951524af6e3382c785869b9b3fb5e52ee95ae23add53ee8f9/protobuf-7.35.1-cp310-abi3-manylinux2014_s390x.whl", hash = "sha256:b73f9489a4b8b1c9cb1f8ed951c736392592edb24b9d6819f36d2e10b171d5b4", size = 344030, upload-time = "2026-06-11T21:55:34.941Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/be/5b3cfe508bfab6761414ff944e3366eb13be4fd71efcd69450f89ba39f43/protobuf-7.35.1-cp310-abi3-manylinux2014_x86_64.whl", hash = "sha256:74758715c53d7158fb76caf4f0cfdacc5329a4b1bb994f865d6cf302d413a1c4", size = 327130, upload-time = "2026-06-11T21:55:35.921Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/bc/6d6c7ba8709c85f8f2c390b2b118d6fb08a783676a572271851bf45a7d22/protobuf-7.35.1-cp310-abi3-win32.whl", hash = "sha256:353652e4efd0bca5b5fc2656abf8307ef351f0cf938c9eba09f0e09c20a25c30", size = 428945, upload-time = "2026-06-11T21:55:37.034Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/19/8d0cb6f20a1ef7b18f1c8986ad5783f22f84cce39c6ce9a6e645ea55192e/protobuf-7.35.1-cp310-abi3-win_amd64.whl", hash = "sha256:230a75ddfc2de4806e56696ce9640c1cdfdb6543b7cfce98d42a4c0a0e7bdb87", size = 439996, upload-time = "2026-06-11T21:55:38.123Z" },
+    { url = "https://files.pythonhosted.org/packages/19/c7/5f7c636ec43e0c545e28d1f1db71990108306f7bdcb89f069ba97e428e7f/protobuf-7.35.1-py3-none-any.whl", hash = "sha256:4bc97768d8fe4ad6743c8a19403e314511ed9f6d13205b687e52421c023ac1b9", size = 171659, upload-time = "2026-06-11T21:55:39.155Z" },
+]
+
+[[package]]
 name = "protspace"
-version = "4.7.1"
+version = "4.7.2"
 source = { editable = "apps/protspace" }
 dependencies = [
     { name = "biocentral-api" },
@@ -3255,6 +3331,13 @@ frontend = [
     { name = "plotly" },
     { name = "python-dotenv" },
     { name = "requests" },
+]
+local = [
+    { name = "einops" },
+    { name = "protobuf" },
+    { name = "sentencepiece" },
+    { name = "torch" },
+    { name = "transformers" },
 ]
 
 [package.dev-dependencies]
@@ -3291,6 +3374,7 @@ requires-dist = [
     { name = "dash-daq", marker = "extra == 'frontend'", specifier = ">=0.5.0" },
     { name = "dash-iconify", marker = "extra == 'frontend'", specifier = ">=0.1.2" },
     { name = "dash-molstar", marker = "extra == 'frontend'", specifier = ">=1.3.0" },
+    { name = "einops", marker = "extra == 'local'", specifier = ">=0.8.2" },
     { name = "gunicorn", marker = "extra == 'frontend'", specifier = ">=23.0.0" },
     { name = "h5py", specifier = ">=3.12.1" },
     { name = "kaleido", marker = "extra == 'frontend'", specifier = ">=0.2.1,!=0.2.1.post1" },
@@ -3299,6 +3383,7 @@ requires-dist = [
     { name = "pandas", specifier = ">=2.0.0" },
     { name = "plotly", marker = "extra == 'frontend'", specifier = ">=5.24.1" },
     { name = "protlabel", editable = "apps/protspace/packages/protlabel" },
+    { name = "protobuf", marker = "extra == 'local'", specifier = ">=7.35.1" },
     { name = "pyarrow", specifier = ">=20.0.0" },
     { name = "pymmseqs", specifier = ">=1.0.4" },
     { name = "python-dotenv", marker = "extra == 'frontend'", specifier = ">=1.0.1" },
@@ -3306,11 +3391,14 @@ requires-dist = [
     { name = "requests", marker = "extra == 'frontend'", specifier = ">=2.32.4" },
     { name = "rich", specifier = ">=14.3.3" },
     { name = "scikit-learn", specifier = ">=1.6.1" },
+    { name = "sentencepiece", marker = "extra == 'local'", specifier = ">=0.2.2" },
+    { name = "torch", marker = "extra == 'local'", specifier = ">=2.4" },
     { name = "tqdm", specifier = ">=4.67.1" },
+    { name = "transformers", marker = "extra == 'local'", specifier = ">=5.13.1" },
     { name = "typer", specifier = ">=0.24.1" },
     { name = "umap-learn", specifier = ">=0.5.10" },
 ]
-provides-extras = ["frontend"]
+provides-extras = ["frontend", "local"]
 
 [package.metadata.requires-dev]
 dev = [
@@ -3890,6 +3978,94 @@ wheels = [
 ]
 
 [[package]]
+name = "regex"
+version = "2026.7.10"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7b/37/451aaddbf50922f34d744ad5ca919ae1fcfac112123885d9728f52a484b3/regex-2026.7.10.tar.gz", hash = "sha256:1050fedf0a8a92e843971120c2f57c3a99bea86c0dfa1d63a9fac053fe54b135", size = 416282, upload-time = "2026-07-10T19:49:46.267Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b3/9c/2503d4ccf3452dc323f8baa3cf3ee10406037d52735c76cfced81423f183/regex-2026.7.10-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:7252b48b0c60100095088fbeb281fca9a4fcf678a4e04b1c520c3f8613c952c4", size = 497114, upload-time = "2026-07-10T19:47:16.22Z" },
+    { url = "https://files.pythonhosted.org/packages/91/eb/04534f4263a4f658cd20a511e9d6124350044f2214eb24fee2db96acf318/regex-2026.7.10-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:da6ef4cb8d457aab0482b50120136ae94238aaa421863eaa7d599759742c72d6", size = 297422, upload-time = "2026-07-10T19:47:17.794Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/2d/35809de392ab66ba439b58c3187ae3b8b53c883233f284b59961e5725c99/regex-2026.7.10-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:fe7ff456c22725c9d9017f7a2a7df2b51af6df77314176760b22e2d05278e181", size = 292110, upload-time = "2026-07-10T19:47:19.188Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/1e/5ce0fbe9aab071893ce2b7df020d0f561f7b411ec334124302468d587884/regex-2026.7.10-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f3463a5f26be513a49e4d497debcf1b252a2db7b92c77d89621aa90b83d2dd38", size = 796800, upload-time = "2026-07-10T19:47:20.639Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/67/c1ccbada395c10e334763b583e1039b1660b142303ebb941d4269130b22f/regex-2026.7.10-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:948dfc62683a6947b9b486c4598d8f6e3ecc542478b6767b87d52be68aeb55c6", size = 865509, upload-time = "2026-07-10T19:47:22.135Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/06/f0b31afc16c1208f945b66290eb2a9936ab8becdfb23bbcedb91cc5f9d9b/regex-2026.7.10-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:c2cbd385d82f63bb35edb60b09b08abad3619bd0a4a492ae59e55afaf98e1b9d", size = 912395, upload-time = "2026-07-10T19:47:24.128Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/1c/8687de3a6c3220f4f872a9bf4bcd8dc249f2a96e7dddfa93de8bd4d16399/regex-2026.7.10-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f6222cafe00e072bb2b8f14142cd969637411fbc4dd3b1d73a90a3b817fa046f", size = 801308, upload-time = "2026-07-10T19:47:25.696Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/e3/60a40ec02a2315d826414a125640aceb6f30450574c530c8f352110ece0e/regex-2026.7.10-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:65ee5d1ac3cd541325f5ac92625b1c1505f4d171520dd931bda7952895c5321a", size = 777120, upload-time = "2026-07-10T19:47:27.158Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/9a/ec579b4f840ac59bc7c192b56e66abd4cbf385615300d59f7c94bf6863ae/regex-2026.7.10-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:aa34473fbcc108fea403074f3f45091461b18b2047d136f16ffaa4c65ad46a68", size = 785164, upload-time = "2026-07-10T19:47:28.732Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/1c/60d88afd5f98d4b0fb1f8b8969270628140dc01c7ff93a939f2aa83f31a6/regex-2026.7.10-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:9d028d189d8f38d7ff292f22187c0df37f2317f554d2ed9a2908ada330af57c0", size = 860161, upload-time = "2026-07-10T19:47:30.605Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/40/08ae3ba45fe79e48c9a888a3389a7ee7e2d8c580d2d996da5ece02dfdcb9/regex-2026.7.10-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:396ea70e4ea1f19571940add3bad9fd3eb6a19dc610d0d01f692bc1ba0c10cb4", size = 765829, upload-time = "2026-07-10T19:47:32.06Z" },
+    { url = "https://files.pythonhosted.org/packages/12/e6/e613c6755d19aca9d977cdc3418a1991ffc8f386779752dd8fdfa888ea89/regex-2026.7.10-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:ebbf0d83ed5271991d666e54bb6c90ac2c55fb2ef3a88740c6af85dc85de2402", size = 852170, upload-time = "2026-07-10T19:47:33.567Z" },
+    { url = "https://files.pythonhosted.org/packages/03/33/89072f2060e6b844b4916d5bc40ef01e973640c703025707869264ec75ab/regex-2026.7.10-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:58a4571b2a093f6f6ee4fd281faa8ebf645abcf575f758173ea2605c7a1e1ecb", size = 789550, upload-time = "2026-07-10T19:47:35.395Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/3c/4bc8be9a155035e63780ccac1da101f36194946fdc3f6fce90c7179fc6df/regex-2026.7.10-cp312-cp312-win32.whl", hash = "sha256:eac1207936555aa691ce32df1432b478f2729d54e6d93a1f4db9215bcd8eb47d", size = 267151, upload-time = "2026-07-10T19:47:37.047Z" },
+    { url = "https://files.pythonhosted.org/packages/35/73/9f5aade65bb98cc6e99c336e45a49a658300720c16721f3e687f8d754fec/regex-2026.7.10-cp312-cp312-win_amd64.whl", hash = "sha256:ecae626449d00db8c08f8f1fc00047a32d6d7eb5402b3976f5c3fda2b80a7a4f", size = 277751, upload-time = "2026-07-10T19:47:38.488Z" },
+    { url = "https://files.pythonhosted.org/packages/36/6f/d069dd12872ea1d50e17319d342f89e2072cae4b62f4245009a1108c74d8/regex-2026.7.10-cp312-cp312-win_arm64.whl", hash = "sha256:87794549a3f5c1c2bdfba2380c1bf87b931e375f4133d929da44f95e396bf5fe", size = 277063, upload-time = "2026-07-10T19:47:40.023Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/88/0c977b9f3ba9b08645516eca236388c340f56f7a87054d41a187a04e134c/regex-2026.7.10-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:4db009b4fc533d79af3e841d6c8538730423f82ea8508e353a3713725de7901c", size = 496868, upload-time = "2026-07-10T19:47:41.675Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/51/600882cd5d9a3cf083fd66a4064f5b7f243ba2a7de2437d42823e286edaf/regex-2026.7.10-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:b96341cb29a3faa5db05aff29c77d141d827414f145330e5d8846892119351c1", size = 297306, upload-time = "2026-07-10T19:47:43.521Z" },
+    { url = "https://files.pythonhosted.org/packages/52/6f/48a912054ffcb756e374207bb8f4430c5c3e0ffa9627b3c7b6661844b30a/regex-2026.7.10-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:14d27f6bd04beb01f6a25a1153d73e58c290fd45d92ba56af1bb44199fd1010d", size = 291950, upload-time = "2026-07-10T19:47:45.267Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/c8/8e1c3c86ebcee7effccbd1f7fc54fe3af22aa0e9204503e2baea4a6ff001/regex-2026.7.10-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e6b6a11bf898cca3ce7bfaa17b646901107f3975677fbd5097f36e5eb5641983", size = 796817, upload-time = "2026-07-10T19:47:48.054Z" },
+    { url = "https://files.pythonhosted.org/packages/65/39/3e49d9ff0e0737eb8180a00569b47aabb59b84611f48392eba4d998d91a0/regex-2026.7.10-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:234f8e0d65cf1df9becadae98648f74030ee85a8f12edcb5eb0f60a22a602197", size = 865513, upload-time = "2026-07-10T19:47:49.855Z" },
+    { url = "https://files.pythonhosted.org/packages/70/57/6511ad809bb3122c65bbeeffa5b750652bb03d273d29f3acb0754109b183/regex-2026.7.10-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:91b916d495db3e1b473c7c8e68733beec4dce8e487442db61764fff94f59740e", size = 912391, upload-time = "2026-07-10T19:47:51.776Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/29/a1b0c109c9e878cb04b931bfe4c54332d692b93c322e127b5ae9f25b0d9e/regex-2026.7.10-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1f0d4ccf70b1d13711242de0ba78967db5c35d12ac408378c70e06295c3f6644", size = 801338, upload-time = "2026-07-10T19:47:53.38Z" },
+    { url = "https://files.pythonhosted.org/packages/33/be/171c3dad4d77000e1befeff2883ca88734696dfd97b2951e5e074f32e4dd/regex-2026.7.10-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:c622f4c638a725c39abcb2e680b1bd592663c83b672a4ed350a17f806d75618e", size = 777149, upload-time = "2026-07-10T19:47:54.944Z" },
+    { url = "https://files.pythonhosted.org/packages/33/61/41ab0de0e4574da1071c151f67d1eb9db3d92c43e31d64d2e6863c3d89bf/regex-2026.7.10-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:41a47c2b28d9421e2509a4583a22510dc31d83212fcf38e1508a7013140f71a8", size = 785216, upload-time = "2026-07-10T19:47:56.56Z" },
+    { url = "https://files.pythonhosted.org/packages/66/28/372859ea693736f07cf7023247c7eca8f221d9c6df8697ff9f93371cca08/regex-2026.7.10-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:13fba679fe035037e9d5286620f88bbfd105df4d5fcd975942edd282ab986775", size = 860229, upload-time = "2026-07-10T19:47:58.278Z" },
+    { url = "https://files.pythonhosted.org/packages/50/b1/e1d32cd944b599534ae655d35e8640d0ec790c0fa12e1fb29bf434d50f55/regex-2026.7.10-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:8e26a075fa9945b9e44a3d02cc83d776c3b76bb1ff4b133bbfa620d5650131da", size = 765797, upload-time = "2026-07-10T19:48:00.291Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/62/79a2cd9556a3329351e370929743ef4f0ccc0aaff6b3dc414ae5fa4a1302/regex-2026.7.10-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:d0834c84ae8750ae1c4cede59b0afd4d2f775be958e11b18a3eea24ed9d0d9f1", size = 852130, upload-time = "2026-07-10T19:48:01.972Z" },
+    { url = "https://files.pythonhosted.org/packages/66/58/76fec29898cf5d359ab63face50f9d4f7135cc2eca3477139227b1d09952/regex-2026.7.10-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:64722a5031aeace7f6c8d5ea9a9b22d9368af0d6e8fa532585da8158549ea963", size = 789644, upload-time = "2026-07-10T19:48:03.748Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/06/3c7cec7817bda293e13c8f88aed227bbcf8b37e5990936ff6442a8fdf11a/regex-2026.7.10-cp313-cp313-win32.whl", hash = "sha256:74ae61d8573ecd51b5eeee7be2218e4c56e99c14fa8fcf97cf7519611d4be92e", size = 267130, upload-time = "2026-07-10T19:48:05.677Z" },
+    { url = "https://files.pythonhosted.org/packages/88/6c/e2a6f9a6a905f923cfc912298a5949737e9504b1ca24f29eda8d04d05ece/regex-2026.7.10-cp313-cp313-win_amd64.whl", hash = "sha256:5e792367e5f9b4ffb8cad93f1beaa91837056b94da98aa5c65a0db0c1b474927", size = 277722, upload-time = "2026-07-10T19:48:07.318Z" },
+    { url = "https://files.pythonhosted.org/packages/00/a6/9d8935aaa940c388496aa1a0c82669cc4b5d06291c2712d595e3f0cf16d3/regex-2026.7.10-cp313-cp313-win_arm64.whl", hash = "sha256:82ab8330e7e2e416c2d42fcec67f02c242393b8681014750d4b70b3f158e1f08", size = 277059, upload-time = "2026-07-10T19:48:08.977Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/e9/26decfd3e85c09e42ff7b0d23a6f51085ca4c268db15f084928ca33459c6/regex-2026.7.10-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:2b93eafd92c4128bab2f93500e8912cc9ecb3d3765f6685b902c6820d0909b6b", size = 501508, upload-time = "2026-07-10T19:48:10.668Z" },
+    { url = "https://files.pythonhosted.org/packages/38/a5/5b167cebde101945690219bf34361481c9f07e858a4f46d9996b80ec1490/regex-2026.7.10-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:3f03b92fb6ec739df042e45b06423fc717ecf0063e07ffe2897f7b2d5735e1e8", size = 299705, upload-time = "2026-07-10T19:48:12.544Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/20/7909be4b9f449f8c282c14b6762d59aa722aeaeebe7ee4f9bb623eeaa5e0/regex-2026.7.10-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:bb5aab464a0c5e03a97abad5bdf54517061ebbf72340d576e99ff661a42575cc", size = 294605, upload-time = "2026-07-10T19:48:14.495Z" },
+    { url = "https://files.pythonhosted.org/packages/82/88/e52550185d6fda68f549b01239698697de47320fd599f5e880b1986b7673/regex-2026.7.10-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:fadb07dbe36a541283ff454b1a268afd54b077d917043f2e1e5615372cb5f200", size = 811747, upload-time = "2026-07-10T19:48:16.197Z" },
+    { url = "https://files.pythonhosted.org/packages/06/98/16c255c909714de1ee04da6ae30f3ee04170f300cdc0dcf57a314ee4816a/regex-2026.7.10-cp313-cp313t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:21150500b970b12202879dfd82e7fd809d8e853140fff84d08e57a90cf1e154e", size = 871203, upload-time = "2026-07-10T19:48:18.12Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/32/423ed27c9bae2092a453e853da2b6628a658d08bb5a6117db8d591183d85/regex-2026.7.10-cp313-cp313t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a68b637451d64ba30ed8ae125c973fa834cc2d37dfa7f154c2b479015d477ba8", size = 917334, upload-time = "2026-07-10T19:48:19.952Z" },
+    { url = "https://files.pythonhosted.org/packages/73/87/74dac8efb500db31cb000fda6bae2be45fc2fbf1fa9412f445fbb8acbe37/regex-2026.7.10-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:3e23458d8903e33e7d27196d7a311523dc4e2f4137a5f34e4dbd30c8d37ff33e", size = 816379, upload-time = "2026-07-10T19:48:21.616Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/9f/1859403654e3e030b288f06d49233c6a4f889d62b84c4ef3f3a28653173d/regex-2026.7.10-cp313-cp313t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:cae27622c094558e519abf3242cf4272db961d12c5c9a9ffb7a1b44b2627d5c6", size = 785563, upload-time = "2026-07-10T19:48:23.643Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/d8/35d30d6bdf1ef6a5430e8982607b3a6db4df1ddedbe001e43435585d88ba/regex-2026.7.10-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:ee877b6d78f9dff1da94fef51ae8cf9cce0967e043fdcc864c40b85cf293c192", size = 801415, upload-time = "2026-07-10T19:48:25.499Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/22/630f31f5ea4826167b2b064d9cac2093a5b3222af380aa432cfe1a5dabcd/regex-2026.7.10-cp313-cp313t-musllinux_1_2_ppc64le.whl", hash = "sha256:2c66a8a1969cfd506d1e203c0005fd0fc3fe6efc83c945606566b6f9611d4851", size = 866560, upload-time = "2026-07-10T19:48:27.789Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/14/f5914a6d9c5bc63b9bed8c9a1169fb0be35dbe05cdc460e17d953031a366/regex-2026.7.10-cp313-cp313t-musllinux_1_2_riscv64.whl", hash = "sha256:2bc350e1c5fa250f30ab0c3e38e5cfdffcd82cb8af224df69955cab4e3003812", size = 772877, upload-time = "2026-07-10T19:48:29.563Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/0f/7c13999eef3e4186f7c79d4950fa56f041bf4de107682fb82c80db605ff9/regex-2026.7.10-cp313-cp313t-musllinux_1_2_s390x.whl", hash = "sha256:53f54993b462f3f91fea0f2076b46deb6619a5f45d70dbd1f543f789d8b900ef", size = 856648, upload-time = "2026-07-10T19:48:31.282Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/71/a48e43909b6450fb48fa94e783bef2d9a37179258bc32ef2283955df7be7/regex-2026.7.10-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:cfcec18f7da682c4e2d82112829ce906569cb8d69fa6c26f3a50dfbed5ceb682", size = 803520, upload-time = "2026-07-10T19:48:33.275Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/b8/f037d1bf2c133cb24ceb6e7d81d08417080390eddab6ddfd701aa7091874/regex-2026.7.10-cp313-cp313t-win32.whl", hash = "sha256:a2d6d30be35ddd70ce0f8ee259a4c25f24d6d689a45a5ac440f03e6bcc5a21d1", size = 269168, upload-time = "2026-07-10T19:48:35.353Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/9c/eaac34f8452a838956e7e89852ad049678cdc1af5d14f72d3b3b658b1ea5/regex-2026.7.10-cp313-cp313t-win_amd64.whl", hash = "sha256:c57b6ad3f7a1bdd101b2966f29dc161adf49727b1e8d3e1e89db2eda8a75c344", size = 280004, upload-time = "2026-07-10T19:48:37.106Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/a9/e22e997587bc1d588b0b2cd0572027d39dd3a006216e40bbf0361688c51c/regex-2026.7.10-cp313-cp313t-win_arm64.whl", hash = "sha256:3d8ef9df02c8083c7b4b855e3cb87c8e0ebbcfea088d98c7a886aaefdf88d837", size = 279308, upload-time = "2026-07-10T19:48:38.907Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/4a/a7fa3ada9bd2d2ce20d56dfceec6b2a51afeed9bf3d8286355ceec5f0628/regex-2026.7.10-cp314-cp314-macosx_10_13_universal2.whl", hash = "sha256:39f81d1fdf594446495f2f4edd8e62d8eda0f7a802c77ac596dc8448ad4cc5ca", size = 497087, upload-time = "2026-07-10T19:48:40.543Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/7e/ca0b1a87192e5828dbc16f16ae6caca9b67f25bf729a3348468a5ff52755/regex-2026.7.10-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:441edc66a54063f8269d1494fc8474d06605e71e8a918f4bcfd079ebda4ce042", size = 297307, upload-time = "2026-07-10T19:48:42.213Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/6c/fb40bb34275d3cd4d7a376d5fb2ea1f0f4a96fd884fa83c0c4ae869001bf/regex-2026.7.10-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:cfeb11990f59e59a0df26c648f0adfcbf27be77241250636f5769eb08db662be", size = 292163, upload-time = "2026-07-10T19:48:43.929Z" },
+    { url = "https://files.pythonhosted.org/packages/18/0b/34cbea16c8fea9a18475a7e8f5837c70af451e738bfeb4eb5b029b7dc07a/regex-2026.7.10-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:460176b2db044a292baaee6891106566739657877af89a251cded228689015a6", size = 797064, upload-time = "2026-07-10T19:48:45.623Z" },
+    { url = "https://files.pythonhosted.org/packages/87/77/f6805d97f15f5a710bdfd56a768f3468c978239daf9e1b15efd8935e1967/regex-2026.7.10-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:9dc55698737aca028848bde418d6c51d74f2a5fd44872d3c8b56b626729adb89", size = 866155, upload-time = "2026-07-10T19:48:47.589Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/e3/a2a905807bba3bcd90d6ebbb67d27af2adf7d41708175cbc6b956a0c75f1/regex-2026.7.10-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:d3e10779f60c000213a5b53f518824bd07b3dc119333b26d70c6be1c27b5c794", size = 911596, upload-time = "2026-07-10T19:48:49.473Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/ca/a3126888b2c6f33c7e29144fedf85f6d5a52a400024fa045ad8fc0550ef1/regex-2026.7.10-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:38a5926601aaccf379512746b86eb0ac1d29121f6c776dac6ac5b31077432f2c", size = 800713, upload-time = "2026-07-10T19:48:51.452Z" },
+    { url = "https://files.pythonhosted.org/packages/66/19/9d252fd969f726c8b56b4bacf910811cc70495a110907b3a7ccb96cd9cad/regex-2026.7.10-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:a72ecf5bfd3fc8d57927f7e3ded2487e144472f39010c3acaec3f6f3ff53f361", size = 777286, upload-time = "2026-07-10T19:48:53.443Z" },
+    { url = "https://files.pythonhosted.org/packages/40/7a/5f1bf433fa446ecb3aab87bb402603dc9e171ef8052c1bb8690bb4e255a3/regex-2026.7.10-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:d50714405845c1010c871098558cfe5718fe39d2a2fab5f95c8863caeb7a82b3", size = 785826, upload-time = "2026-07-10T19:48:55.381Z" },
+    { url = "https://files.pythonhosted.org/packages/99/ca/69f3a7281d86f1b592338007f3e535cc219d771448e2b61c0b56e4f9d05b/regex-2026.7.10-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:ec1c44cf9bd22079aac37a07cb49a29ced9050ab5bddf24e50aba298f1e34d90", size = 860957, upload-time = "2026-07-10T19:48:57.962Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/11/487ff55c8d515ec9dd60d7ba3c129eeaa9e527358ed9e8a054a9e9430f81/regex-2026.7.10-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:9e9aaef25a40d1f1e1bbb1d0eb0190c4a64a7a1750f7eb67b8399bed6f4fd2a6", size = 765959, upload-time = "2026-07-10T19:49:00.27Z" },
+    { url = "https://files.pythonhosted.org/packages/73/e1/fa034e6fa8896a09bd0d5e19c81fdc024411ab37980950a0401dccee8f6d/regex-2026.7.10-cp314-cp314-musllinux_1_2_s390x.whl", hash = "sha256:e54e088dc64dd2766014e7cfe5f8bc45399400fd486816e494f93e3f0f55da06", size = 851447, upload-time = "2026-07-10T19:49:02.128Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/a5/b9427ed53b0e14c540dc436d56aaf57a19fb9183c6e7abd66f4b4368fbad/regex-2026.7.10-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:834271b1ff2cfa1f67fcd65a48bf11d11e9ab837e21bf79ce554efb648599ae8", size = 789418, upload-time = "2026-07-10T19:49:03.949Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/52/aab92420c8aa845c7bcbe68dc65023d4a9e9ea785abf0beb2198f0de5ba1/regex-2026.7.10-cp314-cp314-win32.whl", hash = "sha256:f988a1cec68058f71a38471813fba9e87dffe855582682e8a10e40ece12567a2", size = 272538, upload-time = "2026-07-10T19:49:05.833Z" },
+    { url = "https://files.pythonhosted.org/packages/99/16/5c7050e0ef7dd8889441924ff0a2c33b7f0587c0ccb0953fe7ca997d673b/regex-2026.7.10-cp314-cp314-win_amd64.whl", hash = "sha256:2129e4a5e86f26926982d883dff815056f2e98220fdf630e59f961b578a26c43", size = 280796, upload-time = "2026-07-10T19:49:07.593Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/1a/4f6099d2ba271502fdb97e697bae2ed0213c0d87f2273fe7d21e2e401d12/regex-2026.7.10-cp314-cp314-win_arm64.whl", hash = "sha256:9cd5b6805396157b4cf993a6940cbb8663161f29b4df2458c1c9991f099299c5", size = 281017, upload-time = "2026-07-10T19:49:09.767Z" },
+    { url = "https://files.pythonhosted.org/packages/19/02/4061fc71f64703e0df61e782c2894c3fbc089d277767eff6e16099581c73/regex-2026.7.10-cp314-cp314t-macosx_10_13_universal2.whl", hash = "sha256:103e8f3acc3dcede88c0331c8612766bdcfc47c9250c5477f0e10e0550b9da49", size = 501467, upload-time = "2026-07-10T19:49:11.952Z" },
+    { url = "https://files.pythonhosted.org/packages/73/a5/8d42b2f3fd672908a05582effd0f88438bf9bb4e8e02d69a62c723e23601/regex-2026.7.10-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:538ddb143f5ca085e372def17ef3ed9d74b50ad7fc431bd85dc50a9af1a7076f", size = 299700, upload-time = "2026-07-10T19:49:14.067Z" },
+    { url = "https://files.pythonhosted.org/packages/65/70/36fa4b46f73d268c0dbe77c40e62da2cd4833ee206d3b2e438c2034e1f36/regex-2026.7.10-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:6e3448e86b05ce87d4eb50f9c680860830f3b32493660b39f43957d6263e2eba", size = 294590, upload-time = "2026-07-10T19:49:15.883Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/a7/b6db1823f3a233c2a46f854fdc986f4fd424a84ed557b7751f2998efb266/regex-2026.7.10-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5eab9d3f981c423afd1a61db055cfe83553c3f6455949e334db04722469dd0a2", size = 811925, upload-time = "2026-07-10T19:49:17.97Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/7d/f8bee4c210c42c7e8b952bb9fb7099dd7fb2f4bd0f33d0d65a8ab08aafc0/regex-2026.7.10-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:177f930af3ad72e1045f8877540e0c43a38f7d328cf05f31963d0bd5f7ecf067", size = 871257, upload-time = "2026-07-10T19:49:19.943Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/78/22adf72e614ba0216b996e9aaef5712c23699e360ea127bb3d5ee1a7666f/regex-2026.7.10-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:dd3b6d97beb39afb412f2c79522b9e099463c31f4c49ab8347c5a2ca3531c478", size = 917551, upload-time = "2026-07-10T19:49:22.069Z" },
+    { url = "https://files.pythonhosted.org/packages/03/f7/ebc15a39e81e6b58da5f913b91fc293a25c6700d353c14d5cd25fc85712a/regex-2026.7.10-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8679f0652a183d93da646fcec8da8228db0be40d1595da37e6d74c2dc8c4713c", size = 816436, upload-time = "2026-07-10T19:49:24.131Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/33/20bc2bdd57f7e0fcc51be37e4c4d1bca7f0b4af8dc0a148c23220e689da8/regex-2026.7.10-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:494b19a5805438aeb582de99f9d97603d8fd48e6f4cc74d0088bb292b4da3b70", size = 785935, upload-time = "2026-07-10T19:49:26.265Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/51/87ff99c849b56309c40214a72b54b0eef320d0516a8a516970cc8be1b725/regex-2026.7.10-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:0911e34151a5429d0325dae538ba9851ec0b62426bdfd613060cda8f1c36ec7f", size = 801494, upload-time = "2026-07-10T19:49:28.493Z" },
+    { url = "https://files.pythonhosted.org/packages/16/11/fde67d49083fef489b7e0f841e2e5736516795b166c9867f05956c1e494b/regex-2026.7.10-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:b862572b7a5f5ed47d2ba5921e63bf8d9e3b682f859d8f11e0e5ca46f7e82173", size = 866549, upload-time = "2026-07-10T19:49:30.592Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/b5/31a156c36acf10181d88f55a66c688d5454a344e53ccc03d49f4a48a2297/regex-2026.7.10-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:3f361215e000d68a4aff375106637b83c80be36091d83ee5107ad3b32bd73f48", size = 773089, upload-time = "2026-07-10T19:49:32.661Z" },
+    { url = "https://files.pythonhosted.org/packages/27/bb/734e978c904726664df47ae36ce5eca5065de5141185ae46efec063476a2/regex-2026.7.10-cp314-cp314t-musllinux_1_2_s390x.whl", hash = "sha256:4533af6099543db32ef26abc2b2f824781d4eebb309ab9296150fd1a0c7eb07d", size = 856710, upload-time = "2026-07-10T19:49:35.289Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/e5/dc35cea074dbdcb9776c4b0542a3bc326ff08454af0768ef35f3fc66e7fa/regex-2026.7.10-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:668ab85105361d0200e3545bec198a1acfc6b0aeb5fff8897647a826e5a171be", size = 803621, upload-time = "2026-07-10T19:49:37.704Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/b2/124564af46bc0b592785610b3985315610af0a07f4cf21fa36e06c2398dd/regex-2026.7.10-cp314-cp314t-win32.whl", hash = "sha256:dd7715817a187edd7e2a2390908757f7ba42148e59cad755fb8ee1160c628eca", size = 274558, upload-time = "2026-07-10T19:49:39.926Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/9c/cd813ce9f3404c0443915175c1e339c5afd8fcda04310102eaf233015eef/regex-2026.7.10-cp314-cp314t-win_amd64.whl", hash = "sha256:78712d4954234df5ca24fdadb65a2ab034213f0cdfde376c272f9fc5e09866bb", size = 283687, upload-time = "2026-07-10T19:49:41.872Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/d3/3dae6a6ce46144940e64425e32b8573a393a009aeaf75fa6752a35399056/regex-2026.7.10-cp314-cp314t-win_arm64.whl", hash = "sha256:749b92640e1970e881fdf22a411d74bf9d049b154f4ef7232eeb9a90dd8be7f3", size = 283377, upload-time = "2026-07-10T19:49:43.985Z" },
+]
+
+[[package]]
 name = "requests"
 version = "2.34.2"
 source = { registry = "https://pypi.org/simple" }
@@ -4175,6 +4351,30 @@ wheels = [
 ]
 
 [[package]]
+name = "safetensors"
+version = "0.8.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/45/06/f955dbbb1859e3bd23c8ac6141af5106e7ad5fedec4a3a6e3d60f94b7001/safetensors-0.8.0.tar.gz", hash = "sha256:fabaf3e0f18a6618d9b36560682562157f77c2b71fcffc7b432be2baed9d753d", size = 325846, upload-time = "2026-06-09T07:52:25.563Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/39/a0/f718cda65b05407d228f97602cf60dca269c979867aa5beb25410de26cd3/safetensors-0.8.0-cp310-abi3-macosx_10_12_x86_64.whl", hash = "sha256:c554f85858e05226d3c2828e32395e677434685d6d94594a41643361c5e837f0", size = 473568, upload-time = "2026-06-09T07:52:18.829Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/b1/fa7c600e7dceae12e9606c7578cbc9ff1e1ed55844883ee5c92205e86226/safetensors-0.8.0-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:c80201d22cbf405b80647a60ada77bba06c8fba2da2743ba1e89cdcc39a81f25", size = 484562, upload-time = "2026-06-09T07:52:17.518Z" },
+    { url = "https://files.pythonhosted.org/packages/09/7d/65a7de0af421317bb36a067241e4235fff194eed60b961ed6d3f59a3fc60/safetensors-0.8.0-cp310-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7a46e5ff292c356d6991e60942ba7f79817682d3a2cef0702136448cb9c4d235", size = 502844, upload-time = "2026-06-09T07:52:07.624Z" },
+    { url = "https://files.pythonhosted.org/packages/91/4f/3175c9d75634e0e0dda0082794193521035edd7c70a6f212bf33ca06ddf4/safetensors-0.8.0-cp310-abi3-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:4124502b78f03534117c848f87a39b8f31e577b15eff423bf8bfb95f2a8c30d0", size = 511823, upload-time = "2026-06-09T07:52:09.565Z" },
+    { url = "https://files.pythonhosted.org/packages/20/87/846c289e7aa2299eff406335717cf43ce8777194ece8aad75772e0411615/safetensors-0.8.0-cp310-abi3-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:7bc0a787ba8a35be368ee3574edfa2b1ad389eebd0a72e482ae275490e3f6c98", size = 633461, upload-time = "2026-06-09T07:52:11.128Z" },
+    { url = "https://files.pythonhosted.org/packages/76/22/8d64d9df2c45d5ded401df889d0ad90882804ca172d79ec4f0df8f727fe0/safetensors-0.8.0-cp310-abi3-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:040070828e36dc8e122178bbbd5830ff9e97920affb84cbe0f46442497bed358", size = 545148, upload-time = "2026-06-09T07:52:13.603Z" },
+    { url = "https://files.pythonhosted.org/packages/28/50/f203ff3a3ddfe19308efc83c5a3a29ed02bf786732ec35e68bf9162f3365/safetensors-0.8.0-cp310-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:fd6f3f93c9a0a7cc2788ee63fb763353d4bd2e89b0751bc78fcf7dda00bea774", size = 516040, upload-time = "2026-06-09T07:52:16.29Z" },
+    { url = "https://files.pythonhosted.org/packages/46/fb/cdaed17ceb2948784fd9c36b6fd3e951b608547cea81a48e8ee6f8cfdfcb/safetensors-0.8.0-cp310-abi3-manylinux_2_31_riscv64.whl", hash = "sha256:fcdd41ec4628fee5799f807c73c353629130fbd942aa23d83c623dd6c9d52d78", size = 513832, upload-time = "2026-06-09T07:52:12.37Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/49/1e15de264dcc3b77943d2d0c56a95809956883b1c2d6d585c792523f180b/safetensors-0.8.0-cp310-abi3-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:8e9f537aa183a38ace122d27303dcd986b26bd2a7591f9181d7f0c396f4677ca", size = 559930, upload-time = "2026-06-09T07:52:14.743Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/43/bf38443278eab4b1be1fce2931e2b012ad9cb7df52ada751d0aab8f7659a/safetensors-0.8.0-cp310-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:87eec7ffed2b809f05a398a8becb7d013f19f7837cd15d9748580d6cf30dbaf4", size = 678670, upload-time = "2026-06-09T07:52:20.032Z" },
+    { url = "https://files.pythonhosted.org/packages/72/e3/68cd3fa5b48488e84add63e04cb12f3bc28ae4638c06d4508c6e88823d0e/safetensors-0.8.0-cp310-abi3-musllinux_1_2_armv7l.whl", hash = "sha256:4a95ae2b05d7726d751da4ebf626a2ca782b706e101bd894c95bc2450b1cffcc", size = 786679, upload-time = "2026-06-09T07:52:21.322Z" },
+    { url = "https://files.pythonhosted.org/packages/29/4b/1c19c509d56e01f4fbb3d0a2e597450f6cc04d1d56cf52defb0a62dfd715/safetensors-0.8.0-cp310-abi3-musllinux_1_2_i686.whl", hash = "sha256:3ae091f16662658bdc019a4ff6cb4c085bb7d725eb5978b183ffd265863b6d2d", size = 765683, upload-time = "2026-06-09T07:52:22.594Z" },
+    { url = "https://files.pythonhosted.org/packages/27/43/41c1621732edd934d868a00d1b891584c892a7b62a9aab82ea5a0a5623ee/safetensors-0.8.0-cp310-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:8e080062fcde23be189565e1c3305d16751a218ecf9412c8601e64204eb6f846", size = 722361, upload-time = "2026-06-09T07:52:23.924Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/3f/73ccf82579412b4a71c4ca673f10b5f1f888d7cf5af7fe24f27d30307be4/safetensors-0.8.0-cp310-abi3-win32.whl", hash = "sha256:2ddf52eac562eda224f99acfa7889d02968c1fd59a5b011ae7d8137c37e9c02d", size = 342401, upload-time = "2026-06-09T07:52:28.895Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/6d/3fba214c1e5e0f69991677ec3bc17023f0421776975e1de0c682dca475e2/safetensors-0.8.0-cp310-abi3-win_amd64.whl", hash = "sha256:096ec1a98435df7beb08853bb5aa9081a84f23d0adc67ed1a0a10550f608373f", size = 355540, upload-time = "2026-06-09T07:52:27.832Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/fc/7eedc3510d97878876e32774eebbeb61c43f148a96e915c84229a3e967aa/safetensors-0.8.0-cp310-abi3-win_arm64.whl", hash = "sha256:f7838e5135a406ad3e02efdcb8cf2e5397d368b0154537c4fec682dbc544d452", size = 340500, upload-time = "2026-06-09T07:52:26.745Z" },
+]
+
+[[package]]
 name = "scikit-learn"
 version = "1.9.0"
 source = { registry = "https://pypi.org/simple" }
@@ -4297,6 +4497,49 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/c5/f0/184b4b5f8d00f2a92cf96eec8967a3d550b52cf94362dad1100df9e48d57/send2trash-2.1.0.tar.gz", hash = "sha256:1c72b39f09457db3c05ce1d19158c2cbef4c32b8bedd02c155e49282b7ea7459", size = 17255, upload-time = "2026-01-14T06:27:36.056Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/1c/78/504fdd027da3b84ff1aecd9f6957e65f35134534ccc6da8628eb71e76d3f/send2trash-2.1.0-py3-none-any.whl", hash = "sha256:0da2f112e6d6bb22de6aa6daa7e144831a4febf2a87261451c4ad849fe9a873c", size = 17610, upload-time = "2026-01-14T06:27:35.218Z" },
+]
+
+[[package]]
+name = "sentencepiece"
+version = "0.2.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/cc/33/ea3cb3839607eb175da835244a798f797f478c5ddf0e8ecdf57ea85a4c70/sentencepiece-0.2.2.tar.gz", hash = "sha256:3d2b5e824b5622038dc7b490897efe05ebbbb9e7350fc142f3ecc8789ef9bdf6", size = 8218435, upload-time = "2026-07-12T08:39:34.701Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b8/13/7a562289c8d5b49ebdf3f9c1e8ab67cf14a8743b1d90c8f406bfdec36b72/sentencepiece-0.2.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:1edb10e520e4bddf74d85b0f5ae74cc2d60c2b448885080bfb618bc2b3a49f6b", size = 2188384, upload-time = "2026-07-12T08:38:28.486Z" },
+    { url = "https://files.pythonhosted.org/packages/85/d1/912f14fd5eae168aba726ffb6a9a2dc1c71fe7676c53da6f5c442b886d4a/sentencepiece-0.2.2-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:f7c06c751c19d923435a54bff4f7e66e728fad160e8da28254f133abc9725820", size = 1441553, upload-time = "2026-07-12T08:38:30.552Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/44/caa9cab5f261a019e2808bc5046152775dc57352ba9cbae7525e9e7a1ed4/sentencepiece-0.2.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:38111ed1f79268f399c505028023d5eaaf0ab4e5eafceb709468b0d3323e7838", size = 1347176, upload-time = "2026-07-12T08:38:32.211Z" },
+    { url = "https://files.pythonhosted.org/packages/19/90/cd798935668cff71d309d8ff10385844ecf216b1fe454f1993ed8bf2cb91/sentencepiece-0.2.2-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:cbce24284f51f71d10a42b7b9c964dcb9048b28f1c8e5db40bcbcb6f428cba6a", size = 1325200, upload-time = "2026-07-12T08:38:33.689Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/2d/37e3da037318a70066ded0d51bc2a7f35491ae6338dd993d5eb1503fc3b5/sentencepiece-0.2.2-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c8a168b040bc61681293f79a949b5d911c8e25086f4260285b8d97ab5f1195da", size = 1397736, upload-time = "2026-07-12T08:38:35.771Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/11/753fca2e6b109be3ab7867abf357dfe48677fe726ae5a5363d0b54ca9450/sentencepiece-0.2.2-cp312-cp312-win_amd64.whl", hash = "sha256:7c6e7bf684dc12145bfa685d3060beaea55139134ba848289bee514ed42e7383", size = 1248030, upload-time = "2026-07-12T08:38:37.604Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/0a/70efbe861ca182d7d4b6e1a20f58e043400848fa9f2915229f082e221648/sentencepiece-0.2.2-cp312-cp312-win_arm64.whl", hash = "sha256:76ff5814db72e7462dece042d7593cdf102b8ec82c2b1cc201a2add34ee3050d", size = 1187325, upload-time = "2026-07-12T08:38:39.348Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/a3/b3b05095c174d6e80d37d5ddc2f57c2c56237333e7bbd6079cf3243c2a8a/sentencepiece-0.2.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:77c3ce990b23441e5ecfa5bce181fd6f408b564aeb6d7e1d1e7de9c5612501c8", size = 2188346, upload-time = "2026-07-12T08:38:41.089Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/f3/72ebc4acb10a06bcf7503fbc6091c8f5db68300f6aac4356c09e6c76e0e1/sentencepiece-0.2.2-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:fd523c4992041faa5c2b3cde62253d11a96c30d73a34afe48a486e8e2254cd1c", size = 1441434, upload-time = "2026-07-12T08:38:42.56Z" },
+    { url = "https://files.pythonhosted.org/packages/34/db/f9ea1a6844b4fa5dfe2312095cd866a1f724cd0905054ab9d5991778ba50/sentencepiece-0.2.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:201a8e0f55501a76e08dbf2c54bc45f4642b379271e89c667d517bfbc2191f2a", size = 1347267, upload-time = "2026-07-12T08:38:44.389Z" },
+    { url = "https://files.pythonhosted.org/packages/32/4f/31c1073314ad94466bca37d29581761d70110237ee3d46b0efece59a8c1e/sentencepiece-0.2.2-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8eed98514bffe5ecac37f493f91869c351fbb05629328bfdbc08502c6c094dc0", size = 1324980, upload-time = "2026-07-12T08:38:46.304Z" },
+    { url = "https://files.pythonhosted.org/packages/59/b4/a0356fa04d6a14337a6e0e443556785a0422c53ec58baae6b9568120eb0f/sentencepiece-0.2.2-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:64b656f025355cf8c51abe9fbe3848540756c6d7ca5e6791b1afa664bc24c7cb", size = 1397593, upload-time = "2026-07-12T08:38:48.302Z" },
+    { url = "https://files.pythonhosted.org/packages/09/fa/d2d6369257fd2f0de616b1c7110b73fab409ef61b14f1b9e0010ed325914/sentencepiece-0.2.2-cp313-cp313-win_amd64.whl", hash = "sha256:74f0ee601047c0c12a783088b51be4e6214a62ecd9e02278c477433cd16e0ed9", size = 1247987, upload-time = "2026-07-12T08:38:50.15Z" },
+    { url = "https://files.pythonhosted.org/packages/17/ee/2bb594da6fd95e32f29057f1aa7fa996701b8980090923c2d8711fdc0a24/sentencepiece-0.2.2-cp313-cp313-win_arm64.whl", hash = "sha256:b23fe17779834d3c27aaf2edac9486d04cca1a7deb8f5facda35150ac6263a91", size = 1187250, upload-time = "2026-07-12T08:38:52.246Z" },
+    { url = "https://files.pythonhosted.org/packages/58/9c/dfc82846460e7a712310f5613f23d8b553cabb4e2e648663c11d8382af56/sentencepiece-0.2.2-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:72b7825b331b1b7e7c45be2e674b3e3c65af608fa376bad2d851b20aaf0cdc78", size = 2223080, upload-time = "2026-07-12T08:38:54.391Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/4e/3ff12cebe6d31662d9ceeabfb282de20bd0d6098fa282b4a3b8305abc7e8/sentencepiece-0.2.2-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:d795c4ac689a57f9d4ba2288126ec7901d389ad5827d2f8b8533c883974fe563", size = 1458511, upload-time = "2026-07-12T08:38:56.811Z" },
+    { url = "https://files.pythonhosted.org/packages/59/5a/16d51d05360be4cee3ebfe4837c184054c4eed16cabaeb3b039524e9a000/sentencepiece-0.2.2-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:3ab3f1ae98970b5590e2209341522718900ba19bcc2c207ffaa6bd417ad960c5", size = 1361138, upload-time = "2026-07-12T08:38:58.808Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/af/c30ee2a9f99d51db9844acaa8fa0b611a97c2fa7116646fa43db3300b187/sentencepiece-0.2.2-cp313-cp313t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3ec27c152a1f1b24bc9168b55a5880f3c16e2334e697da6f55a1046a22405a3d", size = 1328625, upload-time = "2026-07-12T08:39:00.849Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/1a/4c6b39d03f5ba8439509adbd5a23c9538088a3cb679e7a47b911e8442bc6/sentencepiece-0.2.2-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:59d6588712101ccfcae9b03692be3aaae1514c2078666d7b05f15ba3a702e41b", size = 1398595, upload-time = "2026-07-12T08:39:02.86Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/bc/9eedddcec1fd57bc70200fa3ebf792d18fa63527a5369581cd416c81f97f/sentencepiece-0.2.2-cp313-cp313t-win_amd64.whl", hash = "sha256:89625fb43765cccaa1443b9adb61f283e5fe4cb1536728205d06bada730caa53", size = 1259346, upload-time = "2026-07-12T08:39:04.559Z" },
+    { url = "https://files.pythonhosted.org/packages/41/15/7e74c8533848866ff560b29f7d8719921b76c4ec7149592d6d28e0deee75/sentencepiece-0.2.2-cp313-cp313t-win_arm64.whl", hash = "sha256:4f0603267cd15b92b68c2c0e852a441507614b70dc7773659baa6b8c214a91fd", size = 1196596, upload-time = "2026-07-12T08:39:06.454Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/7e/f5df63edb6bcb46c1343cfa5d9192d73a4eb61af2e800d9402efff387523/sentencepiece-0.2.2-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:c62bd361cec1f5b556eb8210264ecfff37486cd990c3386cc00310f26c54090a", size = 2190240, upload-time = "2026-07-12T08:39:08.178Z" },
+    { url = "https://files.pythonhosted.org/packages/52/0a/095d183b453b2a2e20b016829029c58eca90adc1c9911113e5d26fff45ed/sentencepiece-0.2.2-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:46ba07b543add034de0ff47ac5f907e9a06682f91d85121a972764628933be6b", size = 1442220, upload-time = "2026-07-12T08:39:09.91Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/18/823954c9c90e74eba09fb96752dc37a5555df00d69866cb9406d1725dc7e/sentencepiece-0.2.2-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:79bac5a251f23a7341e28fda9ce0d5319edf45328239ce037c0682936f137906", size = 1348056, upload-time = "2026-07-12T08:39:11.744Z" },
+    { url = "https://files.pythonhosted.org/packages/10/ca/1b6c251321901cbf8a2d2e48b8b70eb82a449011b766af52a228d0a90b6b/sentencepiece-0.2.2-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1402d8ee36f0d851cea8eee4dbb85fea14643b7503cf4d00d102eec0fe3ca719", size = 1325463, upload-time = "2026-07-12T08:39:13.413Z" },
+    { url = "https://files.pythonhosted.org/packages/24/b3/718847349da7b25c8220ed86d85b89080af94740b2d87a59198104ae5c51/sentencepiece-0.2.2-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8d44b20234905ff022b7d535f79d1f823ad7670c9851cc4f03cdc34787cdb3ab", size = 1398138, upload-time = "2026-07-12T08:39:15.564Z" },
+    { url = "https://files.pythonhosted.org/packages/33/fe/4906f12c458274edd96387e4baaad7c6f064a2b7c11a1cc2401c8a7bd483/sentencepiece-0.2.2-cp314-cp314-win_amd64.whl", hash = "sha256:63250cfab8b80a1ef82a614eb2b3cadfec2c405f870cedc139d08e2f063eb708", size = 1356144, upload-time = "2026-07-12T08:39:17.313Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/eb/22f89b6542aba400b0007cf0b1697cc3f99be8fb682fdb4c05eec450e33f/sentencepiece-0.2.2-cp314-cp314-win_arm64.whl", hash = "sha256:65d84ec36888de4a848eee5f910e67fbc79b064685ef1e10a502e14520ead9c9", size = 1294351, upload-time = "2026-07-12T08:39:18.967Z" },
+    { url = "https://files.pythonhosted.org/packages/84/c4/7afe8c2315b76e46818851a057e50a378a0382aa00b970a1fa444181b6f6/sentencepiece-0.2.2-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:d254c98ca6387655400b3959c33c83efd807f5edeb608e3aca45800ceaa77151", size = 2223281, upload-time = "2026-07-12T08:39:20.978Z" },
+    { url = "https://files.pythonhosted.org/packages/98/42/fb678e472c554ef086be6375d20060ca610a2c4218854d4c091001fc6f91/sentencepiece-0.2.2-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:3fd9ce2ab4460c713cfdeb4aca693ca6732a11538e05fb332d5af42e3d7fde25", size = 1458779, upload-time = "2026-07-12T08:39:22.812Z" },
+    { url = "https://files.pythonhosted.org/packages/78/52/ffe402b13bce1889228a98dc6cd86ae8afac1112362236be3468be784441/sentencepiece-0.2.2-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:7fc14c1585139fa6b68775e616a6b90cf622ebf219f9558c0aeaf5d253ee6c9b", size = 1361736, upload-time = "2026-07-12T08:39:24.602Z" },
+    { url = "https://files.pythonhosted.org/packages/78/4a/2288f60e7283583ec0a0f16e72f9c8e68557d7e7a4b585d2cda4f9f47e64/sentencepiece-0.2.2-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:df88b0c34f2fa909d322f7b06b1398e1e81af4b2f42a7b8e3556f928b25d1811", size = 1328155, upload-time = "2026-07-12T08:39:26.422Z" },
+    { url = "https://files.pythonhosted.org/packages/26/31/5dd6882ebe899f741a5cfe40ff56c6efc06bc26ee287abdb723b671f409c/sentencepiece-0.2.2-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:3f5851441ab1ef8634963a5100b733a8bbeefe623e0c5c005b1f1f3880e574cf", size = 1398307, upload-time = "2026-07-12T08:39:28.637Z" },
+    { url = "https://files.pythonhosted.org/packages/da/05/7d7780fa63f4b8c1821953b916e25f89ae8f14d4da6ba91e10f6d06dc2b4/sentencepiece-0.2.2-cp314-cp314t-win_amd64.whl", hash = "sha256:046b15ea22d8042e2e173561d464ec3b64a9c2081324df70ebce7bf7ebb3e497", size = 1367133, upload-time = "2026-07-12T08:39:30.546Z" },
+    { url = "https://files.pythonhosted.org/packages/49/a1/70007fef3f818c688de4a730f98024a671599ab67f20270f8efb03d69dcc/sentencepiece-0.2.2-cp314-cp314t-win_arm64.whl", hash = "sha256:fa9f5ef0e2a82233dd0b8b32ea3f5710e0c44afbc07ed3620219f32601e56090", size = 1302760, upload-time = "2026-07-12T08:39:32.457Z" },
 ]
 
 [[package]]
@@ -4506,6 +4749,32 @@ wheels = [
 ]
 
 [[package]]
+name = "tokenizers"
+version = "0.22.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "huggingface-hub" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/73/6f/f80cfef4a312e1fb34baf7d85c72d4411afde10978d4657f8cdd811d3ccc/tokenizers-0.22.2.tar.gz", hash = "sha256:473b83b915e547aa366d1eee11806deaf419e17be16310ac0a14077f1e28f917", size = 372115, upload-time = "2026-01-05T10:45:15.988Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/92/97/5dbfabf04c7e348e655e907ed27913e03db0923abb5dfdd120d7b25630e1/tokenizers-0.22.2-cp39-abi3-macosx_10_12_x86_64.whl", hash = "sha256:544dd704ae7238755d790de45ba8da072e9af3eea688f698b137915ae959281c", size = 3100275, upload-time = "2026-01-05T10:41:02.158Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/47/174dca0502ef88b28f1c9e06b73ce33500eedfac7a7692108aec220464e7/tokenizers-0.22.2-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:1e418a55456beedca4621dbab65a318981467a2b188e982a23e117f115ce5001", size = 2981472, upload-time = "2026-01-05T10:41:00.276Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/84/7990e799f1309a8b87af6b948f31edaa12a3ed22d11b352eaf4f4b2e5753/tokenizers-0.22.2-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2249487018adec45d6e3554c71d46eb39fa8ea67156c640f7513eb26f318cec7", size = 3290736, upload-time = "2026-01-05T10:40:32.165Z" },
+    { url = "https://files.pythonhosted.org/packages/78/59/09d0d9ba94dcd5f4f1368d4858d24546b4bdc0231c2354aa31d6199f0399/tokenizers-0.22.2-cp39-abi3-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:25b85325d0815e86e0bac263506dd114578953b7b53d7de09a6485e4a160a7dd", size = 3168835, upload-time = "2026-01-05T10:40:38.847Z" },
+    { url = "https://files.pythonhosted.org/packages/47/50/b3ebb4243e7160bda8d34b731e54dd8ab8b133e50775872e7a434e524c28/tokenizers-0.22.2-cp39-abi3-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:bfb88f22a209ff7b40a576d5324bf8286b519d7358663db21d6246fb17eea2d5", size = 3521673, upload-time = "2026-01-05T10:40:56.614Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/fa/89f4cb9e08df770b57adb96f8cbb7e22695a4cb6c2bd5f0c4f0ebcf33b66/tokenizers-0.22.2-cp39-abi3-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:1c774b1276f71e1ef716e5486f21e76333464f47bece56bbd554485982a9e03e", size = 3724818, upload-time = "2026-01-05T10:40:44.507Z" },
+    { url = "https://files.pythonhosted.org/packages/64/04/ca2363f0bfbe3b3d36e95bf67e56a4c88c8e3362b658e616d1ac185d47f2/tokenizers-0.22.2-cp39-abi3-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:df6c4265b289083bf710dff49bc51ef252f9d5be33a45ee2bed151114a56207b", size = 3379195, upload-time = "2026-01-05T10:40:51.139Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/76/932be4b50ef6ccedf9d3c6639b056a967a86258c6d9200643f01269211ca/tokenizers-0.22.2-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:369cc9fc8cc10cb24143873a0d95438bb8ee257bb80c71989e3ee290e8d72c67", size = 3274982, upload-time = "2026-01-05T10:40:58.331Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/28/5f9f5a4cc211b69e89420980e483831bcc29dade307955cc9dc858a40f01/tokenizers-0.22.2-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:29c30b83d8dcd061078b05ae0cb94d3c710555fbb44861139f9f83dcca3dc3e4", size = 9478245, upload-time = "2026-01-05T10:41:04.053Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/fb/66e2da4704d6aadebf8cb39f1d6d1957df667ab24cff2326b77cda0dcb85/tokenizers-0.22.2-cp39-abi3-musllinux_1_2_armv7l.whl", hash = "sha256:37ae80a28c1d3265bb1f22464c856bd23c02a05bb211e56d0c5301a435be6c1a", size = 9560069, upload-time = "2026-01-05T10:45:10.673Z" },
+    { url = "https://files.pythonhosted.org/packages/16/04/fed398b05caa87ce9b1a1bb5166645e38196081b225059a6edaff6440fac/tokenizers-0.22.2-cp39-abi3-musllinux_1_2_i686.whl", hash = "sha256:791135ee325f2336f498590eb2f11dc5c295232f288e75c99a36c5dbce63088a", size = 9899263, upload-time = "2026-01-05T10:45:12.559Z" },
+    { url = "https://files.pythonhosted.org/packages/05/a1/d62dfe7376beaaf1394917e0f8e93ee5f67fea8fcf4107501db35996586b/tokenizers-0.22.2-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:38337540fbbddff8e999d59970f3c6f35a82de10053206a7562f1ea02d046fa5", size = 10033429, upload-time = "2026-01-05T10:45:14.333Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/18/a545c4ea42af3df6effd7d13d250ba77a0a86fb20393143bbb9a92e434d4/tokenizers-0.22.2-cp39-abi3-win32.whl", hash = "sha256:a6bf3f88c554a2b653af81f3204491c818ae2ac6fbc09e76ef4773351292bc92", size = 2502363, upload-time = "2026-01-05T10:45:20.593Z" },
+    { url = "https://files.pythonhosted.org/packages/65/71/0670843133a43d43070abeb1949abfdef12a86d490bea9cd9e18e37c5ff7/tokenizers-0.22.2-cp39-abi3-win_amd64.whl", hash = "sha256:c9ea31edff2968b44a88f97d784c2f16dc0729b8b143ed004699ebca91f05c48", size = 2747786, upload-time = "2026-01-05T10:45:18.411Z" },
+    { url = "https://files.pythonhosted.org/packages/72/f4/0de46cfa12cdcbcd464cc59fde36912af405696f687e53a091fb432f694c/tokenizers-0.22.2-cp39-abi3-win_arm64.whl", hash = "sha256:9ce725d22864a1e965217204946f830c37876eee3b2ba6fc6255e8e903d5fcbc", size = 2612133, upload-time = "2026-01-05T10:45:17.232Z" },
+]
+
+[[package]]
 name = "torch"
 version = "2.13.0"
 source = { registry = "https://pypi.org/simple" }
@@ -4580,6 +4849,26 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/57/a9/a2584b8313b89f94869ddb3c4074617a691de1812a614d2d50e32ca5a7a6/traitlets-5.15.1.tar.gz", hash = "sha256:7b1c07854fe25acb39e009bae49f11b79ff6cbb2f27999104e9110e7a6b53722", size = 163344, upload-time = "2026-06-03T12:26:06.181Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/96/8d/1080ee4c231f361b6ce4470d556c8c435b67c7e0753aaa641497ee92f88b/traitlets-5.15.1-py3-none-any.whl", hash = "sha256:770a53705f84b81ac107e83a1b3328ff2dae16094d8fc3cfc004e4b22dfd8e92", size = 85858, upload-time = "2026-06-03T12:26:04.395Z" },
+]
+
+[[package]]
+name = "transformers"
+version = "5.13.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "huggingface-hub" },
+    { name = "numpy" },
+    { name = "packaging" },
+    { name = "pyyaml" },
+    { name = "regex" },
+    { name = "safetensors" },
+    { name = "tokenizers" },
+    { name = "tqdm" },
+    { name = "typer" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/6e/f7/418169401560cec2b61512e6bf37b0cfb4c8e27700cfa868a1de073cb65d/transformers-5.13.1.tar.gz", hash = "sha256:1e2452d6778a7482158df5d5dacf6bf775d5b2fdcfce33caaf7f6b0e5f3e3397", size = 9196891, upload-time = "2026-07-11T09:15:50.845Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/29/47/54eacf96b5c835bbd6ca631aa2740e7705ed63d9e3a8afd2d2cc6d09cae5/transformers-5.13.1-py3-none-any.whl", hash = "sha256:53f0ea8aa397e29244c2377ba981bcaf0c87adcf44fbdd447ef6306522afcacd", size = 11503977, upload-time = "2026-07-11T09:15:46.801Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Makes embedding possible **without the remote Biocentral API**, so the Colab notebooks and CLI keep working when Biocentral is down (issue #59). Ported from the pre-monorepo standalone repo (`protspace-legacy#73` + `#74`) and re-landed here as one consolidated PR against `apps/protspace`.

## What's in it

- **New `data/embedding/local.py`** — on-device embedding via HuggingFace `transformers`, shipped as the optional **`[local]`** extra (`torch>=2.4`, `transformers>=5.13.1`, `sentencepiece`, `protobuf`, `einops`). Covers all 12 pLM shortcuts with per-family special-token handling + mean-pooling. ESM-C uses **Synthyra ESM++** (ungated, ~1e-9 MSE vs native). `resolve_default_backend()` picks `local` on Colab+CUDA, else `biocentral`.
- **`-b/--backend {biocentral,local}`** on `embed` + `prepare`. `embed_fasta` dispatches on backend (local = short key, biocentral = resolved model name) over a shared FASTA parse. Backend-aware `--batch-size` (unset → 1000 API / 8 GPU micro-batch), rejected when non-positive.
- **Review hardening:** empty-`.h5` guard, correct VRAM release, `LocalEmbedConfig` validation.

## Packaging

- `[local]` extra added via `uv add --optional local` → resolved into the **root** `uv.lock` (monorepo single-lock workspace). Default behavior unchanged (`biocentral`).

## Tests

- `tests/test_local_embedder.py` (21) + `tests/test_backend_switch.py` (10).
- Full fast suite: **783 passed**, ruff clean, monorepo precommit (frontend quality + docs build) green.

## Docs

- `docs/cli.md` + `CLAUDE.md` updated.
- Plan committed at `docs/superpowers/plans/2026-07-13-colab-biocentral-independence.md` (6-PR roadmap; this PR is PR1+PR2).

## Follow-ups (see the plan)

PR3 local-vs-Biocentral parity cross-check · PR4 notebook local-default-in-Colab · PR5 wire the dead `--stats` toggle into the Preparation notebook · PR6 append EAT to the Preparation notebook.

🤖 Generated with [Claude Code](https://claude.com/claude-code)