### PR TITLE
fix(explore): preserve shape size across projection reloads

### DIFF
--- a/apps/web/src/explore/dataset-controller.eat.test.ts
+++ b/apps/web/src/explore/dataset-controller.eat.test.ts
@@ -122,7 +122,7 @@ describe('dataset controller', () => {
 
   describe('EAT settings restore', () => {
     it('applies embedded EAT settings after an OPFS reload while retaining OPFS legend precedence', async () => {
-      const { controlBar, controller, legendElement, plotElement } = createControllerHarness({
+      const { controlBar, controller, legendElement } = createControllerHarness({
         loadQueue: {
           getRunningLoadMeta: () => ({ sequence: 7, kind: 'opfs' as const }),
           getLatestSequence: () => 7,

--- a/apps/web/src/explore/dataset-controller.eat.test.ts
+++ b/apps/web/src/explore/dataset-controller.eat.test.ts
@@ -5,7 +5,9 @@ import { createEmptyExploreViewRequest } from './url-state';
 const mocks = vi.hoisted(() => ({
   loadData: vi.fn(),
   markLastLoadStatus: vi.fn(),
+  readTooltipAnnotations: vi.fn(() => [] as string[]),
   resolvePendingLoadFinalization: vi.fn(),
+  writeTooltipAnnotations: vi.fn(),
 }));
 
 vi.mock('./data-renderer', () => ({
@@ -28,8 +30,8 @@ vi.mock('./opfs-dataset-store', () => ({
 }));
 
 vi.mock('./tooltip-annotations-store', () => ({
-  readTooltipAnnotations: () => [],
-  writeTooltipAnnotations: vi.fn(),
+  readTooltipAnnotations: mocks.readTooltipAnnotations,
+  writeTooltipAnnotations: mocks.writeTooltipAnnotations,
 }));
 
 import { createDatasetController } from './dataset-controller';
@@ -49,173 +51,205 @@ const data: VisualizationData = {
   annotation_data: { ec: new Int32Array([0]) },
 };
 
-describe('dataset controller EAT settings restore', () => {
+type DatasetControllerOptions = Parameters<typeof createDatasetController>[0];
+
+function createControllerHarness({
+  getLatestViewRequest = () => createEmptyExploreViewRequest(),
+  loadQueue: loadQueueOverrides = {},
+}: {
+  getLatestViewRequest?: () => ReturnType<typeof createEmptyExploreViewRequest>;
+  loadQueue?: Partial<DatasetControllerOptions['loadQueue']>;
+} = {}) {
+  const controlBar = {
+    clearForNewDataset: vi.fn(),
+    hasFileSettings: false,
+  };
+  const legendElement = {
+    clearForNewDataset: vi.fn(),
+    setFileSettings: vi.fn(),
+    applyEatSettings: vi.fn(),
+  };
+  const plotElement = {
+    eatOverlayEnabled: true,
+  };
+  const viewController = {
+    subscribeToViewChanges: vi.fn(() => () => {}),
+    resolveLatestView: vi.fn(),
+    getLatestViewRequest: vi.fn(getLatestViewRequest),
+    applyLatestViewForDatasetLoad: vi.fn(),
+    setRequestedView: vi.fn(),
+  };
+  const loadQueue = {
+    registerFileLoad: vi.fn(),
+    getLoadMetaForFile: vi.fn(),
+    getRunningLoadMeta: () => null,
+    getLatestSequence: () => 0,
+    resolvePendingLoadFinalization: mocks.resolvePendingLoadFinalization,
+    ...loadQueueOverrides,
+  };
+  const options = {
+    controlBar,
+    dataLoader: {},
+    defaultDatasetName: 'default.parquetbundle',
+    getIsDisposed: () => false,
+    interactionController: {},
+    legendElement,
+    loadQueue,
+    overlayController: { update: vi.fn() },
+    plotElement,
+    setCurrentDatasetIsDemo: vi.fn(),
+    setCurrentDatasetName: vi.fn(),
+    structureViewer: {},
+    viewController,
+  } as unknown as DatasetControllerOptions;
+
+  return {
+    controlBar,
+    controller: createDatasetController(options),
+    legendElement,
+    plotElement,
+    viewController,
+  };
+}
+
+describe('dataset controller', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mocks.loadData.mockResolvedValue(undefined);
     mocks.markLastLoadStatus.mockResolvedValue(undefined);
+    mocks.readTooltipAnnotations.mockReturnValue([]);
   });
 
-  it('applies embedded EAT settings after an OPFS reload while retaining OPFS legend precedence', async () => {
-    const controlBar = {
-      clearForNewDataset: vi.fn(),
-      hasFileSettings: false,
-    };
-    const legendElement = {
-      clearForNewDataset: vi.fn(),
-      setFileSettings: vi.fn(),
-      applyEatSettings: vi.fn(),
-    };
-    const plotElement = {
-      eatOverlayEnabled: true,
-    };
-    const viewController = {
-      subscribeToViewChanges: vi.fn(() => () => {}),
-      resolveLatestView: vi.fn(),
-      getLatestViewRequest: vi.fn(() => createEmptyExploreViewRequest()),
-      applyLatestViewForDatasetLoad: vi.fn(),
-      setRequestedView: vi.fn(),
-    };
-    const options = {
-      controlBar,
-      dataLoader: {},
-      defaultDatasetName: 'default.parquetbundle',
-      getIsDisposed: () => false,
-      interactionController: {},
-      legendElement,
-      loadQueue: {
-        registerFileLoad: vi.fn(),
-        getLoadMetaForFile: vi.fn(),
-        getRunningLoadMeta: () => ({ sequence: 7, kind: 'opfs' as const }),
-        getLatestSequence: () => 7,
-        resolvePendingLoadFinalization: mocks.resolvePendingLoadFinalization,
-      },
-      overlayController: { update: vi.fn() },
-      plotElement,
-      setCurrentDatasetIsDemo: vi.fn(),
-      setCurrentDatasetName: vi.fn(),
-      structureViewer: {},
-      viewController,
-    } as unknown as Parameters<typeof createDatasetController>[0];
-    const controller = createDatasetController(options);
-
-    await controller.handleDataLoaded({
-      detail: {
-        data,
-        settings: {
-          legendSettings: { ec: { categories: {} } },
-          exportOptions: {},
-          eatOverlayEnabled: false,
-          eatConfidenceThreshold: 0.75,
+  describe('EAT settings restore', () => {
+    it('applies embedded EAT settings after an OPFS reload while retaining OPFS legend precedence', async () => {
+      const { controlBar, controller, legendElement, plotElement } = createControllerHarness({
+        loadQueue: {
+          getRunningLoadMeta: () => ({ sequence: 7, kind: 'opfs' as const }),
+          getLatestSequence: () => 7,
         },
-        source: 'auto',
-      },
-    } as unknown as Event);
+      });
 
-    expect(controlBar.clearForNewDataset).toHaveBeenCalledOnce();
-    expect(legendElement.applyEatSettings).toHaveBeenCalledWith(false, 0.75);
-    expect(controlBar.hasFileSettings).toBe(true);
-    expect(legendElement.setFileSettings).not.toHaveBeenCalled();
-    expect(mocks.markLastLoadStatus).toHaveBeenCalledWith('success');
-    expect(mocks.resolvePendingLoadFinalization).toHaveBeenCalledWith(7);
+      await controller.handleDataLoaded({
+        detail: {
+          data,
+          settings: {
+            legendSettings: { ec: { categories: {} } },
+            exportOptions: {},
+            eatOverlayEnabled: false,
+            eatConfidenceThreshold: 0.75,
+          },
+          source: 'auto',
+        },
+      } as unknown as Event);
 
-    await controller.handleDataLoaded({
-      detail: {
+      expect(controlBar.clearForNewDataset).toHaveBeenCalledOnce();
+      expect(legendElement.applyEatSettings).toHaveBeenCalledWith(false, 0.75);
+      expect(controlBar.hasFileSettings).toBe(true);
+      expect(legendElement.setFileSettings).not.toHaveBeenCalled();
+      expect(mocks.markLastLoadStatus).toHaveBeenCalledWith('success');
+      expect(mocks.resolvePendingLoadFinalization).toHaveBeenCalledWith(7);
+
+      await controller.handleDataLoaded({
+        detail: {
+          data,
+          settings: {
+            legendSettings: {},
+            exportOptions: {},
+            eatOverlayEnabled: true,
+          },
+          source: 'auto',
+        },
+      } as unknown as Event);
+      expect(legendElement.applyEatSettings).toHaveBeenLastCalledWith(
+        true,
+        DEFAULT_EAT_CONFIDENCE_THRESHOLD,
+      );
+    });
+  });
+
+  describe('legend persistence lifecycle', () => {
+    it('reuses dataset lifecycle across initial load, user import, and explicit reset', async () => {
+      let latestViewRequest = createEmptyExploreViewRequest();
+      const { controlBar, controller, legendElement, viewController } = createControllerHarness({
+        getLatestViewRequest: () => latestViewRequest,
+        loadQueue: {
+          getLoadMetaForFile: vi.fn(() => ({ sequence: 1, kind: 'user' as const })),
+        },
+      });
+      const defaultEventDetail = {
         data,
         settings: {
           legendSettings: {},
           exportOptions: {},
-          eatOverlayEnabled: true,
         },
-        source: 'auto',
-      },
-    } as unknown as Event);
-    expect(legendElement.applyEatSettings).toHaveBeenLastCalledWith(
-      true,
-      DEFAULT_EAT_CONFIDENCE_THRESHOLD,
-    );
-  });
+        source: 'auto' as const,
+      };
+      const event = { detail: defaultEventDetail } as unknown as Event;
 
-  it('reuses dataset lifecycle across initial load, user import, and explicit reset', async () => {
-    const controlBar = {
-      clearForNewDataset: vi.fn(),
-      hasFileSettings: false,
-    };
-    const legendElement = {
-      clearForNewDataset: vi.fn(),
-      setFileSettings: vi.fn(),
-      applyEatSettings: vi.fn(),
-    };
-    let latestViewRequest = createEmptyExploreViewRequest();
-    const viewController = {
-      subscribeToViewChanges: vi.fn(() => () => {}),
-      resolveLatestView: vi.fn(),
-      getLatestViewRequest: vi.fn(() => latestViewRequest),
-      applyLatestViewForDatasetLoad: vi.fn(),
-      setRequestedView: vi.fn(),
-    };
-    const options = {
-      controlBar,
-      dataLoader: {},
-      defaultDatasetName: 'default.parquetbundle',
-      getIsDisposed: () => false,
-      interactionController: {},
-      legendElement,
-      loadQueue: {
-        registerFileLoad: vi.fn(),
-        getLoadMetaForFile: vi.fn(() => ({ sequence: 1, kind: 'user' as const })),
-        getRunningLoadMeta: () => null,
-        getLatestSequence: () => 0,
-        resolvePendingLoadFinalization: mocks.resolvePendingLoadFinalization,
-      },
-      overlayController: { update: vi.fn() },
-      plotElement: { eatOverlayEnabled: true },
-      setCurrentDatasetIsDemo: vi.fn(),
-      setCurrentDatasetName: vi.fn(),
-      structureViewer: {},
-      viewController,
-    } as unknown as Parameters<typeof createDatasetController>[0];
-    const controller = createDatasetController(options);
-    const defaultEventDetail = {
-      data,
-      settings: {
-        legendSettings: {},
-        exportOptions: {},
-      },
-      source: 'auto' as const,
-    };
-    const event = { detail: defaultEventDetail } as unknown as Event;
+      await controller.handleDataLoaded(event);
 
-    await controller.handleDataLoaded(event);
+      expect(legendElement.clearForNewDataset).toHaveBeenNthCalledWith(
+        1,
+        expect.any(String),
+        false,
+      );
+      expect(controlBar.clearForNewDataset).toHaveBeenNthCalledWith(1, expect.any(String), false);
+      expect(legendElement.setFileSettings).toHaveBeenNthCalledWith(
+        1,
+        {},
+        expect.any(String),
+        false,
+      );
 
-    expect(legendElement.clearForNewDataset).toHaveBeenNthCalledWith(1, expect.any(String), false);
-    expect(controlBar.clearForNewDataset).toHaveBeenNthCalledWith(1, expect.any(String), false);
-    expect(legendElement.setFileSettings).toHaveBeenNthCalledWith(1, {}, expect.any(String), false);
+      latestViewRequest = {
+        requested: { tooltip: ['stale-annotation'] },
+        present: { annotation: false, projection: false, tooltip: true },
+        normalize: { annotation: false, projection: false, tooltip: false },
+      };
+      await controller.handleDataLoaded({
+        detail: {
+          ...defaultEventDetail,
+          source: 'user',
+          file: { name: 'custom.parquetbundle' } as File,
+        },
+      } as unknown as Event);
 
-    latestViewRequest = {
-      requested: { tooltip: ['stale-annotation'] },
-      present: { annotation: false, projection: false, tooltip: true },
-      normalize: { annotation: false, projection: false, tooltip: false },
-    };
-    await controller.handleDataLoaded({
-      detail: {
-        ...defaultEventDetail,
-        source: 'user',
-        file: { name: 'custom.parquetbundle' } as File,
-      },
-    } as unknown as Event);
+      expect(legendElement.clearForNewDataset).toHaveBeenNthCalledWith(2, expect.any(String), true);
+      expect(viewController.setRequestedView).toHaveBeenCalledWith({
+        requested: { tooltip: undefined },
+        present: { annotation: false, projection: false, tooltip: false },
+        normalize: { annotation: false, projection: false, tooltip: true },
+      });
 
-    expect(legendElement.clearForNewDataset).toHaveBeenNthCalledWith(2, expect.any(String), true);
-    expect(viewController.setRequestedView).toHaveBeenCalledWith({
-      requested: { tooltip: undefined },
-      present: { annotation: false, projection: false, tooltip: false },
-      normalize: { annotation: false, projection: false, tooltip: true },
+      await controller.handleDataLoaded(event);
+
+      expect(legendElement.clearForNewDataset).toHaveBeenNthCalledWith(3, expect.any(String), true);
+      expect(controlBar.clearForNewDataset).toHaveBeenNthCalledWith(3, expect.any(String), true);
+      expect(legendElement.setFileSettings).toHaveBeenNthCalledWith(
+        3,
+        {},
+        expect.any(String),
+        true,
+      );
     });
 
-    await controller.handleDataLoaded(event);
+    it('restores saved tooltip annotations on an automatic load with a silent URL', async () => {
+      mocks.readTooltipAnnotations.mockReturnValue(['ec']);
+      const { controller, viewController } = createControllerHarness();
 
-    expect(legendElement.clearForNewDataset).toHaveBeenNthCalledWith(3, expect.any(String), true);
-    expect(controlBar.clearForNewDataset).toHaveBeenNthCalledWith(3, expect.any(String), true);
-    expect(legendElement.setFileSettings).toHaveBeenNthCalledWith(3, {}, expect.any(String), true);
+      await controller.handleDataLoaded({
+        detail: {
+          data,
+          settings: { legendSettings: {}, exportOptions: {} },
+          source: 'auto',
+        },
+      } as unknown as Event);
+
+      expect(viewController.setRequestedView).toHaveBeenCalledWith({
+        requested: { tooltip: ['ec'] },
+        present: { annotation: false, projection: false, tooltip: true },
+        normalize: { annotation: false, projection: false, tooltip: false },
+      });
+    });
   });
 });

--- a/apps/web/src/explore/dataset-controller.eat.test.ts
+++ b/apps/web/src/explore/dataset-controller.eat.test.ts
@@ -136,7 +136,7 @@ describe('dataset controller EAT settings restore', () => {
     );
   });
 
-  it('preserves settings on initial default load and clears them on explicit reset', async () => {
+  it('reuses dataset lifecycle across initial load, user import, and explicit reset', async () => {
     const controlBar = {
       clearForNewDataset: vi.fn(),
       hasFileSettings: false,
@@ -146,10 +146,11 @@ describe('dataset controller EAT settings restore', () => {
       setFileSettings: vi.fn(),
       applyEatSettings: vi.fn(),
     };
+    let latestViewRequest = createEmptyExploreViewRequest();
     const viewController = {
       subscribeToViewChanges: vi.fn(() => () => {}),
       resolveLatestView: vi.fn(),
-      getLatestViewRequest: vi.fn(() => createEmptyExploreViewRequest()),
+      getLatestViewRequest: vi.fn(() => latestViewRequest),
       applyLatestViewForDatasetLoad: vi.fn(),
       setRequestedView: vi.fn(),
     };
@@ -162,7 +163,7 @@ describe('dataset controller EAT settings restore', () => {
       legendElement,
       loadQueue: {
         registerFileLoad: vi.fn(),
-        getLoadMetaForFile: vi.fn(),
+        getLoadMetaForFile: vi.fn(() => ({ sequence: 1, kind: 'user' as const })),
         getRunningLoadMeta: () => null,
         getLatestSequence: () => 0,
         resolvePendingLoadFinalization: mocks.resolvePendingLoadFinalization,
@@ -175,16 +176,15 @@ describe('dataset controller EAT settings restore', () => {
       viewController,
     } as unknown as Parameters<typeof createDatasetController>[0];
     const controller = createDatasetController(options);
-    const event = {
-      detail: {
-        data,
-        settings: {
-          legendSettings: {},
-          exportOptions: {},
-        },
-        source: 'auto',
+    const defaultEventDetail = {
+      data,
+      settings: {
+        legendSettings: {},
+        exportOptions: {},
       },
-    } as unknown as Event;
+      source: 'auto' as const,
+    };
+    const event = { detail: defaultEventDetail } as unknown as Event;
 
     await controller.handleDataLoaded(event);
 
@@ -192,10 +192,30 @@ describe('dataset controller EAT settings restore', () => {
     expect(controlBar.clearForNewDataset).toHaveBeenNthCalledWith(1, expect.any(String), false);
     expect(legendElement.setFileSettings).toHaveBeenNthCalledWith(1, {}, expect.any(String), false);
 
-    await controller.handleDataLoaded(event);
+    latestViewRequest = {
+      requested: { tooltip: ['stale-annotation'] },
+      present: { annotation: false, projection: false, tooltip: true },
+      normalize: { annotation: false, projection: false, tooltip: false },
+    };
+    await controller.handleDataLoaded({
+      detail: {
+        ...defaultEventDetail,
+        source: 'user',
+        file: { name: 'custom.parquetbundle' } as File,
+      },
+    } as unknown as Event);
 
     expect(legendElement.clearForNewDataset).toHaveBeenNthCalledWith(2, expect.any(String), true);
-    expect(controlBar.clearForNewDataset).toHaveBeenNthCalledWith(2, expect.any(String), true);
-    expect(legendElement.setFileSettings).toHaveBeenNthCalledWith(2, {}, expect.any(String), true);
+    expect(viewController.setRequestedView).toHaveBeenCalledWith({
+      requested: { tooltip: undefined },
+      present: { annotation: false, projection: false, tooltip: false },
+      normalize: { annotation: false, projection: false, tooltip: true },
+    });
+
+    await controller.handleDataLoaded(event);
+
+    expect(legendElement.clearForNewDataset).toHaveBeenNthCalledWith(3, expect.any(String), true);
+    expect(controlBar.clearForNewDataset).toHaveBeenNthCalledWith(3, expect.any(String), true);
+    expect(legendElement.setFileSettings).toHaveBeenNthCalledWith(3, {}, expect.any(String), true);
   });
 });

--- a/apps/web/src/explore/dataset-controller.eat.test.ts
+++ b/apps/web/src/explore/dataset-controller.eat.test.ts
@@ -135,4 +135,67 @@ describe('dataset controller EAT settings restore', () => {
       DEFAULT_EAT_CONFIDENCE_THRESHOLD,
     );
   });
+
+  it('preserves settings on initial default load and clears them on explicit reset', async () => {
+    const controlBar = {
+      clearForNewDataset: vi.fn(),
+      hasFileSettings: false,
+    };
+    const legendElement = {
+      clearForNewDataset: vi.fn(),
+      setFileSettings: vi.fn(),
+      applyEatSettings: vi.fn(),
+    };
+    const viewController = {
+      subscribeToViewChanges: vi.fn(() => () => {}),
+      resolveLatestView: vi.fn(),
+      getLatestViewRequest: vi.fn(() => createEmptyExploreViewRequest()),
+      applyLatestViewForDatasetLoad: vi.fn(),
+      setRequestedView: vi.fn(),
+    };
+    const options = {
+      controlBar,
+      dataLoader: {},
+      defaultDatasetName: 'default.parquetbundle',
+      getIsDisposed: () => false,
+      interactionController: {},
+      legendElement,
+      loadQueue: {
+        registerFileLoad: vi.fn(),
+        getLoadMetaForFile: vi.fn(),
+        getRunningLoadMeta: () => null,
+        getLatestSequence: () => 0,
+        resolvePendingLoadFinalization: mocks.resolvePendingLoadFinalization,
+      },
+      overlayController: { update: vi.fn() },
+      plotElement: { eatOverlayEnabled: true },
+      setCurrentDatasetIsDemo: vi.fn(),
+      setCurrentDatasetName: vi.fn(),
+      structureViewer: {},
+      viewController,
+    } as unknown as Parameters<typeof createDatasetController>[0];
+    const controller = createDatasetController(options);
+    const event = {
+      detail: {
+        data,
+        settings: {
+          legendSettings: {},
+          exportOptions: {},
+        },
+        source: 'auto',
+      },
+    } as unknown as Event;
+
+    await controller.handleDataLoaded(event);
+
+    expect(legendElement.clearForNewDataset).toHaveBeenNthCalledWith(1, expect.any(String), false);
+    expect(controlBar.clearForNewDataset).toHaveBeenNthCalledWith(1, expect.any(String), false);
+    expect(legendElement.setFileSettings).toHaveBeenNthCalledWith(1, {}, expect.any(String), false);
+
+    await controller.handleDataLoaded(event);
+
+    expect(legendElement.clearForNewDataset).toHaveBeenNthCalledWith(2, expect.any(String), true);
+    expect(controlBar.clearForNewDataset).toHaveBeenNthCalledWith(2, expect.any(String), true);
+    expect(legendElement.setFileSettings).toHaveBeenNthCalledWith(2, {}, expect.any(String), true);
+  });
 });

--- a/apps/web/src/explore/dataset-controller.ts
+++ b/apps/web/src/explore/dataset-controller.ts
@@ -132,8 +132,9 @@ export function createDatasetController({
       }
 
       const datasetHash = generateDatasetHash(data);
+      const hadPreviousDataset = currentDatasetHash !== null;
       const shouldClearPersistedState =
-        (loadMeta.kind === 'default' && currentDatasetHash !== null) ||
+        (loadMeta.kind === 'default' && hadPreviousDataset) ||
         (loadMeta.kind === 'user' && settings != null);
 
       legendElement.clearForNewDataset(datasetHash, shouldClearPersistedState);
@@ -172,7 +173,6 @@ export function createDatasetController({
       // Must be set before the restore block so that any view-change emitted by
       // setRequestedView below is persisted under the new dataset's key, not the
       // previous dataset's key.
-      const hadPreviousDataset = currentDatasetHash !== null;
       currentDatasetHash = datasetHash;
 
       const latestRequest = viewController.getLatestViewRequest();

--- a/apps/web/src/explore/dataset-controller.ts
+++ b/apps/web/src/explore/dataset-controller.ts
@@ -133,7 +133,8 @@ export function createDatasetController({
 
       const datasetHash = generateDatasetHash(data);
       const shouldClearPersistedState =
-        loadMeta.kind === 'default' || (loadMeta.kind === 'user' && settings != null);
+        (loadMeta.kind === 'default' && currentDatasetHash !== null) ||
+        (loadMeta.kind === 'user' && settings != null);
 
       legendElement.clearForNewDataset(datasetHash, shouldClearPersistedState);
       controlBar.clearForNewDataset(datasetHash, shouldClearPersistedState);
@@ -141,7 +142,11 @@ export function createDatasetController({
       await loadData(data);
 
       if (settings && loadMeta.kind !== 'opfs') {
-        legendElement.setFileSettings(settings.legendSettings, datasetHash, true);
+        legendElement.setFileSettings(
+          settings.legendSettings,
+          datasetHash,
+          shouldClearPersistedState,
+        );
       }
       if (settings) {
         const eatOverlayEnabled = settings.eatOverlayEnabled ?? true;

--- a/apps/web/tests/dataset-reload.spec.ts
+++ b/apps/web/tests/dataset-reload.spec.ts
@@ -281,11 +281,35 @@ async function hasLegacyNotificationHelperArtifacts(page: Page): Promise<boolean
   return page.evaluate(() => document.getElementById('protspace-notification-styles') !== null);
 }
 
+async function getShapeSizeState(page: Page) {
+  return page.evaluate(() => {
+    const legend = document.querySelector('protspace-legend') as
+      | (Element & { shapeSize?: number })
+      | null;
+    const plot = document.querySelector('protspace-scatterplot') as
+      | (Element & { config?: { pointSize?: number } })
+      | null;
+
+    return {
+      pointSize: plot?.config?.pointSize,
+      shapeSize: legend?.shapeSize,
+    };
+  });
+}
+
+async function setShapeSize(page: Page, shapeSize: number): Promise<void> {
+  const legend = page.locator('protspace-legend');
+  await legend.getByRole('button', { name: 'Legend settings', exact: true }).click();
+  await legend.locator('#shape-size-input').fill(String(shapeSize));
+  await legend.getByRole('button', { name: 'Save', exact: true }).click();
+  await expect.poll(() => getShapeSizeState(page)).toMatchObject({ shapeSize });
+}
+
 // ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
 
-test.describe('Dataset reload resets state (#178)', () => {
+test.describe('Dataset reload preserves legend state (#340)', () => {
   test.beforeEach(async ({ page }) => {
     // Each Playwright test receives a fresh context; shared storage state only
     // seeds the completed product-tour key, so OPFS starts empty here.
@@ -294,9 +318,7 @@ test.describe('Dataset reload resets state (#178)', () => {
     await dismissTourIfPresent(page);
   });
 
-  test('page reload restores default legend state and clears persisted hidden values', async ({
-    page,
-  }) => {
+  test('page reload restores persisted legend state and hidden values', async ({ page }) => {
     const itemValue = await getFirstLegendItemValue(page);
 
     expect(await isLegendItemHidden(page, itemValue)).toBe(false);
@@ -322,8 +344,8 @@ test.describe('Dataset reload resets state (#178)', () => {
     await waitForExploreDataLoad(page);
     await dismissTourIfPresent(page);
 
-    expect(await isLegendItemHidden(page, itemValue)).toBe(false);
-    expect(await itemHiddenInStorage()).toBe(false);
+    expect(await isLegendItemHidden(page, itemValue)).toBe(true);
+    expect(await itemHiddenInStorage()).toBe(true);
   });
 });
 
@@ -369,6 +391,8 @@ test.describe('Persisted custom datasets in OPFS (#176)', () => {
 
   test('reset to demo clears the persisted custom dataset', async ({ page }) => {
     const defaultCount = await getProteinCount(page);
+    const defaultShapeSize = await getShapeSizeState(page);
+    await setShapeSize(page, 42);
 
     await loadCustomDatasetFromImportMenu(page, CUSTOM_5K_BUNDLE_PATH);
     await page.waitForFunction(
@@ -385,6 +409,7 @@ test.describe('Persisted custom datasets in OPFS (#176)', () => {
 
     await loadDemoDatasetFromImportMenu(page);
     await waitForProteinCount(page, defaultCount);
+    await expect.poll(() => getShapeSizeState(page)).toEqual(defaultShapeSize);
 
     await page.reload();
     await waitForExploreDataLoad(page);

--- a/apps/web/tests/dataset-reload.spec.ts
+++ b/apps/web/tests/dataset-reload.spec.ts
@@ -5,7 +5,9 @@ import {
   clickLegendItem,
   dismissTourIfPresent,
   getFirstLegendItemValue,
+  getShapeSizeState,
   isLegendItemHidden,
+  setShapeSize,
   waitForExploreDataLoad,
   waitForExploreInteractionReady,
   waitForPersistedExploreDataset,
@@ -279,30 +281,6 @@ async function dispatchCustomEvent(
 
 async function hasLegacyNotificationHelperArtifacts(page: Page): Promise<boolean> {
   return page.evaluate(() => document.getElementById('protspace-notification-styles') !== null);
-}
-
-async function getShapeSizeState(page: Page) {
-  return page.evaluate(() => {
-    const legend = document.querySelector('protspace-legend') as
-      | (Element & { shapeSize?: number })
-      | null;
-    const plot = document.querySelector('protspace-scatterplot') as
-      | (Element & { config?: { pointSize?: number } })
-      | null;
-
-    return {
-      pointSize: plot?.config?.pointSize,
-      shapeSize: legend?.shapeSize,
-    };
-  });
-}
-
-async function setShapeSize(page: Page, shapeSize: number): Promise<void> {
-  const legend = page.locator('protspace-legend');
-  await legend.getByRole('button', { name: 'Legend settings', exact: true }).click();
-  await legend.locator('#shape-size-input').fill(String(shapeSize));
-  await legend.getByRole('button', { name: 'Save', exact: true }).click();
-  await expect.poll(() => getShapeSizeState(page)).toMatchObject({ shapeSize });
 }
 
 // ---------------------------------------------------------------------------

--- a/apps/web/tests/helpers/explore.ts
+++ b/apps/web/tests/helpers/explore.ts
@@ -277,3 +277,27 @@ export async function captureExploreViewStability(
   await action();
   return readViewStabilityProbe(page);
 }
+
+export async function getShapeSizeState(page: Page) {
+  return page.evaluate(() => {
+    const legend = document.querySelector('protspace-legend') as
+      | (Element & { shapeSize?: number })
+      | null;
+    const plot = document.querySelector('protspace-scatterplot') as
+      | (Element & { config?: { pointSize?: number } })
+      | null;
+
+    return {
+      pointSize: plot?.config?.pointSize,
+      shapeSize: legend?.shapeSize,
+    };
+  });
+}
+
+export async function setShapeSize(page: Page, shapeSize: number): Promise<void> {
+  const legend = page.locator('protspace-legend');
+  await legend.getByRole('button', { name: 'Legend settings', exact: true }).click();
+  await legend.locator('#shape-size-input').fill(String(shapeSize));
+  await legend.getByRole('button', { name: 'Save', exact: true }).click();
+  await expect.poll(() => getShapeSizeState(page)).toMatchObject({ shapeSize });
+}

--- a/apps/web/tests/url-view-state.spec.ts
+++ b/apps/web/tests/url-view-state.spec.ts
@@ -388,6 +388,7 @@ test.describe('URL-backed explore view state', () => {
 
     await selectProjection(page, targetProjection);
     await waitForView(page, { projection: targetProjection });
+    await expect.poll(() => getShapeSizeState(page)).toEqual(expectedShapeState);
     await page.reload();
     await waitForExploreDataLoad(page);
     await waitForView(page, { projection: targetProjection });

--- a/apps/web/tests/url-view-state.spec.ts
+++ b/apps/web/tests/url-view-state.spec.ts
@@ -288,6 +288,22 @@ async function expectUrlParam(
     .toBe(expected);
 }
 
+async function getShapeSizeState(page: Page) {
+  return page.evaluate(() => {
+    const legend = document.querySelector('protspace-legend') as
+      | (Element & { shapeSize?: number })
+      | null;
+    const plot = document.querySelector('protspace-scatterplot') as
+      | (Element & { config?: { pointSize?: number } })
+      | null;
+
+    return {
+      pointSize: plot?.config?.pointSize,
+      shapeSize: legend?.shapeSize,
+    };
+  });
+}
+
 // Discover the default demo's annotations/projections once per worker. Names can
 // contain spaces/em-dashes and change with demo swaps, so tests derive
 // non-default targets at runtime instead of hardcoding them.
@@ -367,6 +383,46 @@ test.describe('URL-backed explore view state', () => {
       await waitForView(page, { annotation: targetAnnotation, projection: targetProjection });
     },
   );
+
+  test('preserves shape size across projection reloads and deep links', async ({ page }) => {
+    const shapeSize = 42;
+    await page.goto('/explore');
+    await dismissTourIfPresent(page);
+    await waitForExploreDataLoad(page);
+    await waitForExploreInteractionReady(page);
+
+    const legend = page.locator('protspace-legend');
+    await legend.getByRole('button', { name: 'Legend settings', exact: true }).click();
+    await legend.locator('#shape-size-input').fill(String(shapeSize));
+    await legend.getByRole('button', { name: 'Save', exact: true }).click();
+
+    await selectProjection(page, targetProjection);
+    await waitForView(page, { projection: targetProjection });
+    await page.reload();
+    await waitForExploreDataLoad(page);
+    await waitForView(page, { projection: targetProjection });
+    await expect
+      .poll(() => getShapeSizeState(page))
+      .toEqual({
+        pointSize: shapeSize * 8,
+        shapeSize,
+      });
+
+    await page.goto(
+      `/explore?annotation=${encodeURIComponent(demoDefaultAnnotation)}&projection=${encodeURIComponent(demoDefaultProjection)}`,
+    );
+    await waitForExploreDataLoad(page);
+    await waitForView(page, {
+      annotation: demoDefaultAnnotation,
+      projection: demoDefaultProjection,
+    });
+    await expect
+      .poll(() => getShapeSizeState(page))
+      .toEqual({
+        pointSize: shapeSize * 8,
+        shapeSize,
+      });
+  });
 
   test('deep links render the requested view directly without an initial default swap', async ({
     page,

--- a/apps/web/tests/url-view-state.spec.ts
+++ b/apps/web/tests/url-view-state.spec.ts
@@ -6,7 +6,9 @@ import {
   clickLegendItem,
   dismissTourIfPresent,
   getFirstLegendItemValue,
+  getShapeSizeState,
   isLegendItemHidden,
+  setShapeSize,
   supportsExplorePersistedDataset,
   waitForExploreDataLoad,
   waitForExploreInteractionReady,
@@ -288,22 +290,6 @@ async function expectUrlParam(
     .toBe(expected);
 }
 
-async function getShapeSizeState(page: Page) {
-  return page.evaluate(() => {
-    const legend = document.querySelector('protspace-legend') as
-      | (Element & { shapeSize?: number })
-      | null;
-    const plot = document.querySelector('protspace-scatterplot') as
-      | (Element & { config?: { pointSize?: number } })
-      | null;
-
-    return {
-      pointSize: plot?.config?.pointSize,
-      shapeSize: legend?.shapeSize,
-    };
-  });
-}
-
 // Discover the default demo's annotations/projections once per worker. Names can
 // contain spaces/em-dashes and change with demo swaps, so tests derive
 // non-default targets at runtime instead of hardcoding them.
@@ -386,27 +372,24 @@ test.describe('URL-backed explore view state', () => {
 
   test('preserves shape size across projection reloads and deep links', async ({ page }) => {
     const shapeSize = 42;
+    // Mirrors calculatePointSize() in packages/core/src/components/legend/legend-helpers.ts
+    // (LEGEND_DEFAULTS.symbolSizeMultiplier); specs can't import @protspace/core under
+    // Playwright's ESM loader — see the note above waitForView.
+    const SHAPE_SIZE_TO_POINT_SIZE = 8;
+    const expectedShapeState = { pointSize: shapeSize * SHAPE_SIZE_TO_POINT_SIZE, shapeSize };
     await page.goto('/explore');
     await dismissTourIfPresent(page);
     await waitForExploreDataLoad(page);
     await waitForExploreInteractionReady(page);
 
-    const legend = page.locator('protspace-legend');
-    await legend.getByRole('button', { name: 'Legend settings', exact: true }).click();
-    await legend.locator('#shape-size-input').fill(String(shapeSize));
-    await legend.getByRole('button', { name: 'Save', exact: true }).click();
+    await setShapeSize(page, shapeSize);
 
     await selectProjection(page, targetProjection);
     await waitForView(page, { projection: targetProjection });
     await page.reload();
     await waitForExploreDataLoad(page);
     await waitForView(page, { projection: targetProjection });
-    await expect
-      .poll(() => getShapeSizeState(page))
-      .toEqual({
-        pointSize: shapeSize * 8,
-        shapeSize,
-      });
+    await expect.poll(() => getShapeSizeState(page)).toEqual(expectedShapeState);
 
     await page.goto(
       `/explore?annotation=${encodeURIComponent(demoDefaultAnnotation)}&projection=${encodeURIComponent(demoDefaultProjection)}`,
@@ -416,12 +399,7 @@ test.describe('URL-backed explore view state', () => {
       annotation: demoDefaultAnnotation,
       projection: demoDefaultProjection,
     });
-    await expect
-      .poll(() => getShapeSizeState(page))
-      .toEqual({
-        pointSize: shapeSize * 8,
-        shapeSize,
-      });
+    await expect.poll(() => getShapeSizeState(page)).toEqual(expectedShapeState);
   });
 
   test('deep links render the requested view directly without an initial default swap', async ({

--- a/apps/web/tests/url-view-state.spec.ts
+++ b/apps/web/tests/url-view-state.spec.ts
@@ -372,9 +372,11 @@ test.describe('URL-backed explore view state', () => {
 
   test('preserves shape size across projection reloads and deep links', async ({ page }) => {
     const shapeSize = 42;
-    // Mirrors calculatePointSize() in packages/core/src/components/legend/legend-helpers.ts
-    // (LEGEND_DEFAULTS.symbolSizeMultiplier); specs can't import @protspace/core under
-    // Playwright's ESM loader — see the note above waitForView.
+    // LEGEND_DEFAULTS.symbolSizeMultiplier, as used by calculatePointSize() in
+    // packages/core/src/components/legend/legend-helpers.ts. That helper also clamps via
+    // Math.max(10, ...), which this plain multiply omits — equivalent only while
+    // shapeSize >= 2, so keep this test above that. Specs can't import @protspace/core
+    // under Playwright's ESM loader, so the multiplier is mirrored rather than imported.
     const SHAPE_SIZE_TO_POINT_SIZE = 8;
     const expectedShapeState = { pointSize: shapeSize * SHAPE_SIZE_TO_POINT_SIZE, shapeSize };
     await page.goto('/explore');

--- a/docs/explore/legend.md
+++ b/docs/explore/legend.md
@@ -161,10 +161,15 @@ Numeric and multi-label annotations always render as circles; per-category shape
 
 Legend settings are saved per dataset and per annotation in the browser.
 
-- Saved examples: visibility, palette, ordering, numeric binning settings, and duplicate-count preferences
+- Saved examples: visibility, palette, ordering, Shape size / Point size, numeric binning settings,
+  and duplicate-count preferences
 - Numeric binning settings such as palette, gradient direction, strategy, and target bin count are restored on reload/import
 - Numeric hidden values and manual order are only restored when the current numeric topology still matches the saved one
+- Reloading the same demo dataset or opening another projection restores the saved settings for the
+  selected annotation
 - Use `Reset` in the settings dialog to clear saved preferences for the selected annotation
+- After loading a custom dataset, **Import → Load demo dataset** clears saved demo display settings
+  and reapplies the demo bundle defaults
 
 ## Multi-Label Annotations
 

--- a/openspec/changes/preserve-shape-size-across-projection-navigation/.openspec.yaml
+++ b/openspec/changes/preserve-shape-size-across-projection-navigation/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-01

--- a/openspec/changes/preserve-shape-size-across-projection-navigation/design.md
+++ b/openspec/changes/preserve-shape-size-across-projection-navigation/design.md
@@ -33,8 +33,9 @@ file formats, or projection state.
 
 For a `default` load, use replacement semantics only when `currentDatasetHash` is already set. A
 fresh controller has no current dataset, so its automatic default load preserves existing
-dataset-keyed settings. An explicit reset occurs after a dataset is active, so it continues to clear
-and replace those settings.
+dataset-keyed settings. An explicit reset after a dataset is active continues to clear and replace
+those settings. Recovery-banner actions can request the demo before any dataset has loaded; those
+requests intentionally follow startup semantics because there is no active dataset to reset.
 
 This uses state the controller already owns and keeps the change local to the persistence decision.
 
@@ -61,11 +62,26 @@ defaults.
 **Alternative considered:** skip all embedded demo settings on automatic startup. Rejected because
 first-time users would lose curated per-annotation defaults when no local record exists.
 
+### Use one complete dataset identity at every persistence boundary
+
+The dataset controller and legend must hash the same fields. In particular, EAT prediction cells are
+part of the dataset fingerprint, so the legend includes `annotation_predicted` when it recomputes its
+hash after loading data. Otherwise the controller probes and seeds one storage key while the legend
+loads and saves another.
+
 ## Risks / Trade-offs
 
 - **A fresh automatic load restores the complete legend record, not only Shape size.** → This is the
   existing dataset-scoped persistence unit; retaining it avoids partial-record semantics. Explicit
   reset still clears the record.
+- **Other hash-scoped preferences also survive automatic startup.** → The existing storage cleanup
+  removes every `protspace:*:<dataset-hash>` key. Skipping it therefore also activates the existing
+  silent-URL tooltip restore path. An explicit reset after a dataset is active still clears all keys.
+- **A re-curated demo bundle does not replace existing records for returning users.** → The bundle
+  settings table is not part of the dataset hash and stored records do not distinguish seeded
+  defaults from user edits. Changing this would require new persistence provenance and precedence
+  rules; this change favors existing local settings. Changing the demo data changes the hash and
+  seeds the new bundle settings.
 - **Changing non-clearing file application affects its API semantics.** → There are no existing
   production callers of the non-clearing mode; focused controller tests define replacement and
   preserve-existing behavior explicitly.
@@ -77,7 +93,9 @@ first-time users would lose curated per-annotation defaults when no local record
 ## Migration Plan
 
 No data migration is required. Existing persisted records become restorable on reload and projection
-deep links. Rollback is a source revert; stored data remains compatible in either direction.
+deep links. EAT-backed legend records previously saved under the legend's incomplete,
+prediction-omitting hash are not migrated; the corrected shared hash is seeded on the next load.
+Non-EAT dataset keys are unchanged. Rollback is a source revert; the storage schema is unchanged.
 
 ## Open Questions
 

--- a/openspec/changes/preserve-shape-size-across-projection-navigation/design.md
+++ b/openspec/changes/preserve-shape-size-across-projection-navigation/design.md
@@ -1,0 +1,84 @@
+## Context
+
+Legend display settings are persisted under a dataset hash. An in-place projection change keeps the
+same explore controller alive and therefore retains Shape size. Projection deep links and browser
+reloads create a fresh controller, however, and the automatic demo-dataset load is classified as a
+`default` load. The dataset controller currently clears persisted legend and control-bar state for
+every `default` load and then applies the demo bundle's embedded settings with replacement semantics.
+The fresh controller therefore replaces the saved setting before the legend can restore it.
+
+The same `default` load kind is also used by the explicit reset-to-demo action. The implementation
+must distinguish automatic startup from that user-requested reset without changing storage keys,
+file formats, or projection state.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Preserve the dataset-scoped Shape size when projection navigation remounts the explore view.
+- Keep the existing explicit reset-to-demo behavior after a dataset is already active.
+- Preserve the precedence of settings embedded in imported dataset bundles.
+- Add focused regression coverage for the automatic-load and explicit-reset distinction.
+
+**Non-Goals:**
+
+- Making Shape size projection-specific or global across datasets.
+- Introducing a new persistence schema or migrating existing local-storage records.
+- Changing other legend controls, projection URL semantics, or dataset import behavior.
+- Refactoring the dataset loading or persistence architecture.
+
+## Decisions
+
+### Use controller lifecycle state to distinguish startup from reset
+
+For a `default` load, use replacement semantics only when `currentDatasetHash` is already set. A
+fresh controller has no current dataset, so its automatic default load preserves existing
+dataset-keyed settings. An explicit reset occurs after a dataset is active, so it continues to clear
+and replace those settings.
+
+This uses state the controller already owns and keeps the change local to the persistence decision.
+
+**Alternative considered:** never clear state for a `default` load. Rejected because it would break
+the explicit reset-to-demo contract.
+
+**Alternative considered:** persist Shape size in a separate global or per-dataset key. Rejected
+because it duplicates the existing legend persistence mechanism, requires precedence rules, and
+expands the change beyond the reported bug.
+
+### Keep imported bundle precedence unchanged
+
+A user load with embedded settings continues to clear persisted state before applying the bundle's
+settings. OPFS restores continue to use the persisted dataset and legend state as before.
+
+### Seed missing demo settings without overwriting local settings
+
+When file settings are applied without clearing existing storage, retain each annotation key that is
+already persisted and seed embedded settings only for missing annotation keys. Exclude retained keys
+from the in-memory file-precedence map so the normal local-storage restore path remains authoritative.
+This preserves saved Shape size while still giving first-time users the demo bundle's curated legend
+defaults.
+
+**Alternative considered:** skip all embedded demo settings on automatic startup. Rejected because
+first-time users would lose curated per-annotation defaults when no local record exists.
+
+## Risks / Trade-offs
+
+- **A fresh automatic load restores the complete legend record, not only Shape size.** → This is the
+  existing dataset-scoped persistence unit; retaining it avoids partial-record semantics. Explicit
+  reset still clears the record.
+- **Changing non-clearing file application affects its API semantics.** → There are no existing
+  production callers of the non-clearing mode; focused controller tests define replacement and
+  preserve-existing behavior explicitly.
+- **Lifecycle state could be mistaken for load source.** → Focused tests cover both the first
+  automatic default load and a subsequent default load through the same controller.
+- **A later loader refactor could introduce another startup path.** → Keep the behavior specified in
+  terms of automatic first load versus explicit reset, rather than a particular UI event.
+
+## Migration Plan
+
+No data migration is required. Existing persisted records become restorable on reload and projection
+deep links. Rollback is a source revert; stored data remains compatible in either direction.
+
+## Open Questions
+
+None.

--- a/openspec/changes/preserve-shape-size-across-projection-navigation/proposal.md
+++ b/openspec/changes/preserve-shape-size-across-projection-navigation/proposal.md
@@ -1,0 +1,31 @@
+## Why
+
+Changing projection through a direct explore URL or reloading after an in-app projection change
+remounts the default dataset and replaces its persisted legend settings with the bundle defaults.
+The Shape size control then returns to `30` even though projection is view state and point size is a
+dataset-scale preference.
+
+## What Changes
+
+- Retain legend settings when the default dataset is loaded automatically into a fresh explore
+  controller, including projection deep links and browser reloads.
+- Preserve the existing explicit reset-to-demo behavior when a dataset is already active.
+- Add focused regression coverage for automatic default-load retention and explicit default reset.
+
+## Capabilities
+
+### New Capabilities
+
+- `legend-settings-persistence`: Defines how dataset-scoped legend display settings survive explore
+  navigation while explicit dataset reset actions clear them.
+
+### Modified Capabilities
+
+None.
+
+## Impact
+
+- `apps/web/src/explore/dataset-controller.ts` default-load persistence decision.
+- `packages/core/src/controllers/base-persistence-controller.ts` file-setting merge semantics.
+- Dataset-controller unit tests and a focused browser regression for Shape size restoration.
+- No API, dependency, or bundle-format changes.

--- a/openspec/changes/preserve-shape-size-across-projection-navigation/proposal.md
+++ b/openspec/changes/preserve-shape-size-across-projection-navigation/proposal.md
@@ -10,6 +10,8 @@ dataset-scale preference.
 - Retain legend settings when the default dataset is loaded automatically into a fresh explore
   controller, including projection deep links and browser reloads.
 - Preserve the existing explicit reset-to-demo behavior when a dataset is already active.
+- Replace the historical page-reload reset behavior from #178 while retaining that issue's in-app
+  reset path after a custom dataset is active.
 - Add focused regression coverage for automatic default-load retention and explicit default reset.
 
 ## Capabilities
@@ -27,5 +29,8 @@ None.
 
 - `apps/web/src/explore/dataset-controller.ts` default-load persistence decision.
 - `packages/core/src/controllers/base-persistence-controller.ts` file-setting merge semantics.
-- Dataset-controller unit tests and a focused browser regression for Shape size restoration.
+- `packages/core/src/components/legend/legend.ts` dataset identity used by legend persistence.
+- Dataset-controller and legend unit tests plus focused browser regressions for Shape size
+  restoration.
+- Explore documentation for saved Shape size and reload/reset behavior.
 - No API, dependency, or bundle-format changes.

--- a/openspec/changes/preserve-shape-size-across-projection-navigation/specs/legend-settings-persistence/spec.md
+++ b/openspec/changes/preserve-shape-size-across-projection-navigation/specs/legend-settings-persistence/spec.md
@@ -1,0 +1,38 @@
+## ADDED Requirements
+
+### Requirement: Automatic projection navigation preserves dataset display settings
+
+The explore view SHALL restore dataset-scoped legend display settings when projection navigation or
+a browser reload causes a fresh controller to load the same default dataset automatically.
+
+#### Scenario: Direct projection URL restores Shape size
+
+- **WHEN** a user saves a non-default Shape size and opens a projection URL for the same default
+  dataset in a fresh explore controller
+- **THEN** the Shape size and its effective rendered point size match the saved setting
+
+#### Scenario: Reload after projection change restores Shape size
+
+- **WHEN** a user saves a non-default Shape size, changes projection, and reloads the explore page
+- **THEN** the Shape size and its effective rendered point size match the saved setting
+
+### Requirement: Explicit demo reset clears dataset display settings
+
+The explore view SHALL clear persisted dataset display settings when the user explicitly resets to
+the demo dataset after a dataset is already active.
+
+#### Scenario: Reset to demo restores defaults
+
+- **WHEN** a dataset is active and the user explicitly resets to the demo dataset
+- **THEN** persisted custom legend display settings are cleared
+- **AND** the demo dataset uses its default legend display settings
+
+### Requirement: Imported settings retain precedence
+
+The explore view SHALL continue to replace local persisted display settings with settings embedded
+in a user-imported dataset bundle.
+
+#### Scenario: Import bundle with settings
+
+- **WHEN** a user imports a dataset bundle containing legend settings
+- **THEN** the embedded legend settings are applied instead of stale local settings for that dataset

--- a/openspec/changes/preserve-shape-size-across-projection-navigation/specs/legend-settings-persistence/spec.md
+++ b/openspec/changes/preserve-shape-size-across-projection-navigation/specs/legend-settings-persistence/spec.md
@@ -2,8 +2,13 @@
 
 ### Requirement: Automatic projection navigation preserves dataset display settings
 
-The explore view SHALL restore dataset-scoped legend display settings when projection navigation or
-a browser reload causes a fresh controller to load the same default dataset automatically.
+The explore view SHALL restore dataset-scoped display settings when projection navigation or a
+browser reload causes a fresh controller to load the same default dataset automatically.
+
+#### Scenario: In-place projection change retains Shape size
+
+- **WHEN** a user saves a non-default Shape size and changes projection without reloading the dataset
+- **THEN** the Shape size and its effective rendered point size remain unchanged
 
 #### Scenario: Direct projection URL restores Shape size
 
@@ -15,6 +20,23 @@ a browser reload causes a fresh controller to load the same default dataset auto
 
 - **WHEN** a user saves a non-default Shape size, changes projection, and reloads the explore page
 - **THEN** the Shape size and its effective rendered point size match the saved setting
+
+#### Scenario: Silent URL restores saved tooltip selection
+
+- **WHEN** a fresh automatic load has a saved tooltip-annotation selection and the URL does not
+  specify `tooltip`
+- **THEN** the saved tooltip-annotation selection is restored
+
+### Requirement: Persistence components share complete dataset identity
+
+The dataset controller and legend SHALL derive the same persistence identity from display-relevant
+dataset fields, including EAT prediction cells.
+
+#### Scenario: EAT-backed dataset restores the controller-keyed legend record
+
+- **GIVEN** a dataset contains `annotation_predicted` values
+- **WHEN** the controller preserves a legend record during an automatic load
+- **THEN** the legend reads and writes that record under the same dataset hash
 
 ### Requirement: Explicit demo reset clears dataset display settings
 

--- a/openspec/changes/preserve-shape-size-across-projection-navigation/tasks.md
+++ b/openspec/changes/preserve-shape-size-across-projection-navigation/tasks.md
@@ -7,12 +7,16 @@
 - [x] 2.1 Add focused coverage distinguishing the first automatic default load from a subsequent
       explicit default reset.
 - [x] 2.2 Run the focused regression and observe the expected failure before implementation.
+- [x] 2.3 Add focused coverage for in-place projection retention, silent-URL tooltip restoration,
+      and matching controller/legend hashes for EAT-backed data.
+- [x] 2.4 Observe the EAT hash regression fail because the legend omits prediction cells.
 
 ## 3. Implementation
 
 - [x] 3.1 Update the dataset controller's persistence decision and non-clearing file-setting merge
       semantics using existing lifecycle and persistence state.
 - [x] 3.2 Run the focused regressions and observe them pass without changing import precedence.
+- [x] 3.3 Include EAT prediction cells in the legend persistence hash input.
 
 ## 4. Verification
 
@@ -20,3 +24,5 @@
       reproductions.
 - [x] 4.2 Run the affected focused test suites.
 - [x] 4.3 Run `pnpm precommit` successfully before committing and pushing.
+- [x] 4.4 Document saved Shape size, automatic reload retention, explicit reset behavior, and the
+      unchanged-bundle curation trade-off.

--- a/openspec/changes/preserve-shape-size-across-projection-navigation/tasks.md
+++ b/openspec/changes/preserve-shape-size-across-projection-navigation/tasks.md
@@ -1,0 +1,22 @@
+## 1. Specification
+
+- [x] 1.1 Validate the OpenSpec proposal, design, requirements, and task plan.
+
+## 2. Regression Test
+
+- [x] 2.1 Add focused coverage distinguishing the first automatic default load from a subsequent
+      explicit default reset.
+- [x] 2.2 Run the focused regression and observe the expected failure before implementation.
+
+## 3. Implementation
+
+- [x] 3.1 Update the dataset controller's persistence decision and non-clearing file-setting merge
+      semantics using existing lifecycle and persistence state.
+- [x] 3.2 Run the focused regressions and observe them pass without changing import precedence.
+
+## 4. Verification
+
+- [x] 4.1 Verify the saved Shape size survives the original reload and projection deep-link browser
+      reproductions.
+- [x] 4.2 Run the affected focused test suites.
+- [x] 4.3 Run `pnpm precommit` successfully before committing and pushing.

--- a/packages/core/src/components/legend/controllers/persistence-controller.test.ts
+++ b/packages/core/src/components/legend/controllers/persistence-controller.test.ts
@@ -572,6 +572,34 @@ describe('PersistenceController', () => {
         expect(setStorageItem).toHaveBeenCalled();
       });
 
+      it('preserves existing annotation settings when clearing is disabled', () => {
+        const localSettings = {
+          ...fileSettings.annotation1,
+          shapeSize: 42,
+        };
+        vi.mocked(getStorageItem).mockImplementation((key, fallback) =>
+          key === 'legend_hash_protein1_annotation1' ? localSettings : fallback,
+        );
+        controller.updateDatasetHash(['protein1']);
+        controller.updateSelectedAnnotation('annotation1');
+
+        controller.setFileSettings(fileSettings, 'hash_protein1', false);
+        controller.loadSettings();
+
+        expect(removeAllStorageItemsByHash).not.toHaveBeenCalled();
+        expect(setStorageItem).not.toHaveBeenCalledWith(
+          'legend_hash_protein1_annotation1',
+          expect.anything(),
+        );
+        expect(setStorageItem).toHaveBeenCalledWith(
+          'legend_hash_protein1_annotation2',
+          fileSettings.annotation2,
+        );
+        expect(controller.hasFileSettingsForAnnotation('annotation1')).toBe(false);
+        expect(controller.hasFileSettingsForAnnotation('annotation2')).toBe(true);
+        expect(mockCallbacks.onSettingsLoaded).toHaveBeenCalledWith(localSettings);
+      });
+
       it('does not clear or persist settings when null is passed', () => {
         vi.clearAllMocks();
 

--- a/packages/core/src/components/legend/legend.eat-controls.test.ts
+++ b/packages/core/src/components/legend/legend.eat-controls.test.ts
@@ -1,6 +1,12 @@
 // @vitest-environment jsdom
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import type { VisualizationData } from '@protspace/utils';
+import {
+  buildStorageKey,
+  generateDatasetHash,
+  setStorageItem,
+  type LegendPersistedSettings,
+  type VisualizationData,
+} from '@protspace/utils';
 import './legend';
 import type { ProtspaceLegend } from './legend';
 
@@ -72,8 +78,34 @@ async function setup() {
 describe('legend-owned EAT controls', () => {
   afterEach(() => {
     document.body.innerHTML = '';
+    localStorage.clear();
     vi.restoreAllMocks();
     vi.useRealTimers();
+  });
+
+  it('restores EAT legend settings from the controller dataset hash', async () => {
+    const { data, legend, plot } = await setup();
+    plot.dispatchEvent(new CustomEvent('data-change', { detail: { data } }));
+    await legend.updateComplete;
+    const datasetHash = generateDatasetHash(data);
+    const persistedSettings: LegendPersistedSettings = {
+      maxVisibleValues: 10,
+      shapeSize: 42,
+      sortMode: 'size-desc',
+      hiddenValues: [],
+      categories: {},
+      enableDuplicateStackUI: false,
+      selectedPaletteId: 'kellys',
+    };
+    const bundleSettings: LegendPersistedSettings = {
+      ...persistedSettings,
+      shapeSize: 30,
+    };
+    setStorageItem(buildStorageKey('legend', datasetHash, 'ec'), persistedSettings);
+
+    legend.setFileSettings({ ec: bundleSettings }, datasetHash, false);
+
+    expect(legend.shapeSize).toBe(42);
   });
 
   it('renders the controls with counts', async () => {

--- a/packages/core/src/components/legend/legend.ts
+++ b/packages/core/src/components/legend/legend.ts
@@ -831,17 +831,20 @@ export class ProtspaceLegend extends LitElement {
             protein_ids: sourceData.protein_ids,
             annotations: sourceData.annotations,
             numeric_annotation_data: sourceData.numeric_annotation_data,
+            annotation_predicted: sourceData.annotation_predicted,
           }
         : {
             protein_ids: this.proteinIds,
             annotations: this.data?.annotations,
             numeric_annotation_data: this.data?.numeric_annotation_data,
+            annotation_predicted: this.data?.annotation_predicted,
           };
 
       this._persistenceController.updateDatasetHash({
         protein_ids: unfilteredData.protein_ids,
         annotations: unfilteredData.annotations,
         numeric_annotation_data: unfilteredData.numeric_annotation_data,
+        annotation_predicted: unfilteredData.annotation_predicted,
       });
     }
 

--- a/packages/core/src/components/legend/legend.ts
+++ b/packages/core/src/components/legend/legend.ts
@@ -945,6 +945,8 @@ export class ProtspaceLegend extends LitElement {
    * @param settings - All annotation settings from the file, or null to clear
    * @param datasetHash - Optional dataset hash for localStorage keys (required when
    *                      the component's hash isn't yet computed from the new data)
+   * @param clearExistingStorage - Whether file settings replace existing dataset settings. When
+   *                               false, existing annotation settings retain precedence.
    */
   public setFileSettings(
     settings: LegendSettingsMap | null,

--- a/packages/core/src/controllers/base-persistence-controller.ts
+++ b/packages/core/src/controllers/base-persistence-controller.ts
@@ -75,7 +75,7 @@ export abstract class BasePersistenceController<
     datasetHash?: string,
     clearExistingStorage: boolean = true,
   ): void {
-    this._fileSettings = settings;
+    this._fileSettings = settings ? { ...settings } : null;
     this._appliedFileAnnotations.clear();
 
     const hashToUse = datasetHash || this._datasetHash;
@@ -87,7 +87,15 @@ export abstract class BasePersistenceController<
 
       for (const [annotationName, annotationSettings] of Object.entries(settings)) {
         const key = buildStorageKey(this.storageKeyPrefix, hashToUse, annotationName);
+        if (!clearExistingStorage && getStorageItem<TSettings | null>(key, null) !== null) {
+          delete (this._fileSettings as Record<string, TSettings>)[annotationName];
+          continue;
+        }
         setStorageItem(key, annotationSettings);
+      }
+
+      if (this._fileSettings && Object.keys(this._fileSettings).length === 0) {
+        this._fileSettings = null;
       }
     }
 

--- a/packages/core/src/controllers/base-persistence-controller.ts
+++ b/packages/core/src/controllers/base-persistence-controller.ts
@@ -40,18 +40,7 @@ export abstract class BasePersistenceController<
     return this._fileSettings !== null;
   }
 
-  updateDatasetHash(
-    data:
-      | string[]
-      | {
-          protein_ids: string[];
-          annotations?: Record<
-            string,
-            { kind?: 'categorical' | 'numeric'; values?: (string | null)[] }
-          >;
-          numeric_annotation_data?: Record<string, (number | null)[]>;
-        },
-  ): boolean {
+  updateDatasetHash(data: Parameters<typeof generateDatasetHash>[0]): boolean {
     const newHash = generateDatasetHash(data);
     if (newHash !== this._datasetHash) {
       this._datasetHash = newHash;


### PR DESCRIPTION
## Root cause

Automatic demo-dataset loads used the same replacement semantics as an explicit reset. On reload or a direct projection URL, the fresh explore controller first cleared the dataset-scoped legend record and then applied embedded demo bundle settings with replacement semantics, overwriting a saved Shape size with 30.

## Fix

- Distinguish a fresh automatic default load from a later explicit reset using existing controller lifecycle state.
- Preserve existing per-annotation legend settings during automatic startup while seeding embedded demo settings for missing annotations.
- Keep explicit reset-to-demo and imported bundle replacement semantics unchanged.
- Document the behavior in an OpenSpec change.

## Reproduction

1. Open the demo explore view.
2. Save Shape size 42.
3. Change to another projection.
4. Reload the page or open the selected projection as a direct URL.

Before this change, Shape size returned to 30 and effective point size returned to 240. After this change, Shape size remains 42 and effective point size remains 336 across both paths. Explicit reset-to-demo still restores the captured demo defaults.

## Tests

- `pnpm exec vitest run apps/web/src/explore/dataset-controller.eat.test.ts packages/core/src/components/legend/controllers/persistence-controller.test.ts` — 38 passed.
- Affected Playwright projects on the isolated worktree server — 29 passed.
- Focused explicit reset-to-demo browser regression — 1 passed.
- `pnpm test:ci` — 1,873 passed, 1 skipped.
- `pnpm precommit` — passed before commit and push.
- `openspec validate preserve-shape-size-across-projection-navigation --strict` — passed.

Closes #340