### PR TITLE
ci: run the E2E suite on frontend PRs instead of never

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -4,17 +4,10 @@ on:
   schedule:
     - cron: '0 3 * * *'
   pull_request:
-    # `synchronize` is deliberately included: the value of this suite is that the state
-    # actually being merged is green. PR #389's connector regression arrived mid-branch,
-    # days after the PR opened, so running only on `opened` would have missed it.
+    # Keep `synchronize`: the state that gets merged is the one worth testing.
     types: [opened, reopened, synchronize]
-    # Only the trees these tests can exercise. Backend-only PRs — 16 of the last 20 merged —
-    # never start the suite.
-    #
-    # This replaces the previous `run-e2e` label gate rather than joining it: a `paths:`
-    # filter suppresses the webhook itself, so a label added to a PR outside these paths
-    # could never start a run. To cover such a PR, dispatch it by hand:
-    #   gh workflow run e2e.yml --ref <branch>
+    # Do not add a label gate alongside this. `paths:` suppresses the webhook, so a label
+    # on a PR outside these paths can never start a run; use `workflow_dispatch` instead.
     paths:
       - 'apps/web/**'
       - 'packages/core/**'
@@ -22,12 +15,10 @@ on:
       - '.github/workflows/e2e.yml'
   workflow_dispatch:
 
-# One run per ref. A burst of pushes cancels its own superseded runs, so an active branch
-# costs one ~8-minute run per burst rather than one per commit — only the last push, the
-# one that gets merged, runs to completion. Never cancels outside a PR: the nightly on main
-# and any manual dispatch must always finish.
 concurrency:
   group: e2e-${{ github.ref }}
+  # PRs only: a burst of pushes should cancel its superseded runs, but the nightly on main
+  # and manual dispatches must always finish.
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -4,15 +4,35 @@ on:
   schedule:
     - cron: '0 3 * * *'
   pull_request:
-    types: [opened, reopened, synchronize, labeled]
+    # `synchronize` is deliberately included: the value of this suite is that the state
+    # actually being merged is green. PR #389's connector regression arrived mid-branch,
+    # days after the PR opened, so running only on `opened` would have missed it.
+    types: [opened, reopened, synchronize]
+    # Only the trees these tests can exercise. Backend-only PRs — 16 of the last 20 merged —
+    # never start the suite.
+    #
+    # This replaces the previous `run-e2e` label gate rather than joining it: a `paths:`
+    # filter suppresses the webhook itself, so a label added to a PR outside these paths
+    # could never start a run. To cover such a PR, dispatch it by hand:
+    #   gh workflow run e2e.yml --ref <branch>
+    paths:
+      - 'apps/web/**'
+      - 'packages/core/**'
+      - 'packages/utils/**'
+      - '.github/workflows/e2e.yml'
   workflow_dispatch:
+
+# One run per ref. A burst of pushes cancels its own superseded runs, so an active branch
+# costs one ~8-minute run per burst rather than one per commit — only the last push, the
+# one that gets merged, runs to completion. Never cancels outside a PR: the nightly on main
+# and any manual dispatch must always finish.
+concurrency:
+  group: e2e-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   e2e-tests:
     name: E2E Tests (Playwright)
-    if: >-
-      github.event_name != 'pull_request' ||
-      contains(github.event.pull_request.labels.*.name, 'run-e2e')
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -6,19 +6,24 @@ on:
   pull_request:
     # Keep `synchronize`: the state that gets merged is the one worth testing.
     types: [opened, reopened, synchronize]
-    # Do not add a label gate alongside this. `paths:` suppresses the webhook, so a label
-    # on a PR outside these paths can never start a run; use `workflow_dispatch` instead.
+    # Err broad: a wrong filter does not fail the job, it silently never runs, which reads
+    # like a pass (see bundle-contract.yml). Hence `packages/**` and the root files the app
+    # resolves through, not just the two packages it imports today.
+    # Do not add a label gate alongside this: `paths:` suppresses the webhook, so a label on
+    # a PR outside these paths can never start a run. Use `workflow_dispatch` instead.
     paths:
       - 'apps/web/**'
-      - 'packages/core/**'
-      - 'packages/utils/**'
+      - 'packages/**'
+      - 'pnpm-lock.yaml'
+      - 'package.json'
+      - 'turbo.json'
+      - 'pnpm-workspace.yaml'
       - '.github/workflows/e2e.yml'
   workflow_dispatch:
 
 concurrency:
   group: e2e-${{ github.ref }}
-  # PRs only: a burst of pushes should cancel its superseded runs, but the nightly on main
-  # and manual dispatches must always finish.
+  # Cancel superseded PR runs; let the nightly and manual dispatches finish.
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
@@ -58,8 +63,9 @@ jobs:
         id: pw
         run: echo "version=$(pnpm exec playwright --version | awk '{print $2}')" >> "$GITHUB_OUTPUT"
 
-      # Browser binaries only. The system libraries that `--with-deps` installs are 181 apt
-      # packages outside this directory, so they are reinstalled either way.
+      # Keyed on the browser build, not the lockfile: a lockfile hash would rewrite ~456MB
+      # on every dependency bump. No restore-keys for the same reason — a prefix match
+      # restores superseded browser dirs that then get re-saved.
       - name: Cache Playwright browsers
         id: pw-cache
         uses: actions/cache@v4
@@ -67,16 +73,17 @@ jobs:
           path: ~/.cache/ms-playwright
           key: ${{ runner.os }}-playwright-${{ steps.pw.outputs.version }}
 
+      # Unconditional on purpose. `--with-deps` always installs the apt packages (which live
+      # outside the cached directory), and skips the download of any browser whose
+      # INSTALLATION_COMPLETE marker the cache restored. One step covers hit and miss.
       - name: Install Playwright browsers
-        if: steps.pw-cache.outputs.cache-hit != 'true'
         run: pnpm exec playwright install --with-deps chromium firefox webkit
 
-      - name: Install Playwright system dependencies
-        if: steps.pw-cache.outputs.cache-hit == 'true'
-        run: pnpm exec playwright install-deps chromium firefox webkit
-
+      # Only the packages the dev server resolves through node_modules. The tests are served
+      # by `pnpm dev:app` (a Vite dev server, see webServer in playwright.config.ts), so
+      # `@protspace/app#build` produced an 89MB bundle nothing here reads.
       - name: Build workspace packages
-        run: pnpm build
+        run: pnpm build --filter=@protspace/core --filter=@protspace/utils
 
       - name: Run Playwright tests
         run: pnpm test:e2e

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -54,8 +54,26 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+      - name: Resolve Playwright version
+        id: pw
+        run: echo "version=$(pnpm exec playwright --version | awk '{print $2}')" >> "$GITHUB_OUTPUT"
+
+      # Browser binaries only. The system libraries that `--with-deps` installs are 181 apt
+      # packages outside this directory, so they are reinstalled either way.
+      - name: Cache Playwright browsers
+        id: pw-cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: ${{ runner.os }}-playwright-${{ steps.pw.outputs.version }}
+
       - name: Install Playwright browsers
+        if: steps.pw-cache.outputs.cache-hit != 'true'
         run: pnpm exec playwright install --with-deps chromium firefox webkit
+
+      - name: Install Playwright system dependencies
+        if: steps.pw-cache.outputs.cache-hit == 'true'
+        run: pnpm exec playwright install-deps chromium firefox webkit
 
       - name: Build workspace packages
         run: pnpm build

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -46,12 +46,13 @@ explicitly when you have not staged everything.
 EAT provenance connectors, isolation, dataset swap — have no other coverage at all.
 `pnpm precommit` does not touch them.
 
-It runs on PRs touching `apps/web/**`, `packages/core/**` or `packages/utils/**`, and
-nightly on `main`. For anything else, dispatch it:
+It runs nightly on `main`, and on any PR touching the web app, the packages it builds on, or
+the root files that decide what those resolve to — `e2e.yml` owns the exact list. For anything
+else, dispatch it:
 
 ```bash
-gh workflow run e2e.yml --ref <branch>                       # in CI, any branch
-npx playwright test -c apps/web/tests/playwright.config.ts   # locally
+gh workflow run e2e.yml --ref <branch>   # in CI, any branch
+pnpm test:e2e                            # locally
 ```
 
 **Never dismiss a red run as flaky on the strength of local passes.** The regression that

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,6 +45,45 @@ Always run `pnpm precommit` before creating any git commit. It runs:
 
 It is JS-only; Python workspace members are covered by their own CI workflows (see below).
 
+Note that `pnpm precommit` runs lint-staged, so it only inspects **staged** files. Unstaged
+work passes it and still fails CI's `format:check`. Run `pnpm format:check` and `pnpm test`
+explicitly when you have not staged everything.
+
+## End-to-end tests (Playwright)
+
+`e2e.yml` is the only suite that drives the real app in a browser, and it is the only place
+several whole subsystems are covered at all — EAT provenance connectors, isolation, dataset
+swap. Nothing in `pnpm precommit` touches them.
+
+When it runs:
+
+| Trigger                                                            | Runs?                           |
+| ------------------------------------------------------------------ | ------------------------------- |
+| PR touching `apps/web/**`, `packages/core/**`, `packages/utils/**` | yes, on every push              |
+| Backend-only PR                                                    | no — dispatch by hand if wanted |
+| Nightly on `main` (03:00 UTC)                                      | yes                             |
+| `gh workflow run e2e.yml --ref <branch>`                           | yes, any branch                 |
+
+A `concurrency` group cancels superseded PR runs, so a burst of pushes costs one ~8-minute
+run rather than one per commit. Cancellation is scoped to `pull_request`: the nightly and
+manual dispatches always finish.
+
+**Why the paths filter and not a label.** Until 2026-08-06 this suite was gated on a
+`run-e2e` label that did not exist, so it had never run on a pull request — 56 consecutive
+`skipped`. PR #389 merged a regression that deleted every EAT provenance connector on a
+projection change; every other check was green, and only the nightly would have caught it,
+on `main`, the next morning. A label cannot be the fix here: a `paths:` filter suppresses
+the webhook itself, so a label added to a PR outside those paths can never start a run.
+
+**A red E2E run is worth reproducing before you dismiss it.** That regression failed 6/6 in
+CI and 0/17 locally. Local passes prove nothing about it; compare against the nightly's
+history on `main` instead (`gh run list --workflow=e2e.yml --event=schedule`), which is the
+only long-running green baseline. To run it locally:
+
+```bash
+npx playwright test -c apps/web/tests/playwright.config.ts
+```
+
 ## Python workspace members (uv)
 
 The Python packages are uv workspace members (root `[tool.uv.workspace]`) sharing one root

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,16 +23,7 @@ as a spec **before** writing implementation code.
 - **Trivial changes** (typo, one-line fix, formatting, dependency bump) do not need a full
   proposal — use judgment.
 
-**Local setup (one time per machine):**
-
-```bash
-npm i -g @fission-ai/openspec   # the workflow skills shell out to this CLI
-openspec init                   # generates per-tool skills/commands for this repo
-```
-
-Only this `AGENTS.md` and the `openspec/` directory (specs + changes) are committed. The per-tool
-skills/commands under `.claude/` and `.codex/`, and Codex's global prompts in `~/.codex/prompts/`,
-are CLI-generated and gitignored — regenerate them with `openspec init` / `openspec update`.
+One-time CLI setup is in [CONTRIBUTING.md](CONTRIBUTING.md#openspec-one-time-per-machine).
 
 ## Before committing
 
@@ -51,38 +42,22 @@ explicitly when you have not staged everything.
 
 ## End-to-end tests (Playwright)
 
-`e2e.yml` is the only suite that drives the real app in a browser, and it is the only place
-several whole subsystems are covered at all — EAT provenance connectors, isolation, dataset
-swap. Nothing in `pnpm precommit` touches them.
+`e2e.yml` is the only suite that drives the real app in a browser, so several subsystems —
+EAT provenance connectors, isolation, dataset swap — have no other coverage at all.
+`pnpm precommit` does not touch them.
 
-When it runs:
-
-| Trigger                                                            | Runs?                           |
-| ------------------------------------------------------------------ | ------------------------------- |
-| PR touching `apps/web/**`, `packages/core/**`, `packages/utils/**` | yes, on every push              |
-| Backend-only PR                                                    | no — dispatch by hand if wanted |
-| Nightly on `main` (03:00 UTC)                                      | yes                             |
-| `gh workflow run e2e.yml --ref <branch>`                           | yes, any branch                 |
-
-A `concurrency` group cancels superseded PR runs, so a burst of pushes costs one ~8-minute
-run rather than one per commit. Cancellation is scoped to `pull_request`: the nightly and
-manual dispatches always finish.
-
-**Why the paths filter and not a label.** Until 2026-08-06 this suite was gated on a
-`run-e2e` label that did not exist, so it had never run on a pull request — 56 consecutive
-`skipped`. PR #389 merged a regression that deleted every EAT provenance connector on a
-projection change; every other check was green, and only the nightly would have caught it,
-on `main`, the next morning. A label cannot be the fix here: a `paths:` filter suppresses
-the webhook itself, so a label added to a PR outside those paths can never start a run.
-
-**A red E2E run is worth reproducing before you dismiss it.** That regression failed 6/6 in
-CI and 0/17 locally. Local passes prove nothing about it; compare against the nightly's
-history on `main` instead (`gh run list --workflow=e2e.yml --event=schedule`), which is the
-only long-running green baseline. To run it locally:
+It runs on PRs touching `apps/web/**`, `packages/core/**` or `packages/utils/**`, and
+nightly on `main`. For anything else, dispatch it:
 
 ```bash
-npx playwright test -c apps/web/tests/playwright.config.ts
+gh workflow run e2e.yml --ref <branch>                       # in CI, any branch
+npx playwright test -c apps/web/tests/playwright.config.ts   # locally
 ```
+
+**Never dismiss a red run as flaky on the strength of local passes.** The regression that
+prompted this section failed 6/6 in CI and 0/17 locally. The baseline worth comparing
+against is the nightly's history on `main` (`gh run list --workflow=e2e.yml
+--event=schedule`), not your machine.
 
 ## Python workspace members (uv)
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,6 +41,21 @@ pnpm dev:docs     # Docs only (localhost:5174)
 pnpm precommit
 ```
 
+### OpenSpec (one time per machine)
+
+Non-trivial work is planned as a spec before implementation — see
+[AGENTS.md](AGENTS.md#spec-driven-development-with-openspec-default-workflow). The workflow
+skills shell out to the `openspec` CLI, so install it once:
+
+```bash
+npm i -g @fission-ai/openspec   # the CLI the workflow skills call
+openspec init                   # generates per-tool skills/commands for this repo
+```
+
+Only `AGENTS.md` and `openspec/` (specs + changes) are committed. The per-tool skills and
+commands under `.claude/` and `.codex/`, and Codex's global prompts in `~/.codex/prompts/`,
+are CLI-generated and gitignored — regenerate them with `openspec init` / `openspec update`.
+
 ## Development Workflow
 
 1. **Fork and clone** the repository


### PR DESCRIPTION
`e2e.yml` was gated on a `run-e2e` label that did not exist in the repo, so the suite had **never run on a pull request** — 56 consecutive `skipped`. Its only real coverage was the nightly on `main`, which finds things after they land.

That is how #389 merged a regression that deleted every EAT provenance connector on a projection change. Every other check was green.

## Changes

**Gate on paths, not a label.** `apps/web/**`, `packages/core/**`, `packages/utils/**`, and this workflow file. Backend-only PRs — 16 of the last 20 merged — never start the suite, so the common case is unchanged.

A label cannot do this job: a `paths:` filter suppresses the webhook itself, so a label added to a PR outside those paths could never start a run. The two do not compose. `workflow_dispatch` remains the manual override and works on any branch. **The `run-e2e` label is now inert and should probably be deleted.**

`synchronize` stays in `types` — the point is that the state being *merged* is green, and #389's regression arrived mid-branch, days after the PR opened.

**Add a concurrency group** so the added coverage does not cost a run per commit:

```yaml
concurrency:
  group: e2e-${{ github.ref }}
  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
```

A burst of pushes cancels its own superseded runs — one ~8-minute run per burst, on the last push. Scoped to `pull_request` so the nightly and manual dispatches always finish.

**AGENTS.md** gains a section on the suite: when it runs, how to dispatch by hand, how to run locally, and the warning that a local pass proves nothing (that regression failed 6/6 in CI and 0/17 locally) — compare against the nightly's history on `main` instead. Also records that `pnpm precommit` only inspects staged files.

## Verification

This PR touches `.github/workflows/e2e.yml`, which is in its own paths filter, so **the E2E run on this PR is itself the test** that the new trigger fires.