### PR TITLE
perf(e2e): trial 3 workers in CI

### DIFF
--- a/apps/web/tests/playwright.config.ts
+++ b/apps/web/tests/playwright.config.ts
@@ -42,7 +42,13 @@ export default defineConfig({
 
   // Headless WebGL (SwiftShader) is CPU-bound, so leave cores free for the dev
   // server and OS; 50% of cores is a good balance. CI runners are smaller.
-  workers: process.env.CI ? 2 : '50%',
+  //
+  // 3 of the CI runner's 4 vCPUs. At 2 the suite ran 800s of test time in 455s of wall
+  // clock -- 1.76x on a 4-core box, with a core idle. The risk of going higher is not
+  // throughput but stability: `failOnFlakyTests` means a timeout lost to CPU contention
+  // turns the run red, and this suite polls on real rendering. Trialled over repeated CI
+  // runs before landing; if reds appear, drop back to 2 rather than raising the timeouts.
+  workers: process.env.CI ? 3 : '50%',
 
   reporter: process.env.CI ? [['list'], ['html', { open: 'never' }]] : 'list',
 


### PR DESCRIPTION
**Trial, not a merge candidate yet.** Landing this depends on repeated green CI runs, which is the whole point of the PR.

## Why

The E2E suite is the longest job in CI at ~8.6 min, and **88% of that is test execution** (456s). It runs 800s of test time in 456s of wall clock — **1.76×** on a 4-vCPU runner, i.e. one core sits idle.

`workers: 2 → 3` should put the floor near 800/3 ≈ 267s, which is ~4× more than every other E2E saving found so far combined.

## Why it wasn't already 3

Stability, not arithmetic. Headless WebGL runs on SwiftShader so every worker is CPU-bound, and `failOnFlakyTests: true` with `retries: 1` means a single contention-induced timeout turns the run red. This suite polls on real rendering — one of its polls recently failed 6/6 in CI while passing 17/17 locally.

## Acceptance

Repeated CI runs on this branch. If any come back red, revert to 2 — **not** raise the timeouts, which would hide contention rather than remove it.

Baseline at `workers: 2`, measured across five runs: **413 / 430 / 435 / 455 / 456s**, all green.