### PR TITLE
ci: stop dispatching a duplicate PyPI publish on no-op release runs

### DIFF
--- a/.github/workflows/protspace-release.yml
+++ b/.github/workflows/protspace-release.yml
@@ -78,19 +78,34 @@ jobs:
           set -e
           echo "Running semantic release..."
 
-          # Run semantic release with error handling
+          # Run semantic release with error handling.
+          #
+          # `released` MUST be decided from the output, not the exit code:
+          # semantic-release exits 0 when it declines to cut a release ("No
+          # release will be made, X has already been released!"). Every release
+          # pushes a version-bump commit that touches apps/protspace/**, which
+          # re-triggers this workflow; that second run is exactly the exit-0
+          # no-op case. Keying off the exit code alone reported released=true
+          # there and dispatched a duplicate publish of the tag that had just
+          # been published (v4.9.1 was uploaded to PyPI twice on 2026-07-24).
           if output=$(uv tool run --from python-semantic-release semantic-release version --commit --changelog --push --tag --vcs-release 2>&1); then
             echo "$output"
-            echo "released=true" >> $GITHUB_OUTPUT
 
-            # Get the latest tag
             latest_tag=$(git describe --tags --abbrev=0 2>/dev/null || echo "")
             echo "tag=$latest_tag" >> $GITHUB_OUTPUT
+
+            if echo "$output" | grep -q "No release will be made\|no new version"; then
+              echo "No release needed - skipping publish"
+              echo "released=false" >> $GITHUB_OUTPUT
+            else
+              echo "released=true" >> $GITHUB_OUTPUT
+            fi
           else
             echo "Semantic release failed:"
             echo "$output"
 
-            # Check if it's just "no release needed"
+            # Same no-op check on the non-zero path: older versions signalled
+            # "nothing to release" with a failing exit code.
             if echo "$output" | grep -q "No release will be made\|no new version"; then
               echo "No release needed"
               echo "released=false" >> $GITHUB_OUTPUT


### PR DESCRIPTION
## Problem

Every release dispatches **two** publish runs for the same tag.

`semantic-release version` exits **0** when it declines to cut a release:

```
4.10.0
No release will be made, 4.10.0 has already been released!
```

The release step keyed `released` off the exit code alone and set it to `true`. The `No release will be made` guard lived in the `else` branch — reachable only on a *non-zero* exit — so it never fired for the exit-0 case it was written for.

Every release pushes a version-bump commit that touches `apps/protspace/**`, which re-triggers this workflow. That second run is exactly the exit-0 no-op, so it reported `released=true` and dispatched a redundant publish of the tag that had just been published.

Observed:

| Release | Publish runs | Result |
|---|---|---|
| v4.9.1 (2026-07-24) | [30108473678](https://github.com/tsenoner/protspace/actions/runs/30108473678) + [30108475141](https://github.com/tsenoner/protspace/actions/runs/30108475141), 1s apart | both uploaded identical v4.9.1 files to PyPI |
| v4.10.0 (2026-08-06) | [#23](https://github.com/tsenoner/protspace/actions/runs/31115935533) ✅ + [#24](https://github.com/tsenoner/protspace/actions/runs/31116885176) ❌ | #24 is the failed `pypi` deployment on the environments page |

Run #24 itself died on a transient GitHub Actions outage (`Failed to resolve action download info. Error: Service Unavailable`) before any step ran — but it should never have been dispatched at all. 4.10.0 was already on PyPI from #23.

## Fix

Decide `released` from the output on **both** exit paths. The non-zero branch keeps its own no-op check (older versions signalled "nothing to release" with a failing exit code), and a genuine semantic-release error still fails the job.

## Verification

Logic exercised against all four paths, including the real recorded output from run [31115897549](https://github.com/tsenoner/protspace/actions/runs/31115897549):

| Case | Before | After |
|---|---|---|
| exit 0, `No release will be made, 4.10.0 has already been released!` | `released=true` → duplicate publish | `released=false` → no publish |
| exit 0, real release | `released=true` | `released=true` |
| exit 1, genuine error | job fails | job fails |
| exit 1, legacy no-op | `released=false` | `released=false` |

`tag=` is still emitted on every non-failing path.

> [!IMPORTANT]
> Do not squash-merge — use a merge or rebase merge (see AGENTS.md).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015Fb3pBaKWUS3Bz4dzB1PEq