### PR TITLE
docs(protspace): correct drifting facts in CLAUDE.md and installation docs

### DIFF
--- a/.github/workflows/protspace-publish.yml
+++ b/.github/workflows/protspace-publish.yml
@@ -30,11 +30,13 @@ jobs:
         with:
           ref: ${{ github.event.client_payload.tag }}
 
-      # No dependency cache: this job only runs `uv build`, which provisions an
-      # isolated PEP 517 env from build-system.requires (hatchling) and never
-      # installs the locked set — hatchling does not even appear in uv.lock.
       - name: Install uv
         uses: astral-sh/setup-uv@v7
+        with:
+          # Explicitly false, not omitted: setup-uv defaults enable-cache to
+          # "auto". This job only runs `uv build`, which never installs the
+          # locked set.
+          enable-cache: false
 
       - name: Set up Python
         uses: actions/setup-python@v6

--- a/.github/workflows/protspace-publish.yml
+++ b/.github/workflows/protspace-publish.yml
@@ -30,11 +30,11 @@ jobs:
         with:
           ref: ${{ github.event.client_payload.tag }}
 
+      # No dependency cache: this job only runs `uv build`, which provisions an
+      # isolated PEP 517 env from build-system.requires (hatchling) and never
+      # installs the locked set — hatchling does not even appear in uv.lock.
       - name: Install uv
         uses: astral-sh/setup-uv@v7
-        with:
-          enable-cache: true
-          cache-dependency-glob: 'uv.lock'
 
       - name: Set up Python
         uses: actions/setup-python@v6

--- a/apps/protspace/CLAUDE.md
+++ b/apps/protspace/CLAUDE.md
@@ -12,9 +12,13 @@ Python package for dimensionality reduction of protein language model (pLM) embe
 **Always use `uv run` to execute Python commands in this project.** Do not use bare `python` or `python3`.
 
 ```bash
-# Install with dev deps (once per clone). Git hooks are managed by husky via
-# the root `prepare` script — do NOT set core.hooksPath by hand.
+# Install with dev deps (once per clone)
 uv sync --group dev
+
+# Git hooks come from husky, installed by `pnpm install` AT THE REPO ROOT — a
+# Python-only setup leaves you with no pre-commit gate. Never set core.hooksPath
+# by hand; husky owns it.
+pnpm install
 
 # Run tests (skip slow) — testpaths covers both protspace + protlabel
 uv run pytest -m "not slow"
@@ -114,7 +118,8 @@ Model shortcuts are defined in `MODEL_SHORT_KEYS` (CommonEmbedder models) and `E
 ```
 src/protspace/
 ├── cli/
-│   ├── app.py                  # Typer app root, shared utilities
+│   ├── app.py                  # Typer app root, shared utilities, setup_logging()
+│   ├── common_options.py       # Shared Typer options
 │   ├── prepare.py              # Full pipeline command
 │   ├── embed.py                # FASTA → HDF5 embedding
 │   ├── project.py              # HDF5 → DR projections
@@ -141,7 +146,7 @@ src/protspace/
 │   │   └── transformers/       # Post-processing (field normalization, etc.)
 │   ├── io/
 │   │   ├── bundle.py           # .parquetbundle read/write
-│   │   ├── fasta.py            # FASTA parsing, CSV annotation loading
+│   │   ├── fasta.py            # FASTA detection + parsing (is_fasta_file, parse_fasta)
 │   │   ├── formatters.py       # ProteinAnnotations → DataFrame/Arrow
 │   │   ├── predictions.py      # Per-cell prediction overlay columns
 │   │   ├── settings_converter.py # Settings table conversion
@@ -253,10 +258,9 @@ uv run pytest --cov=src/protspace --cov=packages/protlabel/src/protlabel  # With
 
 ### Test Files
 
-Scoped to `apps/protspace/tests/`; `protlabel` has its own suite under
-`packages/protlabel/tests/`. Counts are deliberately omitted — they went stale in
-12 of 28 rows before this table was last corrected. For a live count run
-`uv run pytest --collect-only -q`.
+Scoped to `tests/`; `protlabel` has its own suite under `packages/protlabel/tests/`.
+Counts are deliberately omitted — nothing validates them, so they only ever drift.
+For a live count run `uv run pytest tests/ --collect-only -q`.
 
 | File | What it covers |
 |------|---------------|
@@ -292,9 +296,9 @@ Scoped to `apps/protspace/tests/`; `protlabel` has its own suite under
 | `test_transfer_cli.py` | Transfer orchestration core and CLI registration |
 | `test_predictions_overlay.py` | Building the per-cell prediction overlay columns |
 | `test_display_decode.py` | Display-side decoding of encoded values, multi-hit rendering, gated-off passthrough |
-| `test_toxprot_demo.py` | `scripts/generate_toxprot_demo.py` |
+| `test_toxprot_demo.py` | Signal-peptide bound parsing, mature-FASTA stripping, bundle post-processing (column filter/reorder) |
 | `test_bundle_overlay.py` | Round-trip replacement of the annotations part of a bundle |
-| `test_classification.py` | Query/reference classifier |
+| `test_classification.py` | Query/reference rules: id-prefix and case-insensitive `where` substring, query-over-reference precedence, empty-match and missing-column errors |
 | `test_bundle_version.py` | `format_version=2` stamped into the annotations parquet |
 | `test_uniprot_parser_encoding.py` | UniProtEntry free-text emit points percent-encode reserved chars |
 | `test_cath_names.py` | CATH names file parsing |

--- a/apps/protspace/CLAUDE.md
+++ b/apps/protspace/CLAUDE.md
@@ -12,9 +12,9 @@ Python package for dimensionality reduction of protein language model (pLM) embe
 **Always use `uv run` to execute Python commands in this project.** Do not use bare `python` or `python3`.
 
 ```bash
-# Install with dev deps + enable pre-commit hook (once per clone)
+# Install with dev deps (once per clone). Git hooks are managed by husky via
+# the root `prepare` script — do NOT set core.hooksPath by hand.
 uv sync --group dev
-git config core.hooksPath .githooks
 
 # Run tests (skip slow) — testpaths covers both protspace + protlabel
 uv run pytest -m "not slow"
@@ -122,6 +122,7 @@ src/protspace/
 │   ├── bundle.py               # Combine into .parquetbundle
 │   ├── stats.py                # Projection quality statistics command
 │   ├── serve.py                # Dash web frontend
+│   ├── transfer.py             # Embedding Annotation Transfer (EAT) command
 │   └── style.py                # Annotation styling
 ├── data/
 │   ├── loaders/
@@ -132,6 +133,7 @@ src/protspace/
 │   │   └── similarity.py       # FASTA → MMseqs2 → similarity matrix
 │   ├── annotations/
 │   │   ├── configuration.py    # Annotation category definitions
+│   │   ├── encoding.py         # Bundle format v2 wire contract (percent-encoding)
 │   │   ├── manager.py          # ProteinAnnotationManager orchestrator
 │   │   ├── merging.py          # Merge UniProt + InterPro annotations
 │   │   ├── scores.py           # Annotation score computation
@@ -139,8 +141,9 @@ src/protspace/
 │   │   └── transformers/       # Post-processing (field normalization, etc.)
 │   ├── io/
 │   │   ├── bundle.py           # .parquetbundle read/write
+│   │   ├── fasta.py            # FASTA parsing, CSV annotation loading
 │   │   ├── formatters.py       # ProteinAnnotations → DataFrame/Arrow
-│   │   ├── readers.py          # HDF5/CSV data readers
+│   │   ├── predictions.py      # Per-cell prediction overlay columns
 │   │   ├── settings_converter.py # Settings table conversion
 │   │   └── writers.py          # Annotation output writers
 │   ├── embedding/
@@ -169,6 +172,7 @@ src/protspace/
 │   ├── reducers.py             # All DR method implementations + annoy fallback
 │   ├── add_annotation_style.py # Annotation color/style utilities
 │   └── arrow_reader.py         # Parquet/Arrow reading helpers
+├── analysis/                   # Query/reference classification
 ├── core/                       # Core data models
 ├── ui/                         # Dash UI components
 ├── visualization/              # Plotly visualization builders
@@ -249,36 +253,54 @@ uv run pytest --cov=src/protspace --cov=packages/protlabel/src/protlabel  # With
 
 ### Test Files
 
-| File | Tests | What it covers |
-|------|-------|---------------|
-| `test_annotation_manager.py` | 79 | Annotation fetch, merge, cache, configuration, evidence parsing |
-| `test_transformer.py` | 56 | Annotation transformers (field normalization, EC names) |
-| `test_reducers.py` | 51 | All 6 DR methods: shapes, finite output, float16, config validation |
-| `test_interpro_annotation_retriever.py` | 46 | InterPro API mocking, parsing |
-| `test_settings_converter.py` | 31 | Settings table ↔ visualization state conversion |
-| `test_uniprot_annotation_retriever.py` | 24 | UniProt API mocking, inactive entry resolution |
-| `test_pipeline_utils.py` | 70 | ReductionPipeline, EmbeddingSet, method parsing, multi-input merging, inline param overrides |
-| `test_stats.py` | 50 | Projection statistics: elbow, annotation-based validity (silhouette/DBI/CH per annotation), auto-cluster ARI/NMI agreement, faithfulness (dual continuity + global metrics), cluster-selection (elbow/silhouette/both), subsample determinism/order-invariance, silhouette consistency, `_align` no-id guard, silhouette→elbow fallback |
-| `test_stats_cli.py` | 16 | `protspace stats` CLI + `prepare` stats wiring, `--stats-annotation` (auto/list) wiring, `--settings-out` guard, `--cluster-selection` validation |
-| `test_stats_carriage.py` | 10 | Routing rows to bundle parts (metadata quality, annotation columns, cluster legend) |
-| `test_stats_bundle.py` | 7 | Optional 5th (statistics) bundle part round-trip |
-| `test_annotation_select.py` | 6 | Annotation selection: suitability filter (cardinality/numeric/id-like exclusion), `auto` vs explicit-list label building (explicit names bypass the heuristic), missing-value dropping |
-| `test_annotation_validity.py` | 6 | `AnnotationValidityStatistic`: silhouette/DBI/CH scored per annotation on `ctx.coords`, embedding vs. projection `space_kind`, missing-value exclusion, single-category no-op, id-canonical subsample determinism |
-| `test_biocentral_embedder.py` | 23 | Biocentral API client, embedding flow |
-| `test_backend_switch.py` | 10 | Embedding backend switch: `resolve_default_backend` (Colab+GPU→local), `embed_fasta` local/biocentral dispatch (short key vs resolved name), `protspace embed --backend` CLI wiring + enum validation + non-positive batch_size rejection |
-| `test_local_embedder.py` | 21 | Local embedding backend: checkpoint resolution (12 short keys, Synthyra ESM-C), per-family preprocessing/residue pooling, `/`-in-header guard, LocalEmbedConfig validation, empty-output guard, esm2_8m end-to-end + resume (slow) |
-| `test_fasta.py` | 17 | FASTA parsing, edge cases, CSV annotation loading |
-| `test_biocentral_retriever.py` | 14 | Biocentral prediction retriever (TMbed parsing, per-sequence) |
-| `test_taxonomy_annotation_retriever.py` | 15 | Taxonomy via UniProt Taxonomy API (mocked + integration) |
-| `test_config_validation.py` | 12 | DimensionReductionConfig parameter validation |
-| `test_style_warnings.py` | 17 | `protspace style` warnings: numeric-column detection (#67) + `selectedPaletteId` validation (categorical vs gradient palette, per column type) + pinned palette-catalog contract |
-| `test_h5_parse_identifier.py` | 9 | HDF5 key parsing, identifier extraction |
-| `test_base_data_processor.py` | 9 | BaseProcessor: reduction, output creation, save (incl. settings in unbundled output) |
-| `test_ted_retriever.py` | 7 | TED domain retriever (mocked AlphaFold API, CATH names) |
-| `test_pfam_clan.py` | 7 | Pfam CLAN transformer (mapping, dedup, edge cases) |
-| `test_formatters.py` | 5 | ProteinAnnotations → DataFrame formatting |
-| `test_output_combinations.py` | 4 | Output format flag combinations |
-| `test_bundle_settings.py` | 4 | Parquetbundle settings read/write |
+Scoped to `apps/protspace/tests/`; `protlabel` has its own suite under
+`packages/protlabel/tests/`. Counts are deliberately omitted — they went stale in
+12 of 28 rows before this table was last corrected. For a live count run
+`uv run pytest --collect-only -q`.
+
+| File | What it covers |
+|------|---------------|
+| `test_annotation_manager.py` | Annotation fetch, merge, cache, configuration, evidence parsing |
+| `test_transformer.py` | Annotation transformers (field normalization, EC names) |
+| `test_reducers.py` | All 6 DR methods: shapes, finite output, float16, config validation |
+| `test_interpro_annotation_retriever.py` | InterPro API mocking, parsing |
+| `test_settings_converter.py` | Settings table ↔ visualization state conversion |
+| `test_uniprot_annotation_retriever.py` | UniProt API mocking, inactive entry resolution |
+| `test_pipeline_utils.py` | ReductionPipeline, EmbeddingSet, method parsing, multi-input merging, inline param overrides |
+| `test_stats.py` | Projection statistics: elbow, annotation-based validity (silhouette/DBI/CH per annotation), auto-cluster ARI/NMI agreement, faithfulness (dual continuity + global metrics), cluster-selection (elbow/silhouette/both), subsample determinism/order-invariance, silhouette consistency, `_align` no-id guard, silhouette→elbow fallback |
+| `test_stats_cli.py` | `protspace stats` CLI + `prepare` stats wiring, `--stats-annotation` (auto/list) wiring, `--settings-out` guard, `--cluster-selection` validation |
+| `test_stats_carriage.py` | Routing rows to bundle parts (metadata quality, annotation columns, cluster legend) |
+| `test_stats_bundle.py` | Optional 5th (statistics) bundle part round-trip |
+| `test_annotation_select.py` | Annotation selection: suitability filter (cardinality/numeric/id-like exclusion), `auto` vs explicit-list label building (explicit names bypass the heuristic), missing-value dropping |
+| `test_annotation_validity.py` | `AnnotationValidityStatistic`: silhouette/DBI/CH scored per annotation on `ctx.coords`, embedding vs. projection `space_kind`, missing-value exclusion, single-category no-op, id-canonical subsample determinism |
+| `test_biocentral_embedder.py` | Biocentral API client, embedding flow |
+| `test_backend_switch.py` | Embedding backend switch: `resolve_default_backend` (Colab+GPU→local), `embed_fasta` local/biocentral dispatch (short key vs resolved name), `protspace embed --backend` CLI wiring + enum validation + non-positive batch_size rejection |
+| `test_local_embedder.py` | Local embedding backend: checkpoint resolution (12 short keys, Synthyra ESM-C), per-family preprocessing/residue pooling, `/`-in-header guard, LocalEmbedConfig validation, empty-output guard, esm2_8m end-to-end + resume (slow) |
+| `test_fasta.py` | FASTA parsing, edge cases, CSV annotation loading |
+| `test_biocentral_retriever.py` | Biocentral prediction retriever (TMbed parsing, per-sequence) |
+| `test_taxonomy_annotation_retriever.py` | Taxonomy via UniProt Taxonomy API (mocked + integration) |
+| `test_config_validation.py` | DimensionReductionConfig parameter validation |
+| `test_style_warnings.py` | `protspace style` warnings: numeric-column detection (#67) + `selectedPaletteId` validation (categorical vs gradient palette, per column type) + pinned palette-catalog contract |
+| `test_h5_parse_identifier.py` | HDF5 key parsing, identifier extraction |
+| `test_base_data_processor.py` | BaseProcessor: reduction, output creation, save (incl. settings in unbundled output) |
+| `test_ted_retriever.py` | TED domain retriever (mocked AlphaFold API, CATH names) |
+| `test_pfam_clan.py` | Pfam CLAN transformer (mapping, dedup, edge cases) |
+| `test_formatters.py` | ProteinAnnotations → DataFrame formatting |
+| `test_output_combinations.py` | Output format flag combinations |
+| `test_bundle_settings.py` | Parquetbundle settings read/write |
+| `test_annotation_encoding.py` | Percent-encoding round-trip, reserved-char-only encoding, schema-metadata stamping through parquet |
+| `test_transfer_cli.py` | Transfer orchestration core and CLI registration |
+| `test_predictions_overlay.py` | Building the per-cell prediction overlay columns |
+| `test_display_decode.py` | Display-side decoding of encoded values, multi-hit rendering, gated-off passthrough |
+| `test_toxprot_demo.py` | `scripts/generate_toxprot_demo.py` |
+| `test_bundle_overlay.py` | Round-trip replacement of the annotations part of a bundle |
+| `test_classification.py` | Query/reference classifier |
+| `test_bundle_version.py` | `format_version=2` stamped into the annotations parquet |
+| `test_uniprot_parser_encoding.py` | UniProtEntry free-text emit points percent-encode reserved chars |
+| `test_cath_names.py` | CATH names file parsing |
+| `test_cli_no_frontend.py` | CLI imports without the optional `frontend` extra (plotly, dash) |
+| `test_encoding_e2e.py` | Backend end-to-end round-trip proof for v2 annotation encoding |
+| `test_scores_ted.py` | `--no-scores` strips TED domains |
 
 **Markers:** `@pytest.mark.slow` (database downloads), `@pytest.mark.integration` (external APIs)
 
@@ -294,7 +316,7 @@ Located in `notebooks/`:
 
 ## Dependencies
 
-**Core:** h5py, scikit-learn, umap-learn, pacmap (includes annoy), numpy, pandas, pyarrow, tqdm, requests, pymmseqs, biocentral-api, typer, rich
+**Core:** h5py, scikit-learn, umap-learn, pacmap (includes annoy), numpy, pandas, pyarrow, tqdm, requests, pymmseqs, biocentral-api, typer, rich, protlabel (workspace member)
 
 **Frontend (optional):** dash, plotly, dash-bootstrap-components, dash-molstar
 

--- a/apps/protspace/tests/README.md
+++ b/apps/protspace/tests/README.md
@@ -34,10 +34,16 @@ uv run pytest tests/test_reducers.py
 
 ## Slow Tests
 
-The following tests are marked as slow and can be skipped during rapid development:
+Some tests are marked slow and can be skipped during rapid development — they
+download external data or run a real model. List them with:
 
-- `tests/test_taxonomy_annotation_retriever.py` - Downloads and uses NCBI taxonomy database (~several seconds per test run)
+```bash
+uv run pytest tests/ --collect-only -q -m slow
+```
 
 ## CI/CD
 
-CI runs `uv run pytest tests/ -m "not slow" -q` by default. Slow/integration tests are skipped in CI to avoid external service dependencies.
+CI runs `uv run pytest -m "not slow" -q` by default, with no path argument —
+`testpaths` covers both workspace members, so this collects protspace and
+protlabel. Slow/integration tests are skipped in CI to avoid external service
+dependencies.

--- a/docs/developers/installation.md
+++ b/docs/developers/installation.md
@@ -8,6 +8,13 @@ If you just want to visualize protein data, visit [protspace.app](https://protsp
 
 ## NPM Package
 
+::: danger Not yet published
+`@protspace/core`, `@protspace/react` and `@protspace/utils` are **not on the npm
+registry** — every command in this section and the next currently returns a 404,
+and no publish workflow exists yet. To embed the components today, consume them
+from a local checkout via the workspace (see [Development Setup](#development-setup)).
+:::
+
 Install the `@protspace/core` package to embed ProtSpace components in your project.
 
 ::: code-group
@@ -49,7 +56,7 @@ Use directly from a CDN without installation:
 For production use, pin to a specific version:
 
 ```html
-<script type="module" src="https://unpkg.com/@protspace/core@1.0.0"></script>
+<script type="module" src="https://unpkg.com/@protspace/core@<version>"></script>
 ```
 
 :::

--- a/docs/developers/installation.md
+++ b/docs/developers/installation.md
@@ -9,10 +9,13 @@ If you just want to visualize protein data, visit [protspace.app](https://protsp
 ## NPM Package
 
 ::: danger Not yet published
-`@protspace/core`, `@protspace/react` and `@protspace/utils` are **not on the npm
-registry** — every command in this section and the next currently returns a 404,
-and no publish workflow exists yet. To embed the components today, consume them
-from a local checkout via the workspace (see [Development Setup](#development-setup)).
+These packages are **not on the npm registry** — every command in this section and
+the next currently returns a 404. `@protspace/core` and `@protspace/utils` exist in
+the repo and are ready to publish; `@protspace/react` has not been built yet.
+Tracked in [#378](https://github.com/tsenoner/protspace/issues/378).
+
+To embed the components today, consume them from a local checkout via the
+workspace — see [Development Setup](#development-setup).
 :::
 
 Install the `@protspace/core` package to embed ProtSpace components in your project.

--- a/docs/developers/installation.md
+++ b/docs/developers/installation.md
@@ -12,10 +12,7 @@ If you just want to visualize protein data, visit [protspace.app](https://protsp
 These packages are **not on the npm registry** — every command in this section and
 the next currently returns a 404. `@protspace/core` and `@protspace/utils` exist in
 the repo and are ready to publish; `@protspace/react` has not been built yet.
-Tracked in [#378](https://github.com/tsenoner/protspace/issues/378).
-
-To embed the components today, consume them from a local checkout via the
-workspace — see [Development Setup](#development-setup).
+Publishing is tracked in [#378](https://github.com/tsenoner/protspace/issues/378).
 :::
 
 Install the `@protspace/core` package to embed ProtSpace components in your project.


### PR DESCRIPTION
Handles the items deferred from #374 and #376. Every number below was measured, not estimated.

## The one that actually breaks something

`apps/protspace/CLAUDE.md`'s setup block told contributors to run:

```bash
git config core.hooksPath .githooks
```

`.githooks/` **does not exist**. The repo uses husky — `core.hooksPath` is `.husky/_`, and `.husky/pre-commit` is what runs `pnpm precommit`. Following that instruction repoints git at an empty path and **silently disables the pre-commit gate**, while the contributor believes they just enabled hooks.

Everything else in this PR is accuracy; this one is a live footgun.

## Test-file table: dropped the count column

12 of 28 counts were wrong — and **every error was an undercount**. Nobody wrote a wrong row; they stopped adding rows.

| | |
| --- | --- |
| Documented total | 626 |
| Real total (`--collect-only`) | **793** |
| Understated by | 21% |

Re-syncing the numbers buys correctness for exactly one commit. The column has no validator and decays in one direction — the same failure mode that justified removing the stale `Version: 4.7.1` line and `package.json`'s `4.7.0`.

So: **kept the descriptions, dropped the counts.** The prose is the asset — it explains intent and doesn't go stale when someone adds a `parametrize` case — and readers get pointed at `uv run pytest --collect-only -q`, which is correct by construction.

Also added the **13 test files that had no row at all**. The table now covers every file in `apps/protspace/tests` except `test_config.py` (shared fixtures, collects 0 tests). Verified: **42 files, 41 rows, zero ghosts.**

## Package Structure tree

- Removed `data/io/readers.py` — deleted four months ago in `693685de`, the same commit that removed `JsonReader`.
- Added the two real files in that same block it never listed: `fasta.py`, `predictions.py`.
- Added three significant omissions: `cli/transfer.py` (a *registered CLI command*), `data/annotations/encoding.py` (the bundle format v2 wire contract the web frontend must decode), and the `analysis/` package.
- Verified every documented path now resolves against the filesystem.

Core dependency list was also missing `protlabel`.

## docs/developers/installation.md

`@protspace/core`, `@protspace/react` and `@protspace/utils` are **not on npm** — all three return E404, and no publish workflow exists anywhere in `.github/workflows/`. Every command in the NPM and CDN sections fails today.

**I added a warning rather than deleting the sections** — whether to publish those packages is a product decision, not mine. If there's no plan to, deleting the whole block is the better fix and I'm happy to follow up. Also replaced the stale `@1.0.0` pin (real local version is `0.1.0`) with a placeholder that can't go stale.

## protspace-publish.yml

Dropped the uv dependency cache. The job only runs `uv build`, which provisions an isolated PEP 517 env from `build-system.requires` and never installs the locked set — **`hatchling` appears 0 times in `uv.lock`**. Worth ~1s and 7MB per release run; the point isn't speed, it's that the config no longer claims a relationship that doesn't exist.

## Deliberately not added

A generated-and-checked test-count table. The precedent — `pnpm docs:annotations:check` — owns 100% of its output file and derives it from a typed in-process import. A count tool could only own *one column* of a hand-authored table, would have to round-trip someone else's markdown formatting forever, and would make a working `uv` environment a precondition for committing web-only changes (`pnpm precommit` is currently pure pnpm/tsx).

## Verification

- Every path in the module tree resolves against `find src/protspace -name '*.py'`
- Table row set == real test file set (42 files / 41 rows / `test_config.py` correctly excluded)
- `npm view @protspace/core version` → E404, confirmed for all three packages
- `grep -c hatchling uv.lock` → 0
- Workflow valid YAML; `pnpm precommit` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Uacf46CWEysQKniPs5mtEq