### PR TITLE
ci: add dependency guards that catch what a bump bot cannot

### DIFF
--- a/.github/workflows/model-licences.yml
+++ b/.github/workflows/model-licences.yml
@@ -1,0 +1,30 @@
+name: Model licence canary
+
+# pLM checkpoints are not Python dependencies, so no dependency bot, SBOM or SCA
+# tool can see them. ESM-C was relicensed from non-commercial to MIT on
+# 2026-05-27 and the docs still said non-commercial two months later; this is the
+# only check that would have caught it. Weekly is enough — the failure mode is
+# stale documentation, not a broken build.
+
+on:
+  schedule:
+    - cron: '0 6 * * 1' # Mondays 06:00 UTC
+  workflow_dispatch: # also re-arms the schedule after repo-inactivity auto-disable
+  pull_request:
+    paths:
+      - 'apps/protspace/scripts/check_model_licences.py'
+      - '.github/workflows/model-licences.yml'
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: astral-sh/setup-uv@v7
+        with:
+          python-version: '3.12'
+
+      # No dependencies needed — the script uses only the standard library.
+      - name: Compare documented licences against the HuggingFace Hub
+        run: uv run --no-project python apps/protspace/scripts/check_model_licences.py

--- a/.github/workflows/protspace-ci.yml
+++ b/.github/workflows/protspace-ci.yml
@@ -53,6 +53,16 @@ jobs:
       - name: Ruff format check
         run: uv run ruff format --check src/ packages/ tests/
 
+      # Dependency hygiene. Both are cheap and both exist because of real
+      # regressions: pymmseqs sat in core deps for months publishing cp310-only
+      # wheels against a >=3.12 floor, and rich/protobuf carried floors on
+      # packages this codebase never imports.
+      - name: Unused / undeclared dependencies (deptry)
+        run: uv run deptry src/ tests/
+
+      - name: Every locked package ships a wheel
+        run: uv run python scripts/check_wheels.py
+
   test:
     runs-on: ubuntu-latest
     strategy:

--- a/apps/protspace/pyproject.toml
+++ b/apps/protspace/pyproject.toml
@@ -79,6 +79,7 @@ dev = [
     "polars>=1.26.0",
     "jupytext>=1.17.1",
     "pytest-cov>=7.0.0",
+    "deptry>=0.25.1",
 ]
 
 # protlabel (the EAT engine) is a separate distribution developed in-repo. It is a
@@ -156,6 +157,25 @@ known-first-party = ["protspace", "protlabel"]
 # `uv sync --locked` green. assets stays [] because the lock is staged, not an asset;
 # no wheel build here (publishing is handled by protspace-publish.yml). protspace +
 # protlabel stay lock-step (same bump).
+[tool.deptry]
+# The Python analogue of the `knip` run on the JS side: catches dependencies that
+# are declared but never used. `rich>=14.3.3` and `protobuf>=7.35.1` were floors on
+# packages this codebase does not import, and between them they produced five of the
+# six dependency-conflict warnings users saw on every Colab install.
+#
+# Every DEP002 entry below is required at RUNTIME by something we do import, so
+# deptry cannot see the link. Anything flagged that is NOT on this list is a real
+# candidate for removal -- justify it here or drop it.
+[tool.deptry.per_rule_ignores]
+DEP001 = ["__main__"]  # stdlib module, misdetected as a missing dependency
+DEP002 = [
+    "rich",           # typer renders its --help panels through rich (rich_help_panel)
+    "kaleido",        # plotly's static image-export backend
+    "einops",         # runtime requirement of several transformers architectures
+    "protobuf",       # runtime requirement of transformers/sentencepiece tokenizers
+    "sentencepiece",  # transformers tokenizer backend for the T5/Ankh families
+]
+
 [tool.semantic_release]
 # Monorepo scoping (requires python-semantic-release >= 10, pinned in
 # protspace-release.yml): count ONLY commits that touch this package dir

--- a/apps/protspace/scripts/check_model_licences.py
+++ b/apps/protspace/scripts/check_model_licences.py
@@ -1,0 +1,86 @@
+"""Warn when a pLM checkpoint's HuggingFace licence stops matching our docs.
+
+Model weights are not Python dependencies, so no dependency bot, SBOM or SCA tool
+can see them. ESM-C was relicensed from non-commercial to MIT on 2026-05-27 and
+our docs still said non-commercial two months later; nothing could have caught
+that except asking the Hub.
+
+Run offline-safe: a network failure is reported, not fatal.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+import urllib.error
+import urllib.request
+
+# checkpoint -> licence we currently document (apps/protspace/CLAUDE.md, docs/cli.md)
+EXPECTED: dict[str, str] = {
+    # ProtT5 declares no licence on its model card. Our docs say MIT on the strength
+    # of the paper/repo rather than Hub metadata, so "" means "expect none declared" --
+    # if one ever appears, this flags it so the claim can be checked against it.
+    "Rostlab/prot_t5_xl_uniref50": "",
+    "Rostlab/ProstT5": "mit",
+    "facebook/esm2_t6_8M_UR50D": "mit",
+    "facebook/esm2_t12_35M_UR50D": "mit",
+    "facebook/esm2_t30_150M_UR50D": "mit",
+    "facebook/esm2_t33_650M_UR50D": "mit",
+    "facebook/esm2_t36_3B_UR50D": "mit",
+    "ElnaggarLab/ankh-base": "cc-by-nc-sa-4.0",
+    "ElnaggarLab/ankh-large": "cc-by-nc-sa-4.0",
+    "ElnaggarLab/ankh3-large": "cc-by-nc-sa-4.0",
+    "Synthyra/ESMplusplus_small": "mit",
+    "Synthyra/ESMplusplus_large": "mit",
+}
+
+API = "https://huggingface.co/api/models/"
+
+
+def fetch_licence(model: str) -> str | None:
+    try:
+        with urllib.request.urlopen(API + model, timeout=20) as resp:
+            data = json.load(resp)
+    except (urllib.error.URLError, TimeoutError, json.JSONDecodeError) as exc:
+        print(f"  ?  {model}: could not query the Hub ({exc})")
+        return None
+    card = data.get("cardData") or {}
+    lic = card.get("license") or card.get("license_name")
+    if isinstance(lic, list):
+        lic = lic[0] if lic else None
+    # "" distinguishes "the Hub declares no licence" from None ("could not ask").
+    return str(lic).lower() if lic else ""
+
+
+def main() -> int:
+    drifted: list[str] = []
+    unknown = 0
+    for model, expected in EXPECTED.items():
+        actual = fetch_licence(model)
+        if actual is None:
+            unknown += 1
+            continue
+        if actual != expected:
+            hub = actual or "none declared"
+            want = expected or "none declared"
+            drifted.append(f"  !  {model}: docs say {want}, Hub says {hub}")
+        else:
+            print(f"  ok {model}: {actual or 'no licence declared upstream'}")
+
+    if drifted:
+        print("\nLicence drift detected:")
+        print("\n".join(drifted))
+        print(
+            "\nUpdate apps/protspace/CLAUDE.md, apps/protspace/docs/cli.md, the CLI help in\n"
+            "cli/embed.py and cli/prepare.py, and the embedder hint in the Preparation notebook."
+        )
+        return 1
+
+    if unknown:
+        print(f"\n{unknown} model(s) could not be checked; treating as inconclusive, not failing.")
+    print("\nAll checkable model licences match the documentation.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/apps/protspace/scripts/check_wheels.py
+++ b/apps/protspace/scripts/check_wheels.py
@@ -1,0 +1,62 @@
+"""Fail if any locked dependency can never install from a wheel.
+
+A package that publishes no wheel for our ``requires-python`` is compiled from
+sdist on every install, for every user, forever -- and nothing else in CI
+notices, because a source build succeeds. ``pymmseqs`` sat in the core
+dependencies for months publishing cp310-only wheels against a ``>=3.12``
+floor; ``dash-treeview-antd`` did the same from a 2018 sdist.
+
+Reads ``uv.lock`` only: no network, no resolution, ~0.1s.
+"""
+
+from __future__ import annotations
+
+import sys
+import tomllib
+from pathlib import Path
+
+# Packages knowingly built from source. Keep this list short and justified --
+# every entry is a per-install compile that someone pays for.
+ALLOWED: dict[str, str] = {
+    "pymmseqs": (
+        "cp310-only wheels across all releases. Confined to the optional "
+        "'similarity' extra, so it is opt-in rather than paid by every install. "
+        "Upstream asked for 3.12+ wheels -- see issue #396."
+    ),
+}
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+
+
+def main() -> int:
+    lock_path = REPO_ROOT / "uv.lock"
+    lock = tomllib.loads(lock_path.read_text())
+
+    offenders: list[tuple[str, str]] = []
+    for pkg in lock.get("package", []):
+        source = pkg.get("source", {})
+        if "registry" not in source:
+            continue  # workspace members and direct URLs have no wheels to check
+        name, version = pkg["name"], pkg.get("version", "?")
+        if pkg.get("wheels"):
+            continue
+        if name in ALLOWED:
+            continue
+        offenders.append((name, version))
+
+    if not offenders:
+        print(f"OK: every registry package in {lock_path.name} ships at least one wheel")
+        return 0
+
+    print("Locked packages with NO wheel on PyPI (compiled from sdist on every install):")
+    for name, version in sorted(offenders):
+        print(f"  - {name} {version}")
+    print(
+        "\nEither drop the dependency, move it behind an extra, ask upstream for wheels,\n"
+        "or add it to ALLOWED in this script with a reason."
+    )
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/uv.lock
+++ b/uv.lock
@@ -968,6 +968,29 @@ wheels = [
 ]
 
 [[package]]
+name = "deptry"
+version = "0.25.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "packaging" },
+    { name = "requirements-parser" },
+    { name = "tomli", marker = "python_full_version < '3.15'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b8/b2/50ccc99362ae7757342978b7ecb3b98e47fade721fd617d74db1948ec3a1/deptry-0.25.1.tar.gz", hash = "sha256:45c8cd982c85cd4faae573ddff6920de7eec735336db6973f26a765ae7950f7d", size = 509748, upload-time = "2026-03-18T23:22:18.139Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/33/1d/b538dc635e873b25360d761cfe1fa0ccd7d6c69b698047e552f33401e60d/deptry-0.25.1-cp310-abi3-macosx_10_12_x86_64.whl", hash = "sha256:a4dd1148db24a1ddacfa8b840836c6019c2f864fcb7579dd089fd217606338c8", size = 1850319, upload-time = "2026-03-18T23:22:15.65Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/a9/511477a8f0ae4f6021d68a80bdca77e7ffb0722008dc24ee5d9ef49f5c88/deptry-0.25.1-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:c67c666d916ef12013c0772e40d78be0f21577a495d8d99ec5fcb18c332d393d", size = 1759259, upload-time = "2026-03-18T23:22:30.853Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/4b/c9f0bdda410912a6df79a789cb118fa29acae02a397794ead3c84adcda5c/deptry-0.25.1-cp310-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:58d39279828dbf4efc1abb40bf50a71b21499c36759bed5a8d8a3c0e3149b091", size = 1872012, upload-time = "2026-03-18T23:22:19.145Z" },
+    { url = "https://files.pythonhosted.org/packages/72/9c/6f6f9125bac74b5d5d2af89536cbdb3fa159b6466aa097b74e7e85e8e030/deptry-0.25.1-cp310-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:14bfcc28b4326ed8c6abb30691b19077d4ef8613cfba6c37ef5b1f471775bf6f", size = 1926575, upload-time = "2026-03-18T23:22:11.269Z" },
+    { url = "https://files.pythonhosted.org/packages/52/48/2a5e705a7f898295966ade67bd1223e2af96da433e25b39f6b9483ba2c7b/deptry-0.25.1-cp310-abi3-musllinux_1_1_aarch64.whl", hash = "sha256:555f5f9a487899ec9bf301eecba1745e14d212c4b354f4d3a5fd691e907366d3", size = 2050816, upload-time = "2026-03-18T23:22:27.439Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/c6/50f189a894e1f3bf21266299112c8a06cb731838976e1b9a9cadd0b4a86e/deptry-0.25.1-cp310-abi3-musllinux_1_1_x86_64.whl", hash = "sha256:18d21b3545ab2bfec53f3f45c6f5f201d55f713323327f8d12674505469ae6b7", size = 2145416, upload-time = "2026-03-18T23:22:24.682Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/6a/3f82f7a06217778282bc4456af1b4ffb3bc4b2c8e7891d00e8323f9ad0b8/deptry-0.25.1-cp310-abi3-win_amd64.whl", hash = "sha256:b59a560cb7dffb21832a98bb80d33d614cfb5630ea36ce21833eabf4eae3df99", size = 1718489, upload-time = "2026-03-18T23:22:28.589Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/7f/cd6b3ac8cf95f2f1c5c7a74ff6452e9098af89a9b56607381f677880641e/deptry-0.25.1-cp310-abi3-win_arm64.whl", hash = "sha256:6efffd8116fb9d2c45a251382ce4ce1c38dbb17179f581ec9231ed5390f7fc12", size = 1647020, upload-time = "2026-03-18T23:22:23.311Z" },
+]
+
+[[package]]
 name = "detect-installer"
 version = "0.1.0"
 source = { registry = "https://pypi.org/simple" }
@@ -3327,6 +3350,7 @@ dev = [
     { name = "cairosvg" },
     { name = "dash", extra = ["testing"] },
     { name = "dash-mantine-components" },
+    { name = "deptry" },
     { name = "holoviews" },
     { name = "hvplot" },
     { name = "ijson" },
@@ -3382,6 +3406,7 @@ dev = [
     { name = "cairosvg", specifier = ">=2.7.1" },
     { name = "dash", extras = ["testing"], specifier = ">=3" },
     { name = "dash-mantine-components", specifier = ">=0.14.5" },
+    { name = "deptry", specifier = ">=0.25.1" },
     { name = "holoviews", specifier = ">=1.19.1" },
     { name = "hvplot", specifier = ">=0.11.0" },
     { name = "ijson", specifier = ">=3.3.0" },
@@ -4057,6 +4082,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/ac/c3/e2a2b89f2d3e2179abd6d00ebd70bff6273f37fb3e0cc209f48b39d00cbf/requests-2.34.2.tar.gz", hash = "sha256:f288924cae4e29463698d6d60bc6a4da69c89185ad1e0bcc4104f584e960b9ed", size = 142856, upload-time = "2026-05-14T19:25:27.735Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a0/f4/c67b0b3f1b9245e8d266f0f112c500d50e5b4e83cb6f3b71b6528104182a/requests-2.34.2-py3-none-any.whl", hash = "sha256:2a0d60c172f83ac6ab31e4554906c0f3b3588d37b5cb939b1c061f4907e278e0", size = 73075, upload-time = "2026-05-14T19:25:26.443Z" },
+]
+
+[[package]]
+name = "requirements-parser"
+version = "0.13.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "packaging" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/89/1a/5f3c22d38bf1d87d1f4a961489d9eba35c4370a21395562d94410cdd0e73/requirements_parser-0.13.1.tar.gz", hash = "sha256:78811383b2089b6c5197a1431bc2c12ff950245edca39a23eea3460782038dd3", size = 22783, upload-time = "2026-06-18T07:52:25.291Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bb/f9/15b44d5e4401b0013bbcefe3c09d7bfddcce28cc3d41b1d3077bcedf5b1f/requirements_parser-0.13.1-py3-none-any.whl", hash = "sha256:6e385663eb32589d16e5b22bb6e5251a57908e73803ffff438b53cd6ea2056e0", size = 14926, upload-time = "2026-06-18T07:52:24.171Z" },
 ]
 
 [[package]]
@@ -4751,6 +4788,51 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/fd/18/a545c4ea42af3df6effd7d13d250ba77a0a86fb20393143bbb9a92e434d4/tokenizers-0.22.2-cp39-abi3-win32.whl", hash = "sha256:a6bf3f88c554a2b653af81f3204491c818ae2ac6fbc09e76ef4773351292bc92", size = 2502363, upload-time = "2026-01-05T10:45:20.593Z" },
     { url = "https://files.pythonhosted.org/packages/65/71/0670843133a43d43070abeb1949abfdef12a86d490bea9cd9e18e37c5ff7/tokenizers-0.22.2-cp39-abi3-win_amd64.whl", hash = "sha256:c9ea31edff2968b44a88f97d784c2f16dc0729b8b143ed004699ebca91f05c48", size = 2747786, upload-time = "2026-01-05T10:45:18.411Z" },
     { url = "https://files.pythonhosted.org/packages/72/f4/0de46cfa12cdcbcd464cc59fde36912af405696f687e53a091fb432f694c/tokenizers-0.22.2-cp39-abi3-win_arm64.whl", hash = "sha256:9ce725d22864a1e965217204946f830c37876eee3b2ba6fc6255e8e903d5fcbc", size = 2612133, upload-time = "2026-01-05T10:45:17.232Z" },
+]
+
+[[package]]
+name = "tomli"
+version = "2.4.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/22/de/48c59722572767841493b26183a0d1cc411d54fd759c5607c4590b6563a6/tomli-2.4.1.tar.gz", hash = "sha256:7c7e1a961a0b2f2472c1ac5b69affa0ae1132c39adcb67aba98568702b9cc23f", size = 17543, upload-time = "2026-03-25T20:22:03.828Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c1/ba/42f134a3fe2b370f555f44b1d72feebb94debcab01676bf918d0cb70e9aa/tomli-2.4.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:c742f741d58a28940ce01d58f0ab2ea3ced8b12402f162f4d534dfe18ba1cd6a", size = 155924, upload-time = "2026-03-25T20:21:21.626Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/c7/62d7a17c26487ade21c5422b646110f2162f1fcc95980ef7f63e73c68f14/tomli-2.4.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:7f86fd587c4ed9dd76f318225e7d9b29cfc5a9d43de44e5754db8d1128487085", size = 150018, upload-time = "2026-03-25T20:21:23.002Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/05/79d13d7c15f13bdef410bdd49a6485b1c37d28968314eabee452c22a7fda/tomli-2.4.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ff18e6a727ee0ab0388507b89d1bc6a22b138d1e2fa56d1ad494586d61d2eae9", size = 244948, upload-time = "2026-03-25T20:21:24.04Z" },
+    { url = "https://files.pythonhosted.org/packages/10/90/d62ce007a1c80d0b2c93e02cab211224756240884751b94ca72df8a875ca/tomli-2.4.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:136443dbd7e1dee43c68ac2694fde36b2849865fa258d39bf822c10e8068eac5", size = 253341, upload-time = "2026-03-25T20:21:25.177Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/7e/caf6496d60152ad4ed09282c1885cca4eea150bfd007da84aea07bcc0a3e/tomli-2.4.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:5e262d41726bc187e69af7825504c933b6794dc3fbd5945e41a79bb14c31f585", size = 248159, upload-time = "2026-03-25T20:21:26.364Z" },
+    { url = "https://files.pythonhosted.org/packages/99/e7/c6f69c3120de34bbd882c6fba7975f3d7a746e9218e56ab46a1bc4b42552/tomli-2.4.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:5cb41aa38891e073ee49d55fbc7839cfdb2bc0e600add13874d048c94aadddd1", size = 253290, upload-time = "2026-03-25T20:21:27.46Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/2f/4a3c322f22c5c66c4b836ec58211641a4067364f5dcdd7b974b4c5da300c/tomli-2.4.1-cp312-cp312-win32.whl", hash = "sha256:da25dc3563bff5965356133435b757a795a17b17d01dbc0f42fb32447ddfd917", size = 98141, upload-time = "2026-03-25T20:21:28.492Z" },
+    { url = "https://files.pythonhosted.org/packages/24/22/4daacd05391b92c55759d55eaee21e1dfaea86ce5c571f10083360adf534/tomli-2.4.1-cp312-cp312-win_amd64.whl", hash = "sha256:52c8ef851d9a240f11a88c003eacb03c31fc1c9c4ec64a99a0f922b93874fda9", size = 108847, upload-time = "2026-03-25T20:21:29.386Z" },
+    { url = "https://files.pythonhosted.org/packages/68/fd/70e768887666ddd9e9f5d85129e84910f2db2796f9096aa02b721a53098d/tomli-2.4.1-cp312-cp312-win_arm64.whl", hash = "sha256:f758f1b9299d059cc3f6546ae2af89670cb1c4d48ea29c3cacc4fe7de3058257", size = 95088, upload-time = "2026-03-25T20:21:30.677Z" },
+    { url = "https://files.pythonhosted.org/packages/07/06/b823a7e818c756d9a7123ba2cda7d07bc2dd32835648d1a7b7b7a05d848d/tomli-2.4.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:36d2bd2ad5fb9eaddba5226aa02c8ec3fa4f192631e347b3ed28186d43be6b54", size = 155866, upload-time = "2026-03-25T20:21:31.65Z" },
+    { url = "https://files.pythonhosted.org/packages/14/6f/12645cf7f08e1a20c7eb8c297c6f11d31c1b50f316a7e7e1e1de6e2e7b7e/tomli-2.4.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:eb0dc4e38e6a1fd579e5d50369aa2e10acfc9cace504579b2faabb478e76941a", size = 149887, upload-time = "2026-03-25T20:21:33.028Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/e0/90637574e5e7212c09099c67ad349b04ec4d6020324539297b634a0192b0/tomli-2.4.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c7f2c7f2b9ca6bdeef8f0fa897f8e05085923eb091721675170254cbc5b02897", size = 243704, upload-time = "2026-03-25T20:21:34.51Z" },
+    { url = "https://files.pythonhosted.org/packages/10/8f/d3ddb16c5a4befdf31a23307f72828686ab2096f068eaf56631e136c1fdd/tomli-2.4.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f3c6818a1a86dd6dca7ddcaaf76947d5ba31aecc28cb1b67009a5877c9a64f3f", size = 251628, upload-time = "2026-03-25T20:21:36.012Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/f1/dbeeb9116715abee2485bf0a12d07a8f31af94d71608c171c45f64c0469d/tomli-2.4.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:d312ef37c91508b0ab2cee7da26ec0b3ed2f03ce12bd87a588d771ae15dcf82d", size = 247180, upload-time = "2026-03-25T20:21:37.136Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/74/16336ffd19ed4da28a70959f92f506233bd7cfc2332b20bdb01591e8b1d1/tomli-2.4.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:51529d40e3ca50046d7606fa99ce3956a617f9b36380da3b7f0dd3dd28e68cb5", size = 251674, upload-time = "2026-03-25T20:21:38.298Z" },
+    { url = "https://files.pythonhosted.org/packages/16/f9/229fa3434c590ddf6c0aa9af64d3af4b752540686cace29e6281e3458469/tomli-2.4.1-cp313-cp313-win32.whl", hash = "sha256:2190f2e9dd7508d2a90ded5ed369255980a1bcdd58e52f7fe24b8162bf9fedbd", size = 97976, upload-time = "2026-03-25T20:21:39.316Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/1e/71dfd96bcc1c775420cb8befe7a9d35f2e5b1309798f009dca17b7708c1e/tomli-2.4.1-cp313-cp313-win_amd64.whl", hash = "sha256:8d65a2fbf9d2f8352685bc1364177ee3923d6baf5e7f43ea4959d7d8bc326a36", size = 108755, upload-time = "2026-03-25T20:21:40.248Z" },
+    { url = "https://files.pythonhosted.org/packages/83/7a/d34f422a021d62420b78f5c538e5b102f62bea616d1d75a13f0a88acb04a/tomli-2.4.1-cp313-cp313-win_arm64.whl", hash = "sha256:4b605484e43cdc43f0954ddae319fb75f04cc10dd80d830540060ee7cd0243cd", size = 95265, upload-time = "2026-03-25T20:21:41.219Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/fb/9a5c8d27dbab540869f7c1f8eb0abb3244189ce780ba9cd73f3770662072/tomli-2.4.1-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:fd0409a3653af6c147209d267a0e4243f0ae46b011aa978b1080359fddc9b6cf", size = 155726, upload-time = "2026-03-25T20:21:42.23Z" },
+    { url = "https://files.pythonhosted.org/packages/62/05/d2f816630cc771ad836af54f5001f47a6f611d2d39535364f148b6a92d6b/tomli-2.4.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:a120733b01c45e9a0c34aeef92bf0cf1d56cfe81ed9d47d562f9ed591a9828ac", size = 149859, upload-time = "2026-03-25T20:21:43.386Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/48/66341bdb858ad9bd0ceab5a86f90eddab127cf8b046418009f2125630ecb/tomli-2.4.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:559db847dc486944896521f68d8190be1c9e719fced785720d2216fe7022b662", size = 244713, upload-time = "2026-03-25T20:21:44.474Z" },
+    { url = "https://files.pythonhosted.org/packages/df/6d/c5fad00d82b3c7a3ab6189bd4b10e60466f22cfe8a08a9394185c8a8111c/tomli-2.4.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:01f520d4f53ef97964a240a035ec2a869fe1a37dde002b57ebc4417a27ccd853", size = 252084, upload-time = "2026-03-25T20:21:45.62Z" },
+    { url = "https://files.pythonhosted.org/packages/00/71/3a69e86f3eafe8c7a59d008d245888051005bd657760e96d5fbfb0b740c2/tomli-2.4.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:7f94b27a62cfad8496c8d2513e1a222dd446f095fca8987fceef261225538a15", size = 247973, upload-time = "2026-03-25T20:21:46.937Z" },
+    { url = "https://files.pythonhosted.org/packages/67/50/361e986652847fec4bd5e4a0208752fbe64689c603c7ae5ea7cb16b1c0ca/tomli-2.4.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:ede3e6487c5ef5d28634ba3f31f989030ad6af71edfb0055cbbd14189ff240ba", size = 256223, upload-time = "2026-03-25T20:21:48.467Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/9a/b4173689a9203472e5467217e0154b00e260621caa227b6fa01feab16998/tomli-2.4.1-cp314-cp314-win32.whl", hash = "sha256:3d48a93ee1c9b79c04bb38772ee1b64dcf18ff43085896ea460ca8dec96f35f6", size = 98973, upload-time = "2026-03-25T20:21:49.526Z" },
+    { url = "https://files.pythonhosted.org/packages/14/58/640ac93bf230cd27d002462c9af0d837779f8773bc03dee06b5835208214/tomli-2.4.1-cp314-cp314-win_amd64.whl", hash = "sha256:88dceee75c2c63af144e456745e10101eb67361050196b0b6af5d717254dddf7", size = 109082, upload-time = "2026-03-25T20:21:50.506Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/2f/702d5e05b227401c1068f0d386d79a589bb12bf64c3d2c72ce0631e3bc49/tomli-2.4.1-cp314-cp314-win_arm64.whl", hash = "sha256:b8c198f8c1805dc42708689ed6864951fd2494f924149d3e4bce7710f8eb5232", size = 96490, upload-time = "2026-03-25T20:21:51.474Z" },
+    { url = "https://files.pythonhosted.org/packages/45/4b/b877b05c8ba62927d9865dd980e34a755de541eb65fffba52b4cc495d4d2/tomli-2.4.1-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:d4d8fe59808a54658fcc0160ecfb1b30f9089906c50b23bcb4c69eddc19ec2b4", size = 164263, upload-time = "2026-03-25T20:21:52.543Z" },
+    { url = "https://files.pythonhosted.org/packages/24/79/6ab420d37a270b89f7195dec5448f79400d9e9c1826df982f3f8e97b24fd/tomli-2.4.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:7008df2e7655c495dd12d2a4ad038ff878d4ca4b81fccaf82b714e07eae4402c", size = 160736, upload-time = "2026-03-25T20:21:53.674Z" },
+    { url = "https://files.pythonhosted.org/packages/02/e0/3630057d8eb170310785723ed5adcdfb7d50cb7e6455f85ba8a3deed642b/tomli-2.4.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1d8591993e228b0c930c4bb0db464bdad97b3289fb981255d6c9a41aedc84b2d", size = 270717, upload-time = "2026-03-25T20:21:55.129Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/b4/1613716072e544d1a7891f548d8f9ec6ce2faf42ca65acae01d76ea06bb0/tomli-2.4.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:734e20b57ba95624ecf1841e72b53f6e186355e216e5412de414e3c51e5e3c41", size = 278461, upload-time = "2026-03-25T20:21:56.228Z" },
+    { url = "https://files.pythonhosted.org/packages/05/38/30f541baf6a3f6df77b3df16b01ba319221389e2da59427e221ef417ac0c/tomli-2.4.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:8a650c2dbafa08d42e51ba0b62740dae4ecb9338eefa093aa5c78ceb546fcd5c", size = 274855, upload-time = "2026-03-25T20:21:57.653Z" },
+    { url = "https://files.pythonhosted.org/packages/77/a3/ec9dd4fd2c38e98de34223b995a3b34813e6bdadf86c75314c928350ed14/tomli-2.4.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:504aa796fe0569bb43171066009ead363de03675276d2d121ac1a4572397870f", size = 283144, upload-time = "2026-03-25T20:21:59.089Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/be/605a6261cac79fba2ec0c9827e986e00323a1945700969b8ee0b30d85453/tomli-2.4.1-cp314-cp314t-win32.whl", hash = "sha256:b1d22e6e9387bf4739fbe23bfa80e93f6b0373a7f1b96c6227c32bef95a4d7a8", size = 108683, upload-time = "2026-03-25T20:22:00.214Z" },
+    { url = "https://files.pythonhosted.org/packages/12/64/da524626d3b9cc40c168a13da8335fe1c51be12c0a63685cc6db7308daae/tomli-2.4.1-cp314-cp314t-win_amd64.whl", hash = "sha256:2c1c351919aca02858f740c6d33adea0c5deea37f9ecca1cc1ef9e884a619d26", size = 121196, upload-time = "2026-03-25T20:22:01.169Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/cd/e80b62269fc78fc36c9af5a6b89c835baa8af28ff5ad28c7028d60860320/tomli-2.4.1-cp314-cp314t-win_arm64.whl", hash = "sha256:eab21f45c7f66c13f2a9e0e1535309cee140182a9cdae1e041d02e47291e8396", size = 100393, upload-time = "2026-03-25T20:22:02.137Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/61/cceae43728b7de99d9b847560c262873a1f6c98202171fd5ed62640b494b/tomli-2.4.1-py3-none-any.whl", hash = "sha256:0d85819802132122da43cb86656f8d1f8c6587d54ae7dcaf30e90533028b49fe", size = 14583, upload-time = "2026-03-25T20:22:03.012Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Three cheap CI checks aimed at the dependency problems a version-bump bot cannot see.

Stacked on #391 (base it there or rebase onto main after that merges).

## Why not just add Dependabot/Renovate

A bump bot would have caught **none** of this week's four dependency problems, because in every case the version in use was already current. They were constraint-*shape* problems:

| What went wrong | What actually catches it |
| --- | --- |
| `pymmseqs` cp310-only wheels vs `requires-python>=3.12` → compiled from sdist for every user | `check_wheels.py` |
| its transitive `ipython<9` cap → Colab conflict wall | same check, transitively |
| `rich`/`protobuf` floors on packages we never import → 5 of 6 conflict warnings | `deptry` |
| ESM-C relicensed non-commercial → MIT, docs stale 2 months | `check_model_licences.py` |

Renovate is still worth adopting for staleness and CVEs (notably the never-updated pinned GitHub Actions), but it needs a GitHub App install, and it addresses a different failure class. These guards are the ones that pay for the week that prompted them.

## The checks

**`check_wheels.py`** — reads `uv.lock` offline (~0.1 s), fails on any registry package publishing no wheel at all. A source build *succeeds*, so nothing else in CI notices. It flags `pymmseqs` today, recorded as a documented exception rather than a permanently red build: it's confined to the optional `similarity` extra, and upstream has been asked for 3.12+ wheels (#396). Deleting that allowlist entry makes the check fail again — verified, that's the tripwire.

**`deptry`** — the Python analogue of the `knip` that `pnpm quality` already runs on the JS side. Run against the tree as it was, it returns exactly `rich` and `protobuf`. The four remaining `DEP002` entries are runtime requirements of packages we *do* import (`kaleido`, `einops`, `protobuf`, `sentencepiece`), each justified inline; the `DEP001` hit is stdlib `import __main__`.

**`check_model_licences.py`** — weekly, asks the HuggingFace Hub whether the twelve documented checkpoint licences still match the docs. Model weights aren't Python dependencies, so no SCA, SBOM or dependency bot can see them; this is the only thing that would have caught ESM-C, and within a week rather than two months. Standard library only, and a network failure is inconclusive rather than fatal.

## One finding worth knowing

`Rostlab/prot_t5_xl_uniref50` — the **default embedder** — declares no licence at all on its model card, while our table asserts MIT. Encoded as expected-for-now so that a licence appearing later gets flagged rather than silently disagreeing. Not changed in docs, since MIT rests on the paper/repo rather than Hub metadata and that's your call.

## Verification

The new lint steps reproduced locally: ruff clean, `deptry` clean, wheel check passes, 787 tests pass, `pnpm precommit` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019TxEAVCkBQmh3Yy6bPXPSE
