### PR TITLE
ci(prep): lint and test apps/prep in CI

### DIFF
--- a/.github/workflows/prep-ci.yml
+++ b/.github/workflows/prep-ci.yml
@@ -3,11 +3,14 @@ name: prep CI (Python)
 # protspace-prep is a uv workspace member under apps/prep. GitHub only runs
 # workflows from the root .github/workflows, so this lives here (not nested) and
 # path-filters to prep changes. Run steps use working-directory: apps/prep; uv
-# detects the workspace root and uses the root lock — hence uv.lock in the paths
-# filter, since prep's resolved dependencies live there rather than in the member.
+# detects the workspace root and uses the root lock — which is why uv.lock is in
+# the paths filter, since a dependency bump reaches prep only through that file.
 #
-# Mirrors protspace-ci.yml, minus the Python matrix: prep declares
-# requires-python = ">=3.12" and is only ever run from its pinned container image.
+# One job rather than protspace-ci.yml's lint/test split: that split pays for
+# itself there because `test` is a 3-version matrix, so a merged job would run
+# ruff three times. Here there is no matrix, and both jobs shared an identical
+# ~30s setup (`uv sync` installs ~97 packages via the protspace member) to run
+# two ruff commands that finish in under a second.
 
 on:
   push:
@@ -27,7 +30,7 @@ defaults:
     working-directory: apps/prep
 
 jobs:
-  lint:
+  lint-and-test:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -37,9 +40,13 @@ jobs:
           enable-cache: true
           cache-dependency-glob: 'uv.lock'
 
+      # Pinned, NOT python-version-file: prep declares requires-python ">=3.12",
+      # which setup-python resolves to the newest release (3.14 at time of
+      # writing) — so CI would validate against an interpreter the service never
+      # runs. apps/prep/Dockerfile pins python3.12-bookworm-slim; match it.
       - uses: actions/setup-python@v6
         with:
-          python-version-file: 'apps/prep/pyproject.toml'
+          python-version: '3.12'
 
       - name: Install dependencies
         run: uv sync --group dev
@@ -49,23 +56,6 @@ jobs:
 
       - name: Ruff format check
         run: uv run ruff format --check src/ tests/
-
-  test:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-
-      - uses: astral-sh/setup-uv@v7
-        with:
-          enable-cache: true
-          cache-dependency-glob: 'uv.lock'
-
-      - uses: actions/setup-python@v6
-        with:
-          python-version-file: 'apps/prep/pyproject.toml'
-
-      - name: Install dependencies
-        run: uv sync --group dev
 
       - name: Run tests
         run: uv run pytest

--- a/.github/workflows/prep-ci.yml
+++ b/.github/workflows/prep-ci.yml
@@ -1,0 +1,71 @@
+name: prep CI (Python)
+
+# protspace-prep is a uv workspace member under apps/prep. GitHub only runs
+# workflows from the root .github/workflows, so this lives here (not nested) and
+# path-filters to prep changes. Run steps use working-directory: apps/prep; uv
+# detects the workspace root and uses the root lock — hence uv.lock in the paths
+# filter, since prep's resolved dependencies live there rather than in the member.
+#
+# Mirrors protspace-ci.yml, minus the Python matrix: prep declares
+# requires-python = ">=3.12" and is only ever run from its pinned container image.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'apps/prep/**'
+      - 'uv.lock'
+      - '.github/workflows/prep-ci.yml'
+  pull_request:
+    paths:
+      - 'apps/prep/**'
+      - 'uv.lock'
+      - '.github/workflows/prep-ci.yml'
+
+defaults:
+  run:
+    working-directory: apps/prep
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: astral-sh/setup-uv@v7
+        with:
+          enable-cache: true
+          cache-dependency-glob: 'uv.lock'
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version-file: 'apps/prep/pyproject.toml'
+
+      - name: Install dependencies
+        run: uv sync --group dev
+
+      - name: Ruff check
+        run: uv run ruff check src/ tests/
+
+      - name: Ruff format check
+        run: uv run ruff format --check src/ tests/
+
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: astral-sh/setup-uv@v7
+        with:
+          enable-cache: true
+          cache-dependency-glob: 'uv.lock'
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version-file: 'apps/prep/pyproject.toml'
+
+      - name: Install dependencies
+        run: uv sync --group dev
+
+      - name: Run tests
+        run: uv run pytest

--- a/apps/prep/pyproject.toml
+++ b/apps/prep/pyproject.toml
@@ -22,6 +22,7 @@ dev = [
   "pytest-asyncio>=0.24",
   "httpx>=0.28",
   "respx>=0.21",
+  "ruff>=0.15.21",
 ]
 
 [build-system]
@@ -35,6 +36,45 @@ packages = ["src/protspace_prep"]
 asyncio_mode = "auto"
 testpaths = ["tests"]
 addopts = "-ra -q"
+
+# Mirrors apps/protspace's ruff config, with one deliberate difference:
+# target-version is py312, matching this member's requires-python. Inheriting
+# protspace's py310 instead would flag `ExceptionGroup` (a 3.11+ builtin, used in
+# pipeline.py) as an undefined name. Ruff resolves the *nearest* config, so
+# without this block apps/prep silently falls back to ruff's defaults.
+[tool.ruff]
+target-version = "py312"
+line-length = 88
+
+[tool.ruff.lint]
+select = [
+    "E", # pycodestyle errors
+    "W", # pycodestyle warnings
+    "F", # pyflakes
+    "I", # isort
+    "B", # flake8-bugbear
+    "C4", # flake8-comprehensions
+    "UP", # pyupgrade
+    "ARG001", # unused-function-args
+    "F401", # unused-import
+    "F841", # unused-variable
+]
+ignore = [
+    "E501", # line too long, handled by the formatter
+    "B008", # do not perform function calls in argument defaults (FastAPI Depends)
+    "C901", # too complex
+    # UP042 wants `enum.StrEnum` instead of `(str, enum.Enum)`. Declining: the two
+    # differ in what `str(member)` returns, and JobStatus/ValidationCode cross the
+    # API boundary, so the swap is a wire-format risk for no functional gain.
+    "UP042",
+]
+
+[tool.ruff.lint.isort]
+known-first-party = ["protspace_prep", "protspace"]
+
+[tool.ruff.lint.per-file-ignores]
+"tests/*" = ["ARG001", "F401", "F841", "F811"]  # Pytest fixtures intentionally redefine module-level fixtures
+"tests/conftest.py" = ["ARG001", "F401", "F841", "F811", "E402"]  # must set PREP_JOB_ROOT before importing the app
 
 [tool.uv]
 package = true

--- a/apps/prep/pyproject.toml
+++ b/apps/prep/pyproject.toml
@@ -37,11 +37,11 @@ asyncio_mode = "auto"
 testpaths = ["tests"]
 addopts = "-ra -q"
 
-# Mirrors apps/protspace's ruff config, with one deliberate difference:
-# target-version is py312, matching this member's requires-python. Inheriting
-# protspace's py310 instead would flag `ExceptionGroup` (a 3.11+ builtin, used in
-# pipeline.py) as an undefined name. Ruff resolves the *nearest* config, so
-# without this block apps/prep silently falls back to ruff's defaults.
+# Ruff resolves the *nearest* config; without this block apps/prep silently falls
+# back to ruff's defaults rather than the repo's ruleset. py312 (not protspace's
+# py310) because `ExceptionGroup` — a 3.11+ builtin used in pipeline.py — reads as
+# F821 under py310. This currently duplicates apps/protspace's block; the shared
+# rules belong in a root config that each member extends with its own target.
 [tool.ruff]
 target-version = "py312"
 line-length = 88
@@ -74,7 +74,7 @@ known-first-party = ["protspace_prep", "protspace"]
 
 [tool.ruff.lint.per-file-ignores]
 "tests/*" = ["ARG001", "F401", "F841", "F811"]  # Pytest fixtures intentionally redefine module-level fixtures
-"tests/conftest.py" = ["ARG001", "F401", "F841", "F811", "E402"]  # must set PREP_JOB_ROOT before importing the app
+"tests/conftest.py" = ["E402"]  # merges with the tests/* entry above
 
 [tool.uv]
 package = true

--- a/apps/prep/src/protspace_prep/api.py
+++ b/apps/prep/src/protspace_prep/api.py
@@ -1,10 +1,20 @@
 from __future__ import annotations
+
 import asyncio
 import logging
 import re
-from typing import AsyncIterator
+from collections.abc import AsyncIterator
 
-from fastapi import APIRouter, File, HTTPException, Path, Request, Response, UploadFile, status
+from fastapi import (
+    APIRouter,
+    File,
+    HTTPException,
+    Path,
+    Request,
+    Response,
+    UploadFile,
+    status,
+)
 from fastapi.responses import FileResponse, JSONResponse, StreamingResponse
 from slowapi import Limiter
 from starlette.background import BackgroundTask
@@ -36,19 +46,28 @@ def _safe_download_name(original_name: str) -> str:
     return f"{safe}.parquetbundle"
 
 
-def fasta_validation_error_handler(request: Request, exc: FastaValidationError) -> JSONResponse:
+def fasta_validation_error_handler(
+    request: Request,  # noqa: ARG001 — required by FastAPI's exception-handler contract
+    exc: FastaValidationError,
+) -> JSONResponse:
     return JSONResponse(
         status_code=400,
         content={"error": exc.message, "code": exc.code.value},
     )
 
 
-def make_router(registry: JobRegistry, settings: Settings, limiter: Limiter) -> APIRouter:
+def make_router(
+    registry: JobRegistry, settings: Settings, limiter: Limiter
+) -> APIRouter:
     router = APIRouter()
 
     @router.post("/api/prepare", status_code=status.HTTP_202_ACCEPTED)
     @limiter.limit(settings.rate_limit)
-    async def submit(request: Request, response: Response, file: UploadFile = File(...)):
+    async def submit(
+        request: Request,  # noqa: ARG001 — slowapi's @limiter.limit reads it by name
+        response: Response,  # noqa: ARG001 — see below; slowapi injects headers via it
+        file: UploadFile = File(...),
+    ):
         # `response` is unused here; slowapi reads it via kwargs to inject
         # rate-limit headers (X-RateLimit-*, Retry-After) when headers_enabled=True.
         body = await file.read(settings.upload_max_bytes + 1)
@@ -66,13 +85,17 @@ def make_router(registry: JobRegistry, settings: Settings, limiter: Limiter) -> 
             ) from exc
         parse_and_validate(text, settings)
         try:
-            job_id = await registry.submit(body, original_name=file.filename or "input.fasta")
+            job_id = await registry.submit(
+                body, original_name=file.filename or "input.fasta"
+            )
         except QueueFull:
+            # `from None`: a full queue is an expected condition being translated
+            # into its HTTP form, not an error raised while handling an error.
             raise HTTPException(
                 status_code=503,
                 detail="Server is busy; too many pending jobs. Try again shortly.",
                 headers={"Retry-After": "30"},
-            )
+            ) from None
         return {"job_id": job_id}
 
     @router.get("/api/prepare/{job_id}/events")
@@ -96,7 +119,7 @@ def make_router(registry: JobRegistry, settings: Settings, limiter: Limiter) -> 
                             asyncio.shield(pending),
                             timeout=_KEEPALIVE_INTERVAL_SECONDS,
                         )
-                    except asyncio.TimeoutError:
+                    except TimeoutError:
                         if await request.is_disconnected():
                             return
                         yield KEEPALIVE_FRAME.encode("utf-8")
@@ -127,7 +150,9 @@ def make_router(registry: JobRegistry, settings: Settings, limiter: Limiter) -> 
             "X-Accel-Buffering": "no",
             "Connection": "keep-alive",
         }
-        return StreamingResponse(stream(), media_type="text/event-stream", headers=headers)
+        return StreamingResponse(
+            stream(), media_type="text/event-stream", headers=headers
+        )
 
     @router.get("/api/prepare/{job_id}/bundle")
     async def bundle(job_id: str = _JOB_ID):
@@ -135,7 +160,9 @@ def make_router(registry: JobRegistry, settings: Settings, limiter: Limiter) -> 
         if state is None:
             raise HTTPException(status_code=404, detail="Unknown job_id")
         if state.status is JobStatus.ERROR:
-            raise HTTPException(status_code=409, detail=state.error_message or "Job failed.")
+            raise HTTPException(
+                status_code=409, detail=state.error_message or "Job failed."
+            )
         if state.status is not JobStatus.DONE:
             raise HTTPException(status_code=409, detail="Job not finished.")
         if state.consumed:

--- a/apps/prep/src/protspace_prep/api.py
+++ b/apps/prep/src/protspace_prep/api.py
@@ -65,7 +65,7 @@ def make_router(
     @limiter.limit(settings.rate_limit)
     async def submit(
         request: Request,  # noqa: ARG001 — slowapi's @limiter.limit reads it by name
-        response: Response,  # noqa: ARG001 — see below; slowapi injects headers via it
+        response: Response,  # noqa: ARG001
         file: UploadFile = File(...),
     ):
         # `response` is unused here; slowapi reads it via kwargs to inject

--- a/apps/prep/src/protspace_prep/app.py
+++ b/apps/prep/src/protspace_prep/app.py
@@ -1,9 +1,9 @@
 from __future__ import annotations
+
 import asyncio
 import logging
 from contextlib import asynccontextmanager
 from functools import partial
-from typing import Optional
 
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
@@ -11,7 +11,7 @@ from slowapi import _rate_limit_exceeded_handler
 from slowapi.errors import RateLimitExceeded
 
 from .api import fasta_validation_error_handler, make_router
-from .config import Settings, load_settings
+from .config import load_settings
 from .jobs import JobRegistry, PipelineFn
 from .logger import setup_logging
 from .pipeline import run_protspace_prepare
@@ -21,7 +21,7 @@ from .validation import FastaValidationError
 logger = logging.getLogger("protspace_prep")
 
 
-def create_app(*, pipeline: Optional[PipelineFn] = None) -> FastAPI:
+def create_app(*, pipeline: PipelineFn | None = None) -> FastAPI:
     settings = load_settings()
     # Configure logging before anything else emits a log line so no logger is
     # cached without the structlog formatter.
@@ -36,7 +36,7 @@ def create_app(*, pipeline: Optional[PipelineFn] = None) -> FastAPI:
     )
 
     @asynccontextmanager
-    async def lifespan(app: FastAPI):
+    async def lifespan(app: FastAPI):  # noqa: ARG001 — asynccontextmanager lifespan contract
         async def _sweep_loop():
             while True:
                 try:

--- a/apps/prep/src/protspace_prep/config.py
+++ b/apps/prep/src/protspace_prep/config.py
@@ -50,8 +50,9 @@ def load_settings() -> Settings:
         sweep_interval_seconds=int(os.getenv("PREP_SWEEP_INTERVAL_SECONDS", "300")),
         pipeline_timeout_seconds=int(os.getenv("PREP_PIPELINE_TIMEOUT_SECONDS", "420")),
         log_level=os.getenv("PREP_LOG_LEVEL", "INFO"),
-        log_json_format=os.getenv("PREP_LOG_JSON_FORMAT", "false").lower()
-        in {"1", "true", "yes"},
+        log_json_format=(
+            os.getenv("PREP_LOG_JSON_FORMAT", "false").lower() in {"1", "true", "yes"}
+        ),
         cors_allowed_origins=_parse_origins(os.getenv("CORS_ALLOWED_ORIGIN", "")),
         rate_limit=(os.getenv("PREP_RATE_LIMIT", "").strip() or "5/15minutes"),
     )

--- a/apps/prep/src/protspace_prep/config.py
+++ b/apps/prep/src/protspace_prep/config.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 import os
 from dataclasses import dataclass
 from pathlib import Path
@@ -49,7 +50,8 @@ def load_settings() -> Settings:
         sweep_interval_seconds=int(os.getenv("PREP_SWEEP_INTERVAL_SECONDS", "300")),
         pipeline_timeout_seconds=int(os.getenv("PREP_PIPELINE_TIMEOUT_SECONDS", "420")),
         log_level=os.getenv("PREP_LOG_LEVEL", "INFO"),
-        log_json_format=os.getenv("PREP_LOG_JSON_FORMAT", "false").lower() in {"1", "true", "yes"},
+        log_json_format=os.getenv("PREP_LOG_JSON_FORMAT", "false").lower()
+        in {"1", "true", "yes"},
         cors_allowed_origins=_parse_origins(os.getenv("CORS_ALLOWED_ORIGIN", "")),
         rate_limit=(os.getenv("PREP_RATE_LIMIT", "").strip() or "5/15minutes"),
     )

--- a/apps/prep/src/protspace_prep/jobs.py
+++ b/apps/prep/src/protspace_prep/jobs.py
@@ -1,15 +1,17 @@
 from __future__ import annotations
+
 import asyncio
 import enum
 import logging
 import shutil
 import time
 import uuid
-
-import structlog
+from collections.abc import AsyncIterator, Awaitable, Callable
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any, AsyncIterator, Awaitable, Callable, Optional
+from typing import Any
+
+import structlog
 
 logger = logging.getLogger("protspace_prep.jobs")
 
@@ -67,12 +69,12 @@ class JobState:
     original_name: str
     fasta_path: Path
     output_dir: Path
-    bundle_path: Optional[Path] = None
-    error_message: Optional[str] = None
+    bundle_path: Path | None = None
+    error_message: str | None = None
     created_at: float = field(default_factory=time.time)
-    ready_at: Optional[float] = None
+    ready_at: float | None = None
     consumed: bool = False
-    terminal_event: Optional[Event] = None
+    terminal_event: Event | None = None
     queue_position: int = 0
 
 
@@ -96,12 +98,12 @@ class JobRegistry:
         self._max_pending = max_pending
         self._pipeline = pipeline
         self._jobs: dict[str, JobState] = {}
-        self._subscribers: dict[str, list[asyncio.Queue[Optional[Event]]]] = {}
+        self._subscribers: dict[str, list[asyncio.Queue[Event | None]]] = {}
         self._tasks: dict[str, asyncio.Task] = {}
         self._running = 0
         self._queued = 0
 
-    def get(self, job_id: str) -> Optional[JobState]:
+    def get(self, job_id: str) -> JobState | None:
         return self._jobs.get(job_id)
 
     def counts(self) -> dict[str, int]:
@@ -132,7 +134,14 @@ class JobRegistry:
         self._queued += 1
         await self._publish(
             job_id,
-            Event("queued", {"job_id": job_id, "queue_position": queue_position, "running": running}),
+            Event(
+                "queued",
+                {
+                    "job_id": job_id,
+                    "queue_position": queue_position,
+                    "running": running,
+                },
+            ),
         )
         self._tasks[job_id] = asyncio.create_task(self._run(job_id))
         return job_id
@@ -143,17 +152,31 @@ class JobRegistry:
             return
         # Late subscriber: synthesize queued then replay terminal event and close.
         if state.terminal_event is not None:
-            yield Event("queued", {"job_id": job_id, "queue_position": state.queue_position, "running": self._running})
+            yield Event(
+                "queued",
+                {
+                    "job_id": job_id,
+                    "queue_position": state.queue_position,
+                    "running": self._running,
+                },
+            )
             yield state.terminal_event
             return
 
         # Register the queue before yielding the synthetic queued event to avoid
         # the race where the pipeline completes between the terminal_event check
         # above and registration here.
-        queue: asyncio.Queue[Optional[Event]] = asyncio.Queue(maxsize=128)
+        queue: asyncio.Queue[Event | None] = asyncio.Queue(maxsize=128)
         self._subscribers[job_id].append(queue)
         try:
-            yield Event("queued", {"job_id": job_id, "queue_position": state.queue_position, "running": self._running})
+            yield Event(
+                "queued",
+                {
+                    "job_id": job_id,
+                    "queue_position": state.queue_position,
+                    "running": self._running,
+                },
+            )
             # Re-check after registration: if the pipeline finished in the window
             # between our initial check and queue registration, terminal_event is
             # already set (or the event was already enqueued for us).
@@ -173,7 +196,7 @@ class JobRegistry:
             except (ValueError, KeyError):
                 pass
 
-    def peek_bundle(self, job_id: str) -> Optional[Path]:
+    def peek_bundle(self, job_id: str) -> Path | None:
         """Return bundle path if available, without marking consumed."""
         state = self._jobs.get(job_id)
         if state is None or state.status is not JobStatus.DONE or state.consumed:
@@ -207,7 +230,7 @@ class JobRegistry:
 
     @staticmethod
     def _enqueue(
-        queue: asyncio.Queue[Optional[Event]],
+        queue: asyncio.Queue[Event | None],
         event: Event,
         *,
         terminal: bool,

--- a/apps/prep/src/protspace_prep/logger.py
+++ b/apps/prep/src/protspace_prep/logger.py
@@ -9,6 +9,7 @@ per-call-site changes. `merge_contextvars` attaches request-scoped context
 """
 
 from __future__ import annotations
+
 import logging
 
 import structlog

--- a/apps/prep/src/protspace_prep/pipeline.py
+++ b/apps/prep/src/protspace_prep/pipeline.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
+
 import asyncio
 import logging
+from collections.abc import Awaitable, Callable, Sequence
 from pathlib import Path
-from typing import Awaitable, Callable, Sequence
 
 from protspace.data.loaders.h5 import parse_identifier
 
@@ -47,7 +48,9 @@ def _classify_failure(exc: PipelineFailure) -> PipelineFailure:
     """
     haystack = f"{exc} {exc.detail or ''}".lower()
     if any(p in haystack for p in _BIOCENTRAL_DOWN_PATTERNS):
-        return PipelineFailure(_BIOCENTRAL_FRIENDLY_MESSAGE, code="BIOCENTRAL_UNAVAILABLE")
+        return PipelineFailure(
+            _BIOCENTRAL_FRIENDLY_MESSAGE, code="BIOCENTRAL_UNAVAILABLE"
+        )
     return exc
 
 
@@ -61,7 +64,10 @@ def _normalize_fasta_headers(input_path: Path, output_path: Path) -> None:
     merged annotations. Normalising up-front makes both paths emit identical
     identifiers. Plain headers (no UniProt pipes) are left untouched.
     """
-    with open(input_path, encoding="utf-8") as fin, open(output_path, "w", encoding="utf-8") as fout:
+    with (
+        open(input_path, encoding="utf-8") as fin,
+        open(output_path, "w", encoding="utf-8") as fout,
+    ):
         for line in fin:
             if line.startswith(">"):
                 stripped = line[1:].strip()
@@ -131,7 +137,9 @@ async def run_protspace_prepare(
                 if failures:
                     classified = [_classify_failure(e) for e in failures]
                     if any(c.code == "BIOCENTRAL_UNAVAILABLE" for c in classified):
-                        raise PipelineFailure(_BIOCENTRAL_FRIENDLY_MESSAGE, code="BIOCENTRAL_UNAVAILABLE") from eg
+                        raise PipelineFailure(
+                            _BIOCENTRAL_FRIENDLY_MESSAGE, code="BIOCENTRAL_UNAVAILABLE"
+                        ) from eg
                     # Preserve the per-step diagnostic detail (subprocess stderr)
                     # so it stays available for server-side logging; the joined
                     # message remains the curated, user-facing text.
@@ -170,10 +178,12 @@ async def run_protspace_prepare(
                 str(bundle_path),
             ]
             await _run_step("bundle", bundle_cmd)
-    except asyncio.TimeoutError:
+    except TimeoutError:
+        # `from None`: the watchdog timeout is an expected outcome translated into
+        # a domain failure; the bare TimeoutError carries no extra diagnostics.
         raise PipelineFailure(
             f"protspace pipeline timed out after {settings.pipeline_timeout_seconds}s."
-        )
+        ) from None
 
     if not bundle_path.exists():
         raise PipelineFailure(
@@ -220,7 +230,7 @@ async def _run_step(name: str, cmd: Sequence[str]) -> None:
         process.kill()
         try:
             await asyncio.wait_for(process.wait(), timeout=5)
-        except asyncio.TimeoutError:
+        except TimeoutError:
             pass
         raise
 
@@ -236,5 +246,3 @@ async def _run_step(name: str, cmd: Sequence[str]) -> None:
             f"report this with the reference shown below.",
             detail=f"protspace {name} exited with code {returncode}: {tail}",
         )
-
-

--- a/apps/prep/src/protspace_prep/sse.py
+++ b/apps/prep/src/protspace_prep/sse.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 import json
 from typing import Any
 

--- a/apps/prep/src/protspace_prep/validation.py
+++ b/apps/prep/src/protspace_prep/validation.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
+
 import enum
+from collections.abc import Iterable
 from dataclasses import dataclass
-from typing import Iterable
 
 from protspace.data.loaders.h5 import parse_identifier
 

--- a/apps/prep/tests/test_api.py
+++ b/apps/prep/tests/test_api.py
@@ -5,9 +5,9 @@ import httpx
 import pytest
 from httpx import ASGITransport, AsyncClient
 
+from protspace_prep.api import _safe_download_name
 from protspace_prep.app import create_app
 from protspace_prep.jobs import JobContext, PipelineFailure
-from protspace_prep.api import _safe_download_name
 
 
 async def _fake_success(ctx: JobContext, emit) -> Path:
@@ -73,7 +73,7 @@ async def test_post_prepare_returns_job_id_and_sse_drives_to_done(app_factory):
             events = []
             async for chunk in stream.aiter_lines():
                 if chunk.startswith("event: "):
-                    events.append(chunk[len("event: "):])
+                    events.append(chunk[len("event: ") :])
                 if "event: done" in chunk or "event: error" in chunk:
                     pass
         assert "queued" in events
@@ -159,6 +159,7 @@ async def test_post_prepare_returns_503_when_queue_full(app_factory, monkeypatch
 # Fix 1 — Content-Disposition header injection
 # ---------------------------------------------------------------------------
 
+
 class TestSafeDownloadName:
     def test_normal_name(self):
         assert _safe_download_name("my_sequences.fasta") == "my_sequences.parquetbundle"
@@ -212,7 +213,10 @@ async def test_bundle_download_with_hostile_filename_produces_safe_header(app_fa
         assert r.status_code == 200
 
         cd = r.headers.get("content-disposition", "")
-        assert '"' not in cd.split("filename=", 1)[-1].lstrip('"').rstrip('"') or cd.count('"') == 2
+        assert (
+            '"' not in cd.split("filename=", 1)[-1].lstrip('"').rstrip('"')
+            or cd.count('"') == 2
+        )
         assert "\r" not in cd
         assert "\n" not in cd
         assert "X-Injected" not in r.headers
@@ -222,6 +226,7 @@ async def test_bundle_download_with_hostile_filename_produces_safe_header(app_fa
 # Fix 2 — SSE keep-alive frames
 # ---------------------------------------------------------------------------
 
+
 async def test_sse_keepalive_frame_emitted_on_slow_pipeline(app_factory, monkeypatch):
     """When no event arrives within the keepalive interval, a comment frame
     is sent — and the stream must keep flowing afterwards (regression: a prior
@@ -229,6 +234,7 @@ async def test_sse_keepalive_frame_emitted_on_slow_pipeline(app_factory, monkeyp
     exhausting the subscriber generator so the stream truncated silently).
     """
     import asyncio
+
     import protspace_prep.api as api_module
 
     # Speed up: use a very short keepalive interval so the test doesn't take 15s.
@@ -280,6 +286,7 @@ async def test_sse_keepalive_frame_emitted_on_slow_pipeline(app_factory, monkeyp
 # ---------------------------------------------------------------------------
 # Fix 6 — bundle() marks consumed before read
 # ---------------------------------------------------------------------------
+
 
 async def test_bundle_expired_returns_410_and_does_not_consume(app_factory):
     """If the bundle file is missing when the download is requested, return 410.

--- a/apps/prep/tests/test_config.py
+++ b/apps/prep/tests/test_config.py
@@ -2,7 +2,9 @@ from protspace_prep.config import load_settings
 
 
 def test_cors_origins_parsed_from_env(monkeypatch):
-    monkeypatch.setenv("CORS_ALLOWED_ORIGIN", "https://protspace.app, https://staging.protspace.app")
+    monkeypatch.setenv(
+        "CORS_ALLOWED_ORIGIN", "https://protspace.app, https://staging.protspace.app"
+    )
     settings = load_settings()
     assert settings.cors_allowed_origins == (
         "https://protspace.app",

--- a/apps/prep/tests/test_jobs.py
+++ b/apps/prep/tests/test_jobs.py
@@ -111,7 +111,9 @@ async def test_semaphore_caps_active_jobs(tmp_job_root):
         max_concurrent=2,
         pipeline=slow_pipeline,
     )
-    job_ids = [await registry.submit(b">i\nM\n", original_name="t.fasta") for _ in range(4)]
+    job_ids = [
+        await registry.submit(b">i\nM\n", original_name="t.fasta") for _ in range(4)
+    ]
     await started.wait()
     await asyncio.sleep(0.05)
     assert peak == 2
@@ -153,8 +155,10 @@ async def test_submit_rejects_when_pending_at_cap(tmp_job_root):
     assert len(list(tmp_job_root.iterdir())) == 2
 
     release.set()
-    async for _ in registry.subscribe(a): pass
-    async for _ in registry.subscribe(b): pass
+    async for _ in registry.subscribe(a):
+        pass
+    async for _ in registry.subscribe(b):
+        pass
 
 
 async def test_multiple_concurrent_subscribers_each_receive_full_stream(tmp_job_root):
@@ -246,13 +250,16 @@ async def test_running_and_queued_counts(tmp_job_root):
     await asyncio.sleep(0.05)
     assert registry.counts() == {"running": 1, "queued": 1}
     release.set()
-    async for _ in registry.subscribe(a): pass
-    async for _ in registry.subscribe(b): pass
+    async for _ in registry.subscribe(a):
+        pass
+    async for _ in registry.subscribe(b):
+        pass
     assert registry.counts() == {"running": 0, "queued": 0}
 
 
 async def test_sweep_removes_expired_directories(tmp_path):
     from protspace_prep.jobs import JobRegistry
+
     job_root = tmp_path / "jobs"
     registry = JobRegistry(
         job_root=job_root,
@@ -262,7 +269,9 @@ async def test_sweep_removes_expired_directories(tmp_path):
     job_id = await registry.submit(b">id\nMKT\n", original_name="t.fasta")
     async for _ in registry.subscribe(job_id):
         pass
-    import os, time
+    import os
+    import time
+
     job_dir = job_root / job_id
     past = time.time() - 10_000
     os.utime(job_dir, (past, past))
@@ -299,6 +308,7 @@ async def test_sweep_evicts_consumed_jobs_without_waiting_for_ttl(tmp_job_root):
 # §2.2 — queue_position + running in queued event
 # ---------------------------------------------------------------------------
 
+
 async def test_queued_event_includes_queue_position_and_running(tmp_job_root):
     gate = asyncio.Event()
 
@@ -309,7 +319,9 @@ async def test_queued_event_includes_queue_position_and_running(tmp_job_root):
         bundle.write_bytes(b"x")
         return bundle
 
-    registry = JobRegistry(job_root=tmp_job_root, max_concurrent=1, pipeline=blocking_pipeline)
+    registry = JobRegistry(
+        job_root=tmp_job_root, max_concurrent=1, pipeline=blocking_pipeline
+    )
     job_id_a = await registry.submit(b">a\nM\n", original_name="a.fasta")
     job_id_b = await registry.submit(b">b\nM\n", original_name="b.fasta")
     # Let the tasks start so the semaphore is acquired by job A
@@ -324,6 +336,7 @@ async def test_queued_event_includes_queue_position_and_running(tmp_job_root):
     # Verify the queued event payload by subscribing to the late-subscriber path
     # (job A is running, so terminal_event may not be set yet; check job B which is queued)
     collected_b: list = []
+
     async def collect_b():
         async for e in registry.subscribe(job_id_b):
             collected_b.append(e)
@@ -337,15 +350,19 @@ async def test_queued_event_includes_queue_position_and_running(tmp_job_root):
 
     gate.set()
     # Drain both jobs so tmp dirs are cleaned up
-    async for _ in registry.subscribe(job_id_a): pass
-    async for _ in registry.subscribe(job_id_b): pass
+    async for _ in registry.subscribe(job_id_a):
+        pass
+    async for _ in registry.subscribe(job_id_b):
+        pass
 
 
 async def test_error_event_includes_code_when_pipeline_failure_has_code(tmp_job_root):
     async def coded_failure_pipeline(ctx, emit):
         raise PipelineFailure("nope", code="BIOCENTRAL_UNAVAILABLE")
 
-    registry = JobRegistry(job_root=tmp_job_root, max_concurrent=1, pipeline=coded_failure_pipeline)
+    registry = JobRegistry(
+        job_root=tmp_job_root, max_concurrent=1, pipeline=coded_failure_pipeline
+    )
     job_id = await registry.submit(b">id\nM\n", original_name="t.fasta")
     events = [e async for e in registry.subscribe(job_id)]
     error_event = next(e for e in events if e.event == "error")
@@ -356,7 +373,9 @@ async def test_error_event_omits_code_when_pipeline_failure_has_no_code(tmp_job_
     async def plain_failure_pipeline(ctx, emit):
         raise PipelineFailure("nope")
 
-    registry = JobRegistry(job_root=tmp_job_root, max_concurrent=1, pipeline=plain_failure_pipeline)
+    registry = JobRegistry(
+        job_root=tmp_job_root, max_concurrent=1, pipeline=plain_failure_pipeline
+    )
     job_id = await registry.submit(b">id\nM\n", original_name="t.fasta")
     events = [e async for e in registry.subscribe(job_id)]
     error_event = next(e for e in events if e.event == "error")
@@ -366,6 +385,7 @@ async def test_error_event_omits_code_when_pipeline_failure_has_no_code(tmp_job_
 # ---------------------------------------------------------------------------
 # Fix 3 — subscribe() race between yield queued and queue registration
 # ---------------------------------------------------------------------------
+
 
 async def test_subscribe_after_instant_pipeline_receives_done(tmp_job_root):
     """Submit with an instantly-terminating pipeline and subscribe immediately.
@@ -400,12 +420,15 @@ async def test_subscribe_race_repeated(tmp_job_root):
         # Yield control so the pipeline task can run
         await asyncio.sleep(0)
         events = [e async for e in registry.subscribe(job_id)]
-        assert events[-1].event == "done", f"Expected done, got {[e.event for e in events]}"
+        assert events[-1].event == "done", (
+            f"Expected done, got {[e.event for e in events]}"
+        )
 
 
 # ---------------------------------------------------------------------------
 # Fix 4 — Sweeper hangs live subscribers
 # ---------------------------------------------------------------------------
+
 
 async def test_sweep_notifies_live_subscriber(tmp_job_root):
     """A subscriber blocked on queue.get() must unblock when sweep_expired runs."""
@@ -436,7 +459,9 @@ async def test_sweep_notifies_live_subscriber(tmp_job_root):
     await asyncio.sleep(0.05)
 
     # Backdate the job directory so sweep_expired considers it expired
-    import os, time
+    import os
+    import time
+
     job_dir = tmp_job_root / job_id
     past = time.time() - 10_000
     os.utime(job_dir, (past, past))
@@ -446,7 +471,7 @@ async def test_sweep_notifies_live_subscriber(tmp_job_root):
     # Consumer should unblock (receive None sentinel) and finish promptly
     try:
         await asyncio.wait_for(consumer_task, timeout=1.0)
-    except asyncio.TimeoutError:
+    except TimeoutError:
         consumer_task.cancel()
         pytest.fail("Subscriber task hung after sweep_expired — sentinel not delivered")
 
@@ -457,6 +482,7 @@ async def test_sweep_notifies_live_subscriber(tmp_job_root):
 # ---------------------------------------------------------------------------
 # Fix 5 — _run() doesn't handle CancelledError
 # ---------------------------------------------------------------------------
+
 
 async def test_cancelled_job_publishes_error_event(tmp_job_root):
     """Cancelling a running job task must publish an error event and set ERROR status."""
@@ -493,7 +519,7 @@ async def test_cancelled_job_publishes_error_event(tmp_job_root):
     # Consumer should receive the error event and finish
     try:
         await asyncio.wait_for(consumer_task, timeout=1.0)
-    except asyncio.TimeoutError:
+    except TimeoutError:
         consumer_task.cancel()
         pytest.fail("Subscriber did not receive error event after job cancellation")
 

--- a/apps/prep/tests/test_pipeline.py
+++ b/apps/prep/tests/test_pipeline.py
@@ -1,12 +1,16 @@
 import asyncio
 from pathlib import Path
-from unittest.mock import patch, AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
 from protspace_prep.config import load_settings
 from protspace_prep.jobs import JobContext, PipelineFailure
-from protspace_prep.pipeline import _classify_failure, _normalize_fasta_headers, run_protspace_prepare
+from protspace_prep.pipeline import (
+    _classify_failure,
+    _normalize_fasta_headers,
+    run_protspace_prepare,
+)
 
 
 @pytest.fixture
@@ -46,9 +50,13 @@ def _mock_subprocess(returncode: int, stderr_lines: list[bytes] | None = None):
     return proc
 
 
-def _make_step_router(ctx: JobContext, *, fail_step: str | None = None,
-                      fail_returncode: int = 2,
-                      fail_stderr: list[bytes] | None = None):
+def _make_step_router(
+    ctx: JobContext,
+    *,
+    fail_step: str | None = None,
+    fail_returncode: int = 2,
+    fail_stderr: list[bytes] | None = None,
+):
     """Return a fake create_subprocess_exec that simulates each protspace step.
 
     Each successful step writes its expected output artifact so the next step
@@ -143,7 +151,8 @@ async def test_embed_and_annotate_run_concurrently(ctx):
 async def test_embed_failure_raises_pipeline_failure(ctx):
     settings = load_settings()
     fake = _make_step_router(
-        ctx, fail_step="embed",
+        ctx,
+        fail_step="embed",
         fail_stderr=[b"ERROR Biocentral returned 503: unavailable\n"],
     )
     with patch("asyncio.create_subprocess_exec", new=fake):
@@ -159,7 +168,8 @@ async def test_embed_failure_raises_pipeline_failure(ctx):
 async def test_annotate_failure_raises_pipeline_failure(ctx):
     settings = load_settings()
     fake = _make_step_router(
-        ctx, fail_step="annotate",
+        ctx,
+        fail_step="annotate",
         fail_stderr=[b"ERROR UniProt query failed\n"],
     )
     with patch("asyncio.create_subprocess_exec", new=fake):
@@ -302,12 +312,16 @@ async def test_pipeline_uses_normalized_fasta_for_embed_and_annotate(ctx):
     assert ">P12345" in normalized.read_text()
 
 
-async def test_embed_failure_with_connection_refused_is_classified_as_biocentral_unavailable(ctx):
+async def test_embed_failure_with_connection_refused_is_classified_as_biocentral_unavailable(
+    ctx,
+):
     settings = load_settings()
     fake = _make_step_router(
         ctx,
         fail_step="embed",
-        fail_stderr=[b"aiohttp.ClientConnectorError: Cannot connect to host biocentral.example.com:443\n"],
+        fail_stderr=[
+            b"aiohttp.ClientConnectorError: Cannot connect to host biocentral.example.com:443\n"
+        ],
     )
     with patch("asyncio.create_subprocess_exec", new=fake):
         with pytest.raises(PipelineFailure) as exc_info:
@@ -316,12 +330,16 @@ async def test_embed_failure_with_connection_refused_is_classified_as_biocentral
     assert "Biocentral embedding service is unavailable" in str(exc_info.value)
 
 
-async def test_embed_failure_with_no_healthy_service_timeout_is_classified_as_biocentral_unavailable(ctx):
+async def test_embed_failure_with_no_healthy_service_timeout_is_classified_as_biocentral_unavailable(
+    ctx,
+):
     settings = load_settings()
     fake = _make_step_router(
         ctx,
         fail_step="embed",
-        fail_stderr=[b"TimeoutError: No healthy biocentral service became available in time\n"],
+        fail_stderr=[
+            b"TimeoutError: No healthy biocentral service became available in time\n"
+        ],
     )
     with patch("asyncio.create_subprocess_exec", new=fake):
         with pytest.raises(PipelineFailure) as exc_info:

--- a/apps/prep/tests/test_ratelimit_api.py
+++ b/apps/prep/tests/test_ratelimit_api.py
@@ -54,8 +54,12 @@ async def test_rate_limit_ignores_spoofed_forwarded_for(make_client, monkeypatch
     monkeypatch.setenv("PREP_RATE_LIMIT", "1/hour")
     files = {"file": ("seq.fasta", b">P12345\nMKTAYIAK\n", "text/plain")}
     async with make_client(client=("198.51.100.5", 33333)) as c:
-        r1 = await c.post("/api/prepare", files=files, headers={"X-Forwarded-For": "1.1.1.1"})
-        r2 = await c.post("/api/prepare", files=files, headers={"X-Forwarded-For": "2.2.2.2"})
+        r1 = await c.post(
+            "/api/prepare", files=files, headers={"X-Forwarded-For": "1.1.1.1"}
+        )
+        r2 = await c.post(
+            "/api/prepare", files=files, headers={"X-Forwarded-For": "2.2.2.2"}
+        )
     assert r1.status_code == 202
     assert r2.status_code == 429
 
@@ -65,7 +69,10 @@ async def test_cors_preflight_allows_configured_origin(make_client, monkeypatch)
     async with make_client() as c:
         r = await c.options(
             "/api/prepare",
-            headers={"Origin": "https://protspace.app", "Access-Control-Request-Method": "POST"},
+            headers={
+                "Origin": "https://protspace.app",
+                "Access-Control-Request-Method": "POST",
+            },
         )
     assert r.headers.get("access-control-allow-origin") == "https://protspace.app"
 
@@ -75,7 +82,10 @@ async def test_cors_absent_for_unconfigured_origin(make_client, monkeypatch):
     async with make_client() as c:
         r = await c.options(
             "/api/prepare",
-            headers={"Origin": "https://evil.example", "Access-Control-Request-Method": "POST"},
+            headers={
+                "Origin": "https://evil.example",
+                "Access-Control-Request-Method": "POST",
+            },
         )
     assert r.headers.get("access-control-allow-origin") is None
 

--- a/apps/prep/tests/test_sse.py
+++ b/apps/prep/tests/test_sse.py
@@ -1,4 +1,4 @@
-from protspace_prep.sse import format_event, KEEPALIVE_FRAME
+from protspace_prep.sse import KEEPALIVE_FRAME, format_event
 
 
 def test_format_event_emits_named_event_with_json_data():

--- a/apps/prep/tests/test_validation.py
+++ b/apps/prep/tests/test_validation.py
@@ -5,8 +5,8 @@ import pytest
 from protspace_prep.config import load_settings
 from protspace_prep.validation import (
     FastaValidationError,
-    parse_and_validate,
     ValidationCode,
+    parse_and_validate,
 )
 
 FIXTURES = Path(__file__).parent / "fixtures"

--- a/uv.lock
+++ b/uv.lock
@@ -3446,6 +3446,7 @@ dev = [
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "respx" },
+    { name = "ruff" },
 ]
 
 [package.metadata]
@@ -3465,6 +3466,7 @@ dev = [
     { name = "pytest", specifier = ">=8.3" },
     { name = "pytest-asyncio", specifier = ">=0.24" },
     { name = "respx", specifier = ">=0.21" },
+    { name = "ruff", specifier = ">=0.15.21" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Why

`apps/prep` had **no CI coverage at all**:

- `ci.yml` and `deploy.yml` both `paths-ignore: apps/prep/**`
- `protspace-ci.yml` path-filters to `apps/protspace/**`
- `publish-images.yml` builds the image but runs no tests, and `--no-dev` means they *couldn't* run there

So its 81 tests and its lint cleanliness could regress on `main` with nothing to catch it. That's how the unused `Settings` import survived.

## What

Adds `prep-ci.yml` (lint + test), mirroring `protspace-ci.yml`. Two deliberate differences, both noted in the file header:

- **No Python matrix** — prep declares `requires-python = ">=3.12"` and only ever runs from its pinned container image.
- **`uv.lock` in the paths filter** — prep's resolved deps live in the root lock, not the member, so a lock change should re-run its tests.

## The ruff config, and why it's duplicated rather than hoisted

Ruff resolves the *nearest* config. `apps/prep` had none, so it was silently falling back to ruff's **defaults** — not your configured ruleset. Turning linting on required giving the member a config.

It mirrors `apps/protspace`'s with one difference: `target-version = "py312"`. I originally intended to hoist a single shared config to the root, but testing showed that inheriting protspace's `py310` flags `ExceptionGroup` (a 3.11+ builtin, used in `pipeline.py:129`) as `F821 Undefined name`. The two members genuinely need different targets, so duplication is the honest answer here.

Under the correct config the finding count went 77 → 54 (the `py310` false positive disappeared, and your existing `tests/*` per-file-ignores started matching prep's tests).

## Fixed

- **`raise ... from None` at both `B904` sites** (`api.py`, `pipeline.py`). Each translates an expected condition — queue full, watchdog timeout — into its domain/HTTP form. The originals carry no diagnostics, so suppressing the chain states the intent rather than masking an error-within-error.
- **Dropped the unused `Settings` import** from `app.py`.
- **`ruff --fix` + `ruff format`**: import ordering, `Optional[X]` → `X | None`, `asyncio.TimeoutError` → `TimeoutError` (an alias since 3.11), line wrapping. Annotation- and formatting-level only.

## Suppressed rather than "fixed" — each is a required contract

Worth reviewer attention, since the naive fix would break the service:

| Rule | Site | Why it must stay |
| --- | --- | --- |
| `ARG001` ×3 | `api.py` ×2, `app.py` | FastAPI's exception-handler signature, slowapi's by-name `request`/`response` injection, the lifespan contract. Deleting these args breaks the app. |
| `E402` | `tests/conftest.py` | Must set `PREP_JOB_ROOT` **before** importing the app — already commented in the file. |
| `UP042` | `JobStatus`, `ValidationCode` | `StrEnum` vs `(str, Enum)` differ in what `str(member)` returns, and both cross the API boundary. Wire-format risk for no functional gain. |

## Verification

Simulated the CI job locally from `apps/prep` in a throwaway env:

| Step | Result |
| --- | --- |
| `uv sync --group dev` | ok |
| `uv run ruff check src/ tests/` | **All checks passed!** |
| `uv run ruff format --check src/ tests/` | 20 files already formatted |
| `uv run pytest` | **81 passed** |

Also reviewed the autofixer's output on shipped code with `git diff -w` to confirm nothing semantic changed beyond the two `from None` additions.

## Note

Stacks cleanly with #372 (Docker build context) — different files, no overlap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Uacf46CWEysQKniPs5mtEq