### PR TITLE
fix(ci): pin bundle contract python via setup-uv

### DIFF
--- a/.github/workflows/bundle-contract.yml
+++ b/.github/workflows/bundle-contract.yml
@@ -46,21 +46,16 @@ jobs:
         with:
           enable-cache: true
           cache-dependency-glob: 'uv.lock'
+          # Bind uv sync/run to the repository's supported Python floor. Keep
+          # this explicit per job: the repository intentionally has no
+          # .python-version file, so interpreter selection cannot drift through
+          # an implicit, shared version source.
+          python-version: '3.12'
           # setup-uv defaults to `uv cache prune --ci`, which discards prebuilt
           # wheels and keeps only source builds. This dependency tree is all
           # wheels, so pruning leaves the cache near-empty and every run
           # re-downloads numpy/scipy/pandas/pyarrow/scikit-learn.
           prune-cache: false
-
-      # Pin to .python-version (3.12), NOT pyproject.toml. pyproject declares
-      # `requires-python = ">=3.10"`, from which setup-python installs the newest
-      # satisfying release — it picked 3.14.6, a version no other job in this repo
-      # tests. For a required check that means the interpreter floats with the
-      # runner image, and a new release with lagging numba/llvmlite/pyarrow wheels
-      # would block every merge with no code change.
-      - uses: actions/setup-python@v6
-        with:
-          python-version-file: 'apps/protspace/.python-version'
 
       # pnpm/action-setup must precede setup-node so `cache: 'pnpm'` can resolve
       # the store path. setup-node's built-in cache replaces the hand-rolled


### PR DESCRIPTION
## TLDR

Fix the repository-wide `Bundle format contract` failure by making the existing `setup-uv` step the single Python-version owner and removing the stale reference to the deleted `apps/protspace/.python-version` file.

## Description

### Reproduction

- Freshly fetched `origin/main` and confirmed the isolated worktree was exactly at `fbbaefa1ff558bbea365572297cf976472a93c2e` before branching.
- Main push run [30459291713](https://github.com/tsenoner/protspace/actions/runs/30459291713) checked out that exact SHA and failed in `actions/setup-python@v6` before any project code ran:

  ```text
  The specified python version file at: apps/protspace/.python-version doesn't exist.
  ```

- PRs #398 through #407 all reported the same failing `Bundle format contract` check; representative PR #398 logs show the identical missing-file error.
- A local pre-fix validation extracted `python-version-file: apps/protspace/.python-version` from the workflow, checked the path, and deterministically exited 1 because it did not exist.

### Root cause

The contract workflow began referencing `apps/protspace/.python-version` in `dae249c9` on July 21. PR #382 (`f93f9c6a`) deliberately deleted that file on July 24 while standardizing repository Python workflows on explicit per-job `setup-uv` pins. The older contract branch then merged on July 29 without adapting its stale reference.

This is a branch-ordering/configuration integration defect: `actions/setup-python` receives a path that no longer exists on main, so the job terminates before installing dependencies or running the contract suite.

### Why this fix is durable

The workflow already installs uv. Setting `python-version: '3.12'` on `setup-uv` binds `UV_PYTHON`, so both `uv sync` and the contract test's nested `uv run --no-dev` use the supported floor. Removing `actions/setup-python` avoids two competing interpreter-selection mechanisms.

Re-adding `.python-version` would reverse PR #382's deliberate repository convention and recreate an implicit shared version source. Comparable working workflows (`protspace-ci.yml`, `protspace-publish.yml`, and `protspace-release.yml`) pin Python explicitly through `setup-uv`; `prep-ci.yml` also pins 3.12 directly rather than using a version file.

### Verification

- Red/green configuration validation:
  - before: extracted version-file path was absent (exit 1)
  - after: no workflow contains a `python-version-file` YAML key, and the contract workflow's `setup-uv` pin extracts as `3.12`
- `mise x actionlint@1.7.12 shellcheck@0.11.0 -- actionlint .github/workflows/bundle-contract.yml` — exit 0
- Parsed all 10 workflow YAML files successfully with Ruby's YAML parser
- `UV_PYTHON=3.12 uv 0.12.0 sync --package protspace --no-dev --locked` — exit 0, 58 packages checked/installed
- `UV_PYTHON=3.12 uv run --package protspace --no-dev python ...` — CPython 3.12.13 asserted
- `pnpm install --frozen-lockfile` — exit 0
- `UV_PYTHON=3.12 pnpm test:contract` — 1 file passed, 11/11 tests passed
- `pnpm precommit` — exit 0 before commit, in the commit hook, and again immediately before push
- `git diff --check origin/main...HEAD` — exit 0
- Scope: one commit, one workflow file, 5 insertions and 10 deletions
