### PR TITLE
chore(prep): move dev extra to a PEP 735 dependency group

### DIFF
--- a/apps/prep/Dockerfile
+++ b/apps/prep/Dockerfile
@@ -23,6 +23,10 @@ WORKDIR /app
 
 # Layer 1: external deps only (no workspace members). Cached until the workspace
 # lock or any member's pyproject.toml changes.
+#
+# `--no-dev` is load-bearing, not decorative: prep's test deps are a PEP 735
+# dependency group, which uv installs by default. Dropping the flag ships pytest
+# and friends into the runtime image.
 RUN --mount=type=cache,target=/root/.cache/uv \
     --mount=type=bind,source=uv.lock,target=uv.lock \
     --mount=type=bind,source=pyproject.toml,target=pyproject.toml \

--- a/apps/prep/README.md
+++ b/apps/prep/README.md
@@ -6,10 +6,11 @@ for the design.
 
 ## Run locally
 
+`protspace-prep` is a member of the repo-root uv workspace, so run these from the
+repo root. The `dev` dependency group installs by default — no extra flag needed.
+
 ```bash
-cd apps/prep
-uv venv
-uv pip install -e ".[dev]"
+uv sync --package protspace-prep
 uv run uvicorn protspace_prep.app:app --reload --port 8000
 ```
 

--- a/apps/prep/README.md
+++ b/apps/prep/README.md
@@ -6,24 +6,34 @@ for the design.
 
 ## Run locally
 
-`protspace-prep` is a member of the repo-root uv workspace, so run these from the
-repo root. The `dev` dependency group installs by default — no extra flag needed.
+`protspace-prep` is a uv workspace member, so every command below runs from the
+repo root. Keep `--package protspace-prep` on `uv run` too: the workspace root is
+virtual, so a bare `uv run` resolves _all_ members and pulls in ~135 extra
+packages (torch, jupyter) that this service does not use.
+
+From the repo root:
 
 ```bash
 uv sync --package protspace-prep
-uv run uvicorn protspace_prep.app:app --reload --port 8000
+uv run --package protspace-prep uvicorn protspace_prep.app:app --reload --port 8000
 ```
 
 ## Tests
 
+From the repo root — the path is required, since the root has no pytest config
+and a bare `pytest` collects the whole workspace:
+
 ```bash
-uv run pytest -q
+uv run --package protspace-prep pytest apps/prep -q
 ```
 
 ## Build the Docker image
 
+From the repo root — the build context is the workspace root, not `apps/prep`
+(see the header of [`Dockerfile`](./Dockerfile)):
+
 ```bash
-docker build -t protspace-prep:local .
+docker build -f apps/prep/Dockerfile -t protspace-prep:local .
 ```
 
 ## Configuration

--- a/apps/prep/pyproject.toml
+++ b/apps/prep/pyproject.toml
@@ -14,10 +14,8 @@ dependencies = [
   "slowapi>=0.1.9",
 ]
 
-# PEP 735 group, not a [project.optional-dependencies] extra: these are only ever
-# needed to run the test suite, so they should not be installable by consumers as
-# `protspace-prep[dev]`. Groups are also synced by default, so a plain `uv sync`
-# yields a test-ready environment; the Dockerfile's `--no-dev` still excludes them.
+# A group rather than an extra: test-only tooling should not be installable by
+# consumers as `protspace-prep[dev]`.
 [dependency-groups]
 dev = [
   "pytest>=8.3",

--- a/apps/prep/pyproject.toml
+++ b/apps/prep/pyproject.toml
@@ -14,7 +14,11 @@ dependencies = [
   "slowapi>=0.1.9",
 ]
 
-[project.optional-dependencies]
+# PEP 735 group, not a [project.optional-dependencies] extra: these are only ever
+# needed to run the test suite, so they should not be installable by consumers as
+# `protspace-prep[dev]`. Groups are also synced by default, so a plain `uv sync`
+# yields a test-ready environment; the Dockerfile's `--no-dev` still excludes them.
+[dependency-groups]
 dev = [
   "pytest>=8.3",
   "pytest-asyncio>=0.24",

--- a/uv.lock
+++ b/uv.lock
@@ -3274,7 +3274,7 @@ wheels = [
 
 [[package]]
 name = "protlabel"
-version = "4.7.2"
+version = "4.8.2"
 source = { editable = "apps/protspace/packages/protlabel" }
 dependencies = [
     { name = "numpy" },
@@ -3300,7 +3300,7 @@ wheels = [
 
 [[package]]
 name = "protspace"
-version = "4.7.2"
+version = "4.8.2"
 source = { editable = "apps/protspace" }
 dependencies = [
     { name = "biocentral-api" },
@@ -3440,7 +3440,7 @@ dependencies = [
     { name = "uvicorn", extra = ["standard"] },
 ]
 
-[package.optional-dependencies]
+[package.dev-dependencies]
 dev = [
     { name = "httpx" },
     { name = "pytest" },
@@ -3452,17 +3452,20 @@ dev = [
 requires-dist = [
     { name = "anyio", specifier = ">=4.6" },
     { name = "fastapi", extras = ["standard"], specifier = ">=0.115" },
-    { name = "httpx", marker = "extra == 'dev'", specifier = ">=0.28" },
     { name = "protspace", editable = "apps/protspace" },
-    { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.3" },
-    { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.24" },
     { name = "python-multipart", specifier = ">=0.0.20" },
-    { name = "respx", marker = "extra == 'dev'", specifier = ">=0.21" },
     { name = "slowapi", specifier = ">=0.1.9" },
     { name = "structlog", specifier = ">=24.1" },
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.32" },
 ]
-provides-extras = ["dev"]
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "httpx", specifier = ">=0.28" },
+    { name = "pytest", specifier = ">=8.3" },
+    { name = "pytest-asyncio", specifier = ">=0.24" },
+    { name = "respx", specifier = ">=0.21" },
+]
 
 [[package]]
 name = "psutil"


### PR DESCRIPTION
## Why

`apps/prep` declared its test-only dependencies as a `dev` **extra**:

```toml
[project.optional-dependencies]
dev = ["pytest>=8.3", "pytest-asyncio>=0.24", "httpx>=0.28", "respx>=0.21"]
```

Two problems with that:

1. **Extras are not synced by default.** A plain `uv sync` left the workspace unable to run `apps/prep`'s tests — you had to remember `--all-extras`. This surfaced while recreating a local venv: the env looked complete, but `respx`/`pytest-asyncio` were missing.
2. **A `dev` extra is consumer-visible.** It shipped in the metadata as `provides-extras = ["dev"]`, so `pip install protspace-prep[dev]` was a supported install of our test tooling.

`apps/protspace` already uses a real `[dependency-groups] dev`, so this also makes the two members consistent.

## What

- Move the four deps from `[project.optional-dependencies]` to `[dependency-groups]` (PEP 735). **Version constraints are unchanged** — a pure relocation.
- Refresh `apps/prep/README.md`, which documented the pre-workspace `uv venv` + `uv pip install -e ".[dev]"` flow that this change would otherwise break.
- Regenerate `uv.lock`.

## Verification

In a throwaway environment, so nothing local influenced the result:

| Check | Result |
| --- | --- |
| `uv sync --package protspace-prep` (no flags) | all four dev deps present |
| `pytest -q` in that env | **81 passed** |
| `uv sync --no-dev` (what the Dockerfile runs) | dev deps absent, `import protspace_prep` still OK |

The last row is the one that matters for prod: `apps/prep/Dockerfile` already passes `--no-dev`, which excludes dependency groups exactly as it excluded the un-requested extra before, so the published image is byte-for-byte equivalent in intent.

`pnpm precommit` passes.

## Note on the lockfile diff

`uv lock` also picked up `protspace`/`protlabel` `4.7.2 → 4.8.2` — `uv.lock` on `main` was stale relative to the `4.8.2` release. That's an unrelated but correct refresh; it is not something this branch changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Uacf46CWEysQKniPs5mtEq