### PR TITLE
ci(publish-images): path-filter prep image build to its actual inputs

### DIFF
--- a/.github/workflows/publish-images.yml
+++ b/.github/workflows/publish-images.yml
@@ -6,9 +6,24 @@ on:
     # No tag trigger: protspace releases push `v*` tags to THIS repo, and the
     # prep image must not build/publish on them (it deploys by digest on main,
     # and a `v4.7.1` tag would otherwise mint a mislabeled protspace-prep image).
+    #
+    # Path-filtered to the prep image's actual build inputs so a web-only or
+    # docs-only push to main no longer rebuilds and redeploys an unchanged
+    # backend image. The set below is exactly what apps/prep/Dockerfile binds
+    # and copies (root lock + root pyproject + both uv workspace member sources,
+    # since protspace-prep is source-pinned to the protspace member).
+    paths:
+      - 'apps/prep/**'
+      - 'apps/protspace/**'
+      - 'pyproject.toml'
+      - 'uv.lock'
+      - '.github/workflows/publish-images.yml'
   pull_request:
     paths:
       - 'apps/prep/**'
+      - 'apps/protspace/**'
+      - 'pyproject.toml'
+      - 'uv.lock'
       - '.github/workflows/publish-images.yml'
   workflow_dispatch:
 


### PR DESCRIPTION
The `publish-images.yml` push-to-main trigger had no path filter, so every merge to main — including web-only and docs-only changes — rebuilt and republished the `protspace-prep` backend image (new digest for unchanged code, plus a downstream redeploy). PR #333 (web-only) just triggered exactly this.

Both triggers are now filtered to the image's real build inputs, as bound/copied by `apps/prep/Dockerfile`:
- `apps/prep/**`
- `apps/protspace/**` (protspace-prep is source-pinned to the protspace workspace member)
- `pyproject.toml`, `uv.lock` (root workspace lock)
- `.github/workflows/publish-images.yml`

Backend-affecting changes still rebuild the image; web/docs changes no longer do. Also widens the previously too-narrow `pull_request` filter to the same set so PR-time image builds run on protspace/lock changes too.