### PR TITLE
docs(agents): document Python workspace member conventions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,20 +43,26 @@ Always run `pnpm precommit` before creating any git commit. It runs:
 - TypeScript (typecheck)
 - Vitest (tests)
 
+It is JS-only; Python workspace members are covered by their own CI workflows (see below).
+
 ## Python workspace members (uv)
 
 The Python packages are uv workspace members (root `[tool.uv.workspace]`) sharing one root
-`uv.lock`. Adding a member means wiring up three things it does not get for free:
+`uv.lock`. A new **top-level** member needs three things it does not get for free:
 
-- **`pnpm precommit` is JS-only** — it never lints or tests Python. Each member needs its own
-  workflow in `.github/workflows/` (GitHub runs workflows only from the repo root), path-filtered
-  on the member's directory **and** `uv.lock` — a dependency bump reaches it through the root lock
-  alone.
-- **Each member needs its own `[tool.ruff]`**, with `target-version` matching its `requires-python`.
-  Ruff resolves the nearest _ancestor_ config, so a member without one silently inherits another
-  member's rules and target version — or ruff's defaults if no ancestor has a `[tool.ruff]` table.
-- **Test/lint-only deps go in `[dependency-groups]`**, not `[project.optional-dependencies]`.
+- **Its own workflow** in `.github/workflows/` (GitHub runs workflows only from the repo root),
+  path-filtered on the member's directory **and** `uv.lock` — a dependency bump reaches it through
+  the root lock alone. See `prep-ci.yml` for a worked example.
+- **Its own `[tool.ruff]`**, with `target-version` matching its `requires-python`. Ruff resolves the
+  nearest _ancestor_ config, so a member without one silently inherits another member's rules and
+  target version — or ruff's defaults if no ancestor has a `[tool.ruff]` table.
+- **Test/lint-only deps in `[dependency-groups]`**, not `[project.optional-dependencies]`.
   Groups sync by default; extras do not, and a `dev` extra is installable by consumers.
+
+A member nested inside another — currently only `apps/protspace/packages/protlabel` — needs
+neither of the first two: `protspace-ci.yml` already lints and tests it via `packages/`, and it
+inherits `apps/protspace`'s ruff config, which is correct only while their `requires-python`
+floors agree.
 
 ## Commit style
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,6 +43,21 @@ Always run `pnpm precommit` before creating any git commit. It runs:
 - TypeScript (typecheck)
 - Vitest (tests)
 
+## Python workspace members (uv)
+
+The Python packages are uv workspace members (root `[tool.uv.workspace]`) sharing one root
+`uv.lock`. Adding a member means wiring up three things it does not get for free:
+
+- **`pnpm precommit` is JS-only** — it never lints or tests Python. Each member needs its own
+  workflow in `.github/workflows/` (GitHub runs workflows only from the repo root), path-filtered
+  on the member's directory **and** `uv.lock` — a dependency bump reaches it through the root lock
+  alone.
+- **Each member needs its own `[tool.ruff]`**, with `target-version` matching its `requires-python`.
+  Ruff resolves the nearest _ancestor_ config, so a member without one silently inherits another
+  member's rules and target version — or ruff's defaults if no ancestor has a `[tool.ruff]` table.
+- **Test/lint-only deps go in `[dependency-groups]`**, not `[project.optional-dependencies]`.
+  Groups sync by default; extras do not, and a `dev` extra is installable by consumers.
+
 ## Commit style
 
 Angular-style commit messages, subject under 72 characters:


### PR DESCRIPTION
## Why

#371, #373 and #374 each fixed a *symptom* of one root cause: `AGENTS.md` documents only the JS toolchain. Nothing tells the author of a new Python workspace member that they need CI, a ruff config, or dependency groups.

`apps/prep` shipped with none of the three:

- no CI — its tests and lint were unenforced until #373, which is how an unused import survived on `main`
- no `[tool.ruff]` — so it silently linted under ruff's *defaults*, not the repo's ruleset
- test deps as a consumer-installable `dev` **extra** until #371

Members went 1 → 3 during the monorepo merge. A fourth would repeat all of it.

## One correction worth flagging

I'd been asserting — including in #373's config comment — that a member without `[tool.ruff]` "falls back to ruff's defaults". That's only half true. Ruff walks **up** and adopts the nearest *ancestor* config, ignoring the member's own `requires-python`.

That branch is the more dangerous one: a `py310` member can be linted and auto-fixed as `py312`, with `UP` rules rewriting it into syntax invalid on its own floor. It's live in this repo today — `protlabel` has no `[tool.ruff]` and inherits `apps/protspace`'s `py310`, correct only because protlabel happens to also be `>=3.10`.

The wording covers both branches.

## Verified, not asserted

Every claim checked against the tree:

| Claim | Check |
| --- | --- |
| `pnpm precommit` is JS-only | resolves to `lint-staged && quality && docs:annotations:check && docs:build` — no Python |
| members need `uv.lock` in path filters | `prep-ci.yml` filters on it; `protspace-ci.yml` gained it in #374 |
| members need their own `[tool.ruff]` | `apps/prep` declares one; `protlabel` declares none and inherits |
| test deps belong in `[dependency-groups]` | `apps/prep` uses one, per #371 |

Docs-only; no code or workflow changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Uacf46CWEysQKniPs5mtEq