### PR TITLE
feat(eat): self-transfer, reliability filter modes, and glyph outline parity

### DIFF
--- a/apps/protspace/src/protspace/analysis/classification.py
+++ b/apps/protspace/src/protspace/analysis/classification.py
@@ -1,8 +1,14 @@
 """Classify proteins as transfer queries vs annotated references.
 
 Rules match by ID prefix and/or a case-insensitive metadata substring
-(``column ~ substring``). No biology is hardcoded; a query rule that matches
-nothing is an error.
+(``column ~ substring``). No biology is hardcoded; an *explicit* query rule
+that matches nothing is an error.
+
+A rule with no clauses is **open** — it restricts nothing and matches every
+protein. Passing no rules at all therefore means "transfer within this
+dataset": every protein is a candidate on both sides, and the caller splits
+them per column into the ones missing a value (queries) and the ones holding
+one (references).
 """
 
 from __future__ import annotations
@@ -14,13 +20,30 @@ import pyarrow as pa
 
 @dataclass
 class Rule:
-    """A classification rule. A protein matches if ANY clause matches."""
+    """A classification rule. A protein matches if ANY clause matches.
+
+    A rule with no clauses at all is *open*: it expresses "no restriction"
+    rather than "match nothing" (see ``is_open``).
+    """
 
     id_prefixes: list[str] = field(default_factory=list)
     where: list[tuple[str, str]] = field(default_factory=list)  # (column, substring)
 
+    @property
+    def is_open(self) -> bool:
+        """True when the rule carries no clauses, i.e. it restricts nothing.
+
+        An open rule matches every protein. This is what makes self-transfer
+        (#393) work without a marker column: with both rules open, every
+        protein is a candidate query *and* a candidate reference, and
+        ``run_transfer`` does the real split per column on missing-vs-present.
+        """
+        return not self.id_prefixes and not self.where
+
 
 def _matches(rule: Rule, identifier: str, column_data: dict[str, list], i: int) -> bool:
+    if rule.is_open:
+        return True
     if any(identifier.startswith(p) for p in rule.id_prefixes):
         return True
     for column, substring in rule.where:
@@ -39,8 +62,15 @@ def classify(
 ) -> tuple[list[int], list[int]]:
     """Return (query_indices, reference_indices) into the annotations table.
 
-    Query classification takes precedence: a protein matching both rules is a
-    query. Raises ValueError if the query rule matches nothing.
+    Between two *explicit* rules, query classification takes precedence: a
+    protein matching both is a query and never a reference. An **open** rule
+    (no clauses) expresses no preference, so it never takes a protein away from
+    the other set — which is what lets both sets cover the whole table when no
+    rules are given. The two lists may therefore overlap; callers are expected
+    to make the final, disjoint split themselves (``run_transfer`` does it per
+    column on missing-vs-present).
+
+    Raises ValueError if an explicit query rule matches nothing.
 
     ``identifiers`` may be a pre-materialized list of the string identifier
     column (same order as ``annotations``) to avoid re-materializing it when the
@@ -63,15 +93,30 @@ def classify(
     }
     column_data = {c: annotations.column(c).to_pylist() for c in where_columns}
 
+    # Precedence applies only *between two explicit rules*: there, a protein
+    # matching both is a query and never a reference. When either side is open
+    # it expresses no preference, so it must not consume proteins away from the
+    # other set — otherwise two open rules would hand every protein to the
+    # query list and leave references empty, and transfer would silently
+    # do nothing.
+    both_explicit = not query_rule.is_open and not reference_rule.is_open
+
     query_indices: list[int] = []
     reference_indices: list[int] = []
     for i, identifier in enumerate(identifiers):
-        if _matches(query_rule, identifier, column_data, i):
+        is_query = _matches(query_rule, identifier, column_data, i)
+        is_reference = _matches(reference_rule, identifier, column_data, i)
+        if is_query and is_reference and both_explicit:
+            is_reference = False
+        if is_query:
             query_indices.append(i)
-        elif _matches(reference_rule, identifier, column_data, i):
+        if is_reference:
             reference_indices.append(i)
 
     if not query_indices:
+        if query_rule.is_open:
+            # Nothing to blame on the rules — the table itself is empty.
+            raise ValueError("Classifier found no proteins to use as queries.")
         raise ValueError(
             "Classifier matched no query proteins; check --query-id-prefix / "
             "--query-where rules."

--- a/apps/protspace/src/protspace/cli/transfer.py
+++ b/apps/protspace/src/protspace/cli/transfer.py
@@ -131,8 +131,10 @@ def run_transfer(
 
     if total_transferred == 0:
         logger.warning(
-            "No annotations were transferred. Check the --reference-* rules and "
-            "that query proteins have missing values in the target column(s)."
+            "No annotations were transferred: the target column(s) have either "
+            "no missing values to fill or no values to transfer from. If you "
+            "passed --query-* / --reference-* filters, check they select the "
+            "proteins you meant."
         )
     return out
 
@@ -179,7 +181,7 @@ def transfer(
         list[str] | None,
         typer.Option(
             "--query-id-prefix",
-            help="Only transfer to query IDs with this prefix (repeatable).",
+            help="Restrict queries to IDs with this prefix (default: any protein missing a value).",
             rich_help_panel="Query filters (which proteins receive labels)",
         ),
     ] = None,
@@ -195,7 +197,7 @@ def transfer(
         list[str] | None,
         typer.Option(
             "--reference-id-prefix",
-            help="Only use references whose ID has this prefix (repeatable).",
+            help="Restrict references to IDs with this prefix (default: any protein that has a value).",
             rich_help_panel="Reference filters (which proteins provide labels)",
         ),
     ] = None,
@@ -223,7 +225,13 @@ def transfer(
     ] = "cosine",
     verbose: Opt_Verbose = 0,
 ) -> None:
-    """Fill missing annotations from nearest neighbours (EAT)."""
+    """Fill missing annotations from nearest neighbours (EAT).
+
+    With no query/reference filters, transfer runs *within* the bundle: every
+    protein missing a value in a --transfer column receives one from its
+    nearest neighbour among the proteins that have one. Use the filters only to
+    narrow that down (e.g. to label one species from another).
+    """
     setup_logging(verbose)
 
     import io

--- a/apps/protspace/tests/test_classification.py
+++ b/apps/protspace/tests/test_classification.py
@@ -69,3 +69,44 @@ def test_multiple_id_prefixes_use_or_semantics():
     qi, ri = classify(_table(), q, r)
     assert qi == [0, 1, 2]
     assert ri == [3]
+
+
+# ── Open (unrestricted) rules ──────────────────────────────────────────────
+#
+# A rule with no clauses means "no restriction", not "match nothing". Both
+# rules open is the self-transfer case (#393): every protein is a candidate on
+# both sides, and `run_transfer` does the real partitioning per column on
+# missing-vs-present, which is why the candidate sets are allowed to overlap.
+
+
+def test_both_rules_open_makes_every_protein_a_candidate_on_both_sides():
+    qi, ri = classify(_table(), Rule(), Rule())
+    assert qi == [0, 1, 2, 3]
+    assert ri == [0, 1, 2, 3]
+
+
+def test_open_reference_rule_does_not_starve_references():
+    # Query rule is explicit; an open reference rule must still offer every
+    # other protein as a reference instead of returning an empty set.
+    qi, ri = classify(_table(), Rule(id_prefixes=["TRINITY_"]), Rule())
+    assert qi == [0, 1]
+    assert ri == [0, 1, 2, 3]
+
+
+def test_open_query_rule_does_not_starve_queries():
+    qi, ri = classify(_table(), Rule(), Rule(id_prefixes=["P0"]))
+    assert qi == [0, 1, 2, 3]
+    assert ri == [2, 3]
+
+
+def test_open_rule_does_not_consume_proteins_from_the_other_set():
+    # The precedence rule applies only between two explicit rules. An open
+    # rule that "matches" a protein must not remove it from the other set.
+    _, ri = classify(_table(), Rule(), Rule(id_prefixes=["TRINITY_"]))
+    assert ri == [0, 1]
+
+
+def test_open_query_rule_on_empty_table_raises_a_rule_free_message():
+    empty = pa.table({"identifier": [], "protein_category": []})
+    with pytest.raises(ValueError, match="no proteins"):
+        classify(empty, Rule(), Rule())

--- a/apps/protspace/tests/test_transfer_cli.py
+++ b/apps/protspace/tests/test_transfer_cli.py
@@ -486,3 +486,111 @@ def test_cli_migrates_legacy_cells_and_encodes_reserved_source_id(tmp_path):
     assert (
         rows["TRINITY_1"]["protein_category__pred_source"] == "P0%7Cref%3Bliteral%253B"
     )
+
+
+# ── Self-transfer: no query/reference rules (#393) ──────────────────────────
+#
+# "Apply EAT to all NA values in the current dataset": with no rules, every
+# protein missing a value in the target column is a query and every protein
+# holding one is a reference — no marker column, no second dataset.
+
+
+def test_run_transfer_without_rules_fills_missing_values():
+    annotations, embeddings = _three_protein_inputs()
+    out = run_transfer(
+        annotations=annotations,
+        embeddings=embeddings,
+        transfer_columns=["protein_category"],
+        query_rule=Rule(),
+        reference_rule=Rule(),
+        k=1,
+        metric="euclidean",
+    )
+    by_id = {r["identifier"]: r for r in out.to_pylist()}
+    # TRINITY_1 is the only protein with a missing value; it sits on top of the
+    # neurotoxin reference P00001.
+    assert by_id["TRINITY_1"]["protein_category__pred_value"] == "neurotoxin"
+    assert by_id["TRINITY_1"]["protein_category__pred_source"] == "P00001"
+
+
+def test_run_transfer_without_rules_never_predicts_over_a_curated_value():
+    annotations, embeddings = _three_protein_inputs()
+    out = run_transfer(
+        annotations=annotations,
+        embeddings=embeddings,
+        transfer_columns=["protein_category"],
+        query_rule=Rule(),
+        reference_rule=Rule(),
+        k=1,
+        metric="euclidean",
+    )
+    by_id = {r["identifier"]: r for r in out.to_pylist()}
+    for annotated in ("P00001", "P00002"):
+        assert by_id[annotated]["protein_category__pred_value"] is None
+        assert by_id[annotated]["protein_category"] != ""
+
+
+def test_run_transfer_without_rules_never_uses_a_protein_as_its_own_source():
+    annotations, embeddings = _three_protein_inputs()
+    out = run_transfer(
+        annotations=annotations,
+        embeddings=embeddings,
+        transfer_columns=["protein_category"],
+        query_rule=Rule(),
+        reference_rule=Rule(),
+        k=1,
+        metric="euclidean",
+    )
+    for row in out.to_pylist():
+        source = row["protein_category__pred_source"]
+        if source is not None:
+            assert source != row["identifier"]
+
+
+def test_run_transfer_with_only_a_query_rule_still_finds_references():
+    # Regression: an absent reference rule used to yield an empty reference set,
+    # so the column was skipped and the bundle written back unchanged.
+    annotations, embeddings = _three_protein_inputs()
+    out = run_transfer(
+        annotations=annotations,
+        embeddings=embeddings,
+        transfer_columns=["protein_category"],
+        query_rule=Rule(id_prefixes=["TRINITY_"]),
+        reference_rule=Rule(),
+        k=1,
+        metric="euclidean",
+    )
+    by_id = {r["identifier"]: r for r in out.to_pylist()}
+    assert by_id["TRINITY_1"]["protein_category__pred_value"] == "neurotoxin"
+
+
+def test_cli_transfer_without_rules_fills_missing_values(tmp_path):
+    import io
+
+    import pyarrow.parquet as pq
+    from typer.testing import CliRunner
+
+    from protspace.cli.app import app
+    from protspace.data.io.bundle import read_bundle
+
+    bundle, h5 = _write_bundle_and_h5(tmp_path)
+    out_path = tmp_path / "out.parquetbundle"
+    result = CliRunner().invoke(
+        app,
+        [
+            "transfer",
+            "-b",
+            str(bundle),
+            "-e",
+            str(h5),
+            "-t",
+            "protein_category",
+            "-o",
+            str(out_path),
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    parts, _ = read_bundle(out_path)
+    rows = {r["protein_id"]: r for r in pq.read_table(io.BytesIO(parts[0])).to_pylist()}
+    assert rows["TRINITY_1"]["protein_category__pred_value"] == "neurotoxin"
+    assert rows["P00001"]["protein_category__pred_value"] is None

--- a/apps/web/src/explore/runtime.ts
+++ b/apps/web/src/explore/runtime.ts
@@ -1,4 +1,5 @@
 import '@protspace/core'; // Registers all web components
+import type { EatReliabilityState } from '@protspace/utils';
 import { startProductTour } from '../tour/product-tour';
 import { bindControlBarEvents } from './control-bar-events';
 import { createDatasetController } from './dataset-controller';
@@ -279,14 +280,27 @@ export async function initializeExploreRuntime(): Promise<ExploreController> {
   // that filter pulls the slider back. Each direction guards on the threshold
   // value so they can't ping-pong.
   addTrackedEventListener(lifecycle, legendElement, 'eat-overlay-change', (event: Event) => {
-    const { confidenceThreshold } = (
-      event as CustomEvent<{ enabled: boolean; confidenceThreshold: number }>
+    const { confidenceThreshold, reliability } = (
+      event as CustomEvent<{
+        enabled: boolean;
+        confidenceThreshold: number;
+        reliability?: EatReliabilityState;
+      }>
     ).detail;
-    controlBar.setEatConfidenceThreshold(legendElement.selectedAnnotation, confidenceThreshold);
+    // Prefer the full state (mode + both bounds) so "hide above" and "keep between"
+    // reach the query; fall back to the scalar for any emitter that predates it.
+    if (reliability) {
+      controlBar.setEatReliability(legendElement.selectedAnnotation, reliability);
+    } else {
+      controlBar.setEatConfidenceThreshold(legendElement.selectedAnnotation, confidenceThreshold);
+    }
   });
   addTrackedEventListener(lifecycle, controlBar, 'eat-threshold-mirror', (event: Event) => {
-    const { value } = (event as CustomEvent<{ value: number }>).detail;
-    legendElement.setReliabilityThreshold(value);
+    const { value, state } = (
+      event as CustomEvent<{ value: number; base?: string; state?: EatReliabilityState }>
+    ).detail;
+    if (state) legendElement.setReliabilityState(state);
+    else legendElement.setReliabilityThreshold(value);
   });
   addTrackedEventListener(
     lifecycle,

--- a/openspec/changes/improve-eat-transfer-and-reliability/proposal.md
+++ b/openspec/changes/improve-eat-transfer-and-reliability/proposal.md
@@ -1,0 +1,34 @@
+## Why
+
+The Nature Methods submission builds its case on EAT being an _operation_ a biologist runs, not a static overlay — "function transferred in, candidate curation errors surfaced out"
+(`protspace_publication/nm_2026/story/STORY_v2_nature_methods.md:9`). Three shipped gaps sit between that claim and the tool:
+
+- **Running EAT at all required a marker column (#393).** An empty `Rule` matched nothing, so `protspace transfer` without `--query-*`/`--reference-*` raised "Classifier matched no query proteins". Users had to invent a column describing "the rows that are empty" — the shipped EAT demo bundle needed exactly that (`apps/protspace/data/eat_demo/README.md`).
+- **The reliability filter misled in several ways (#380).** The legend slider identified its condition by pattern-matching `NOT(conf < X)`, so `>`, `between`, a non-negated `<`, and anything nested in a group were invisible to it — while `gt` is what the query builder produces by default for an eat-confidence column. Positive operators also hid every curated protein, which the slider's own help text promises cannot happen.
+- **The two glyph classes were outlined inconsistently (#369)**, and the outline was a fraction of the sprite rather than an absolute width, so at the app's own `nature-1col` preset it fell below the reproducible-line floor for print while the predicted ring survived.
+
+## What Changes
+
+- A classification rule with no clauses is **open** (matches everything) rather than matching nothing, so passing no rules means "transfer within this dataset". Precedence between query and reference applies only between two _explicit_ rules, so an open rule never starves the other set.
+- The reliability filter's conditions are identified by **ownership of the eat-confidence column**, at any depth, instead of by condition shape — so every operator mirrors, and a hand-built condition is recognised rather than duplicated.
+- The reliability control gains **three modes** (at least / at most / between), each expressed as NOT-form conditions so curated proteins stay visible in all of them without changing the evaluator's null semantics.
+- A query matching nothing **clears** the filter channel instead of being pushed as an active filter that blanks the plot.
+- The glyph outline becomes an **absolute device-pixel width** derived from the shader's existing isotropic pixel scale, applied to both filled dots and predicted rings, budget-capped on the ring.
+
+## Capabilities
+
+### New Capabilities
+
+- `eat-transfer-scope`: which proteins act as queries and references when `protspace transfer` runs, including the no-rules (self-transfer) case.
+- `eat-reliability-filter`: how the EAT reliability control and the query builder express and share one filter.
+
+### Modified Capabilities
+
+<!-- The EAT specs live in the unarchived `add-eat-visualization` change, not in openspec/specs/, so there is no committed requirement to modify. -->
+
+## Impact
+
+- **Backend:** `apps/protspace/src/protspace/analysis/classification.py`, `cli/transfer.py`. `feat:` on `apps/protspace/` — earns a PyPI minor bump, which is correct for a user-visible CLI behaviour change.
+- **Frontend:** `packages/core/src/components/control-bar/{control-bar,query-types,query-owned,eat-reliability}.ts`, `packages/core/src/components/legend/legend.ts` + styles, `packages/utils/src/visualization/eat-overlay.ts`, `apps/web/src/explore/runtime.ts`.
+- **Not included:** audit mode (#424) — engine, CLI, bundle contract and a third glyph state, filed separately; persisting the reliability _mode_ to bundle settings (schema addition needing a migration story for the legacy scalar).
+- **Bundle format:** unchanged. `format_version` stays 2; no new columns.

--- a/openspec/changes/improve-eat-transfer-and-reliability/specs/eat-reliability-filter/spec.md
+++ b/openspec/changes/improve-eat-transfer-and-reliability/specs/eat-reliability-filter/spec.md
@@ -1,0 +1,74 @@
+## ADDED Requirements
+
+### Requirement: The reliability filter is identified by column, not by condition shape
+
+The reliability control SHALL treat a numeric condition on an eat-confidence column as its own,
+at any depth in the query, regardless of operator or logical operator, and regardless of whether
+the condition carries an owner tag. Changing the control SHALL replace those conditions rather
+than adding another beside them.
+
+#### Scenario: A hand-built condition is recognised
+
+- **WHEN** the user builds a condition on an eat-confidence column with any operator
+- **AND** then changes the reliability control
+- **THEN** exactly one reliability condition remains in the query
+
+#### Scenario: A condition nested in a group
+
+- **WHEN** a reliability condition sits inside a filter group
+- **THEN** changing the control replaces it in place rather than duplicating it at the top level
+
+#### Scenario: Another base annotation is untouched
+
+- **WHEN** two annotations both carry EAT predictions and both have a reliability condition
+- **THEN** changing one leaves the other's condition unchanged
+
+### Requirement: Curated proteins stay visible in every mode
+
+The reliability control SHALL offer bounding below, bounding above, and a band, and SHALL express
+each as negated conditions so that proteins without a confidence score — the curated ones — are
+retained by the negation's complement in all three.
+
+#### Scenario: Each mode keeps curated proteins
+
+- **WHEN** any of the three modes is applied
+- **THEN** proteins with no confidence score remain visible
+
+#### Scenario: A bound that constrains nothing emits no condition
+
+- **WHEN** the control is at its default position
+- **THEN** the query carries no reliability condition
+
+### Requirement: Deriving the control position respects the logical operator
+
+Reading the control's position back from the query SHALL account for negation: a negated
+less-than is a LOWER bound while a bare less-than is an UPPER bound.
+
+#### Scenario: Negated and bare forms of one operator
+
+- **WHEN** the query carries a negated `less than X`
+- **THEN** the control reads a lower bound at X
+- **WHEN** the query carries a bare `less than X`
+- **THEN** the control reads an upper bound at X
+
+### Requirement: A query matching nothing does not blank the plot
+
+Applying a query whose result is empty SHALL clear the filter channel rather than pushing an
+empty active filter, which the scatter plot reads as "hide everything".
+
+#### Scenario: A self-contradicting query
+
+- **WHEN** the evaluated query matches no proteins
+- **THEN** the filter channel is cleared and the plot is not blanked
+
+### Requirement: Switching the coloured-by annotation repositions the control
+
+When the selected annotation changes, the control SHALL be told the new base's reliability state
+even when that state has not changed since it was last written, because the control is otherwise
+still showing the previous base's position.
+
+#### Scenario: Switching between two transferred annotations
+
+- **WHEN** two annotations carry EAT predictions with different reliability positions
+- **AND** the user switches the coloured-by annotation
+- **THEN** the control shows the newly selected annotation's position

--- a/openspec/changes/improve-eat-transfer-and-reliability/specs/eat-transfer-scope/spec.md
+++ b/openspec/changes/improve-eat-transfer-and-reliability/specs/eat-transfer-scope/spec.md
@@ -1,0 +1,52 @@
+## ADDED Requirements
+
+### Requirement: A rule with no clauses restricts nothing
+
+A classification `Rule` carrying neither an id prefix nor a `where` clause SHALL match every
+protein. Running `protspace transfer` with no query or reference filters SHALL therefore transfer
+within the bundle: every protein missing a value in a target column receives one from its nearest
+neighbour among the proteins that have a value. An _explicit_ rule that matches nothing SHALL
+remain an error.
+
+#### Scenario: No rules at all
+
+- **WHEN** `protspace transfer` is run with no `--query-*` and no `--reference-*` filters
+- **THEN** every protein missing a value in a `--transfer` column is a query
+- **AND** every protein holding a value in that column is a reference
+- **AND** no marker column is required
+
+#### Scenario: An explicit rule that matches nothing still errors
+
+- **WHEN** a query rule names an id prefix no protein carries
+- **THEN** classification fails with an error naming the query filters
+
+### Requirement: An open rule does not consume proteins from the other set
+
+Query classification SHALL take precedence over reference classification only when BOTH rules are
+explicit. When either rule is open, a protein matching both SHALL remain a candidate on both sides.
+
+#### Scenario: Both rules open
+
+- **WHEN** both rules are open
+- **THEN** the query set and the reference set each cover the whole table
+
+#### Scenario: Only a query rule is given
+
+- **WHEN** a query rule is explicit and no reference rule is given
+- **THEN** references are drawn from the remaining proteins rather than coming back empty
+- **AND** the run does not exit successfully having transferred nothing
+
+#### Scenario: Two explicit rules
+
+- **WHEN** both rules are explicit and a protein matches both
+- **THEN** that protein is a query and not a reference
+
+### Requirement: A protein is never its own reference
+
+For each transfer column the query set and the reference set SHALL be complements of the
+missing-value test over that column, so no protein can supply its own label.
+
+#### Scenario: Self-transfer over a real dataset
+
+- **WHEN** transfer runs with no rules over a dataset where some proteins carry the target value
+- **THEN** no emitted prediction names its own protein as the source

--- a/openspec/changes/improve-eat-transfer-and-reliability/tasks.md
+++ b/openspec/changes/improve-eat-transfer-and-reliability/tasks.md
@@ -1,0 +1,35 @@
+## 1. Transfer scope (#393)
+
+- [x] 1.1 Add `Rule.is_open`; an open rule matches every protein.
+- [x] 1.2 Apply query-over-reference precedence only between two explicit rules, so an open rule never starves the other set.
+- [x] 1.3 Keep the "explicit rule matched nothing" error, and give the open-rule case its own message.
+- [x] 1.4 Update the CLI docstring, option help and the "nothing transferred" warning, which all assumed rules were required.
+- [x] 1.5 Tests: open-rule classification, self-transfer end to end, query-only no longer a silent no-op, no self-sourced predictions.
+- [x] 1.6 Verify on the 832-protein phosphatase fixture — reproduces the manuscript's 91.55% EC / 99.06% family held-out accuracy with no rules.
+
+## 2. Reliability filter (#380)
+
+- [x] 2.1 Add a `ConditionOwner` tag and group-aware find/replace over conditions owned for a column.
+- [x] 2.2 Treat an untagged numeric condition on an eat-confidence column as owned, so hand-built and restored conditions mirror.
+- [x] 2.3 Model the filter as a mode plus bounds; translate every mode to NOT-form conditions.
+- [x] 2.4 Respect the logical operator when reading the state back — a bare `lt` is an upper bound, a negated one is a lower bound.
+- [x] 2.5 Key the mirror's de-dupe guard per eat-confidence column; force-emit on an annotation switch.
+- [x] 2.6 Clear rather than activate the filter channel when a query matches nothing.
+- [x] 2.7 Add the legend mode select and the band's second bound; reset the bound a mode no longer uses.
+- [x] 2.8 Emit the full state from the legend and consume it in the runtime, keeping the scalar fallback.
+- [x] 2.9 Tests: all operators replaced not appended, group nesting, curated retained per mode, band from both sides, mode round-trip, layout at 320px.
+
+## 3. Glyph outline (#369)
+
+- [x] 3.1 Hoist the isotropic pixel scale so the ring and the outline share one definition.
+- [x] 3.2 Measure the outline in device pixels instead of as a fraction of the sprite.
+- [x] 3.3 Apply it to both filled dots and predicted rings; budget-cap it against ring width.
+- [x] 3.4 Anti-alias the outline's inner edge.
+- [x] 3.5 Rewrite the characterization assertion that pinned the outline being skipped on rings.
+
+## 4. Verification
+
+- [x] 4.1 `uv run pytest` (840 passed) + `uv run ruff check`.
+- [x] 4.2 `pnpm test:ci` across core/utils/app; `pnpm format:check`; `pnpm precommit` on every commit.
+- [x] 4.3 Playwright `eat-visualization` against the real phosphatase bundle — proves the shader compiles and the legend layout holds.
+- [ ] 4.4 Archive this change before the merge (`/opsx:archive`).

--- a/packages/core/src/components/control-bar/control-bar.query-apply.test.ts
+++ b/packages/core/src/components/control-bar/control-bar.query-apply.test.ts
@@ -324,10 +324,14 @@ describe('control-bar EAT reliability slider <-> query mirror', () => {
         },
       }),
     );
-    expect(mirror).toHaveBeenLastCalledWith(expect.objectContaining({ detail: { value: 0.6 } }));
+    expect(mirror).toHaveBeenLastCalledWith(
+      expect.objectContaining({ detail: expect.objectContaining({ value: 0.6 }) }),
+    );
 
     controlBar._handleQueryChanged(new CustomEvent('query-changed', { detail: { query: [] } }));
-    expect(mirror).toHaveBeenLastCalledWith(expect.objectContaining({ detail: { value: 0 } }));
+    expect(mirror).toHaveBeenLastCalledWith(
+      expect.objectContaining({ detail: expect.objectContaining({ value: 0 }) }),
+    );
   });
 
   it('guards the loop: a query change echoing the forward value does not re-emit', () => {
@@ -460,10 +464,189 @@ describe('control-bar per-base EAT reliability filter (multi-EAT)', () => {
 
     controlBar.selectedAnnotation = 'ec';
     await controlBar.updateComplete;
-    expect(mirror).toHaveBeenLastCalledWith(expect.objectContaining({ detail: { value: 0.5 } }));
+    expect(mirror).toHaveBeenLastCalledWith(
+      expect.objectContaining({ detail: expect.objectContaining({ value: 0.5 }) }),
+    );
 
     controlBar.selectedAnnotation = 'go';
     await controlBar.updateComplete;
-    expect(mirror).toHaveBeenLastCalledWith(expect.objectContaining({ detail: { value: 0.8 } }));
+    expect(mirror).toHaveBeenLastCalledWith(
+      expect.objectContaining({ detail: expect.objectContaining({ value: 0.8 }) }),
+    );
+  });
+});
+
+/**
+ * #380 — "make the EAT reliability filtering work for all kind of different
+ * settings: smaller then, larger then, and between and sync between filter and drag."
+ *
+ * The mirror used to recognise exactly one condition shape, `NOT(conf < X)` matched on
+ * operator AND logical op, at the top level only. Everything else was invisible: a
+ * drag appended a second, contradictory condition instead of replacing the first, and
+ * the slider read 0% while the plot was heavily filtered.
+ */
+describe('control-bar EAT reliability filter — all operators (#380)', () => {
+  let controlBar: ControlBarInternals;
+  let scatter: StubScatterplot;
+
+  beforeEach(async () => {
+    document.body.innerHTML = '';
+    controlBar = document.createElement('protspace-control-bar') as ControlBarInternals;
+    controlBar.autoSync = false;
+    document.body.appendChild(controlBar);
+    await controlBar.updateComplete;
+
+    scatter = {
+      selectedProteinIds: ['sentinel'],
+      isolateSelection: vi.fn(),
+      resetIsolation: vi.fn(),
+      getCurrentData: vi.fn(() => makeEatData()),
+      getMaterializedData: vi.fn(() => makeEatData()),
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+    };
+    controlBar._scatterplotElement = scatter;
+    controlBar._currentData = makeEatData();
+    controlBar.selectedAnnotation = 'family';
+    await controlBar.updateComplete;
+  });
+
+  function eatConditions(query: FilterQuery) {
+    return query.filter(
+      (item) => 'kind' in item && item.kind === 'numeric' && item.annotation === EAT_KEY,
+    );
+  }
+
+  it('replaces a hand-built "greater than" rather than appending beside it', () => {
+    // The query builder DEFAULTS to `gt` when an eat-confidence column is picked, so
+    // this is the most likely thing a user has on screen.
+    controlBar._handleQueryChanged(
+      new CustomEvent('query-changed', {
+        detail: {
+          query: [
+            { id: 'x', kind: 'numeric', annotation: EAT_KEY, operator: 'gt', min: 0.5, max: null },
+          ],
+        },
+      }),
+    );
+
+    controlBar.setEatConfidenceThreshold('family', 0.3);
+
+    // Exactly one reliability condition survives — no silently AND-ed contradiction.
+    expect(eatConditions(controlBar.filterQuery)).toHaveLength(1);
+  });
+
+  it('replaces a hand-built "between" rather than appending beside it', () => {
+    controlBar._handleQueryChanged(
+      new CustomEvent('query-changed', {
+        detail: {
+          query: [
+            {
+              id: 'x',
+              kind: 'numeric',
+              annotation: EAT_KEY,
+              operator: 'between',
+              min: 0.4,
+              max: 0.9,
+            },
+          ],
+        },
+      }),
+    );
+
+    controlBar.setEatConfidenceThreshold('family', 0.6);
+    expect(eatConditions(controlBar.filterQuery)).toHaveLength(1);
+  });
+
+  it('replaces a NON-negated "less than", which used to blank the canvas', () => {
+    // conf < 0.5 AND NOT(conf < 0.5) evaluates to the empty set. That used to be
+    // pushed as an ACTIVE filter, hiding every point with no way back.
+    controlBar._handleQueryChanged(
+      new CustomEvent('query-changed', {
+        detail: {
+          query: [
+            { id: 'x', kind: 'numeric', annotation: EAT_KEY, operator: 'lt', min: null, max: 0.5 },
+          ],
+        },
+      }),
+    );
+
+    controlBar.setEatConfidenceThreshold('family', 0.5);
+
+    expect(eatConditions(controlBar.filterQuery)).toHaveLength(1);
+    expect(scatter.filteredProteinIds?.length ?? 0).toBeGreaterThan(0);
+  });
+
+  it('never hides the curated points, in any mode', () => {
+    // p0-p4 carry a null confidence: they are curated, and the slider's own help text
+    // promises they always stay visible. Only a NOT-complement keeps them.
+    const curated = ['p0', 'p1', 'p2', 'p3', 'p4'];
+    const modes = [
+      { mode: 'atLeast' as const, min: 0.5, max: 1 },
+      { mode: 'atMost' as const, min: 0, max: 0.5 },
+      { mode: 'between' as const, min: 0.4, max: 0.8 },
+    ];
+
+    for (const state of modes) {
+      controlBar.setEatReliability('family', state);
+      for (const id of curated) {
+        expect(scatter.filteredProteinIds).toContain(id);
+      }
+    }
+  });
+
+  it('applies an upper bound that actually removes the high-confidence points', () => {
+    controlBar.setEatReliability('family', { mode: 'atMost', min: 0, max: 0.5 });
+    // p19 has confidence 0.95 — above the bound, so it must be gone; p5 (0.25) stays.
+    expect(scatter.filteredProteinIds).not.toContain('p19');
+    expect(scatter.filteredProteinIds).toContain('p5');
+  });
+
+  it('applies a band from both sides', () => {
+    controlBar.setEatReliability('family', { mode: 'between', min: 0.4, max: 0.6 });
+    expect(scatter.filteredProteinIds).not.toContain('p5'); // 0.25, below the band
+    expect(scatter.filteredProteinIds).not.toContain('p19'); // 0.95, above the band
+    expect(scatter.filteredProteinIds).toContain('p10'); // 0.50, inside
+  });
+
+  it('finds and replaces a reliability condition nested in a group', () => {
+    controlBar._handleQueryChanged(
+      new CustomEvent('query-changed', {
+        detail: {
+          query: [
+            {
+              id: 'g',
+              conditions: [
+                {
+                  id: 'x',
+                  kind: 'numeric',
+                  annotation: EAT_KEY,
+                  operator: 'lt',
+                  min: null,
+                  max: 0.2,
+                  logicalOp: 'NOT',
+                },
+              ],
+            },
+          ],
+        },
+      }),
+    );
+
+    controlBar.setEatConfidenceThreshold('family', 0.7);
+
+    // The nested one is gone rather than duplicated at top level.
+    const all = JSON.stringify(controlBar.filterQuery);
+    expect(all.match(/eat_confidence/g) ?? []).toHaveLength(1);
+  });
+
+  it('does not blank the plot when the query matches nothing', () => {
+    // An impossible band: nothing sits above 0.9 AND below 0.91 except by luck.
+    controlBar.setEatReliability('family', { mode: 'between', min: 0.99, max: 0.995 });
+    // Whatever the outcome, the filter channel must never be left "active but empty",
+    // which reads as "hide everything".
+    if ((scatter.filteredProteinIds?.length ?? 0) === 0) {
+      expect(scatter.filtersActive).toBe(false);
+    }
   });
 });

--- a/packages/core/src/components/control-bar/control-bar.ts
+++ b/packages/core/src/components/control-bar/control-bar.ts
@@ -27,9 +27,21 @@ import {
 import './search';
 import './annotation-select';
 import './query-builder';
-import type { FilterQuery, FilterQueryItem, NumericCondition } from './query-types';
-import { createCondition, createNumericCondition, isFilterGroup } from './query-types';
+import type { FilterQuery } from './query-types';
+import { createCondition } from './query-types';
 import { evaluateQuery, hasConfiguredCondition } from './query-evaluate';
+import { findOwnedCondition, replaceOwnedConditions } from './query-owned';
+import {
+  DEFAULT_EAT_RELIABILITY,
+  conditionsForReliability,
+  reliabilityFromConditions,
+} from './eat-reliability';
+import type { EatReliabilityState } from './eat-reliability';
+
+/** Structural equality for a reliability state — the mirror's de-dupe comparison. */
+function isSameReliability(a: EatReliabilityState, b: EatReliabilityState): boolean {
+  return a.mode === b.mode && a.min === b.min && a.max === b.max;
+}
 
 /** Stable empty statistics — a fresh [] per render would dirty the child on every update. */
 const NO_STATISTICS: readonly ProjectionStatisticRow[] = [];
@@ -84,10 +96,13 @@ export class ProtspaceControlBar extends LitElement {
   @state() private showProjectionMenu: boolean = false;
   @state() private filterQuery: FilterQuery = [];
   @state() private filterActive = false;
-  // Last reliability threshold reflected across the slider<->query mirror. Both
-  // directions compare against it so the forward (slider->query) and reverse
-  // (query->slider) paths can't ping-pong on an unchanged value (#6b).
-  private _lastEmittedThreshold = 0;
+  // Last reliability state reflected across the slider<->query mirror, PER
+  // eat-confidence column. Both directions compare against it so the forward
+  // (slider->query) and reverse (query->slider) paths can't ping-pong on an
+  // unchanged value (#6b). It is keyed because a single shared scalar let a drag on
+  // one base be de-duplicated against another base's threshold, silently dropping
+  // the drag or writing it onto the wrong annotation (#380).
+  private _lastMirroredState = new Map<string, EatReliabilityState>();
   @state() private _currentData: ProtspaceData | undefined;
   @state() private projectionHighlightIndex: number = -1;
 
@@ -535,7 +550,7 @@ export class ProtspaceControlBar extends LitElement {
     // filter channel is reset in parallel by applyPlotState.
     this.filterQuery = [];
     this.filterActive = false;
-    this._lastEmittedThreshold = 0;
+    this._lastMirroredState.clear();
   }
 
   private openFileDialog() {
@@ -1101,7 +1116,7 @@ export class ProtspaceControlBar extends LitElement {
     // NEW base's threshold: re-derive from that base's eat-confidence condition and
     // mirror it out. The value-compare guard inside keeps this from ping-ponging.
     if (changed.has('selectedAnnotation')) {
-      this._emitEatThresholdMirror();
+      this._emitEatThresholdMirror(true);
     }
   }
 
@@ -1570,6 +1585,19 @@ export class ProtspaceControlBar extends LitElement {
       .map((i) => proteinIds[i])
       .filter((id): id is string => id !== undefined);
 
+    // A query that matches nothing used to be pushed as an ACTIVE filter, which
+    // blanked the canvas: `_getVisibleProteinIdsSet()` reads an empty
+    // `filteredProteinIds` as "nothing is visible". Reaching that state was easy —
+    // a self-contradicting pair like `conf < 0.5 AND NOT(conf < 0.5)` — and there
+    // was no way back, because Apply is disabled and Cancel does not revert. Leave
+    // the plot as it is instead; the query builder still reports the 0 count (#380).
+    if (matchedIds.length === 0) {
+      sp.filteredProteinIds = [];
+      sp.filtersActive = false;
+      this.filterActive = false;
+      return;
+    }
+
     sp.filteredProteinIds = matchedIds;
     sp.filtersActive = true;
     this.filterActive = true;
@@ -1619,45 +1647,70 @@ export class ProtspaceControlBar extends LitElement {
       this._currentData = sp.getMaterializedData?.() ?? sp.getCurrentData?.() ?? this._currentData;
     }
 
-    const threshold = Number.isFinite(x) ? Math.min(1, Math.max(0, x)) : 0;
-    const key = this._findEatConfidenceAnnotationKey(baseKey);
-    // Scope the read/write to THIS base's eat-confidence column so tuning one
-    // transferred base's slider can't clobber or misread another base's filter.
-    const current = this._thresholdForKey(key);
-    // Value-compare guard: the query already reflects this threshold, so
-    // re-applying would be redundant and could ping-pong with the reverse mirror.
-    if (threshold === current) return;
+    this.setEatReliability(baseKey, {
+      mode: 'atLeast',
+      min: Number.isFinite(x) ? Math.min(1, Math.max(0, x)) : 0,
+      max: 1,
+    });
+  }
 
-    this._lastEmittedThreshold = threshold;
-    // Remove ONLY this base's reliability condition; every other condition
-    // (other bases' eat filters, unrelated user filters) is preserved.
-    const next = key
-      ? this.filterQuery.filter((item) => !this._isReliabilityConditionForKey(item, key))
-      : [...this.filterQuery];
-    if (threshold > 0 && key) {
-      next.push(
-        createNumericCondition({
-          annotation: key,
-          operator: 'lt',
-          max: threshold,
-          logicalOp: 'NOT',
-        }),
-      );
+  /**
+   * Forward mirror, generalised (#380). The slider owns the reliability conditions
+   * for one base annotation and replaces them wholesale on every change, at any
+   * depth in the query. It used to pattern-match `NOT(conf < X)` at the top level
+   * only, so a hand-built `>`, a band, or anything inside a group was invisible —
+   * and a drag appended a second, contradictory condition beside it.
+   */
+  public setEatReliability(baseKey: string, state: EatReliabilityState): void {
+    // Always resync `_currentData` from the scatter plot's materialized snapshot
+    // before deriving the condition. On a dataset switch the seed can fire before
+    // the plot's data-change event has refreshed `_currentData`, and
+    // clearForNewDataset does NOT reset it — so a stale snapshot would resolve the
+    // eat-confidence column and map matched indices against the PREVIOUS dataset's
+    // protein ids.
+    if (this._scatterplotElement) {
+      const sp = this._scatterplotElement as ScatterplotElementLike;
+      this._currentData = sp.getMaterializedData?.() ?? sp.getCurrentData?.() ?? this._currentData;
     }
-    this.filterQuery = next;
+
+    const key = this._findEatConfidenceAnnotationKey(baseKey);
+    if (!key) return;
+
+    // Value-compare guard, scoped to THIS base: the query already reflects this
+    // state, so re-applying would be redundant and could ping-pong with the reverse
+    // mirror. Keyed, so a drag on one base is never de-duplicated against another's.
+    const current = this._reliabilityForKey(key);
+    if (isSameReliability(current, state)) return;
+    this._lastMirroredState.set(key, state);
+
+    this.filterQuery = replaceOwnedConditions(
+      this.filterQuery,
+      'eat-reliability',
+      key,
+      conditionsForReliability(key, state),
+    );
     this._applyQuery();
   }
 
-  private _emitEatThresholdMirror(): void {
-    // Scope to the SELECTED base: the slider shows the threshold for the base the
-    // user is currently coloring by, so switching annotation moves it to that base.
+  /**
+   * Reverse mirror: tell the legend what the query currently says for the SELECTED
+   * base.
+   *
+   * `force` is set when the selected annotation changed. The slider is then showing
+   * the PREVIOUS base's position and must be repositioned even if this base's state
+   * is unchanged since the control bar last wrote it — the de-dupe guard exists only
+   * to stop the forward and reverse paths ping-ponging within one base.
+   */
+  private _emitEatThresholdMirror(force = false): void {
     const key = this._findEatConfidenceAnnotationKey(this.selectedAnnotation);
-    const derived = this._thresholdForKey(key);
-    if (derived === this._lastEmittedThreshold) return;
-    this._lastEmittedThreshold = derived;
+    if (!key) return;
+    const derived = this._reliabilityForKey(key);
+    const last = this._lastMirroredState.get(key);
+    if (!force && last && isSameReliability(last, derived)) return;
+    this._lastMirroredState.set(key, derived);
     this.dispatchEvent(
       new CustomEvent('eat-threshold-mirror', {
-        detail: { value: derived },
+        detail: { base: this.selectedAnnotation, state: derived, value: derived.min },
         bubbles: true,
         composed: true,
       }),
@@ -1677,35 +1730,13 @@ export class ProtspaceControlBar extends LitElement {
   }
 
   /**
-   * True when `item` is the reliability filter `NOT(<key> < X)` for the specific
-   * eat-confidence column `key` — numeric, that exact column, `lt`, negated.
+   * The reliability state currently expressed by the conditions the slider owns for
+   * eat-confidence column `key`, at any depth. Conditions are matched by their
+   * declared `owner`, not by their shape, which is what lets every operator mirror.
    */
-  private _isReliabilityConditionForKey(
-    item: FilterQueryItem,
-    key: string,
-  ): item is NumericCondition {
-    return (
-      !isFilterGroup(item) &&
-      item.kind === 'numeric' &&
-      item.annotation === key &&
-      item.operator === 'lt' &&
-      item.logicalOp === 'NOT'
-    );
-  }
-
-  /** The reliability `NOT(<key> < X)` condition for eat-confidence column `key`, if present. */
-  private _findReliabilityConditionForKey(
-    query: FilterQuery,
-    key: string,
-  ): NumericCondition | undefined {
-    return query.find((item): item is NumericCondition =>
-      this._isReliabilityConditionForKey(item, key),
-    );
-  }
-
-  /** The current reliability threshold for eat-confidence column `key` (0 if none/unresolved). */
-  private _thresholdForKey(key: string | undefined): number {
-    return key ? (this._findReliabilityConditionForKey(this.filterQuery, key)?.max ?? 0) : 0;
+  private _reliabilityForKey(key: string | undefined): EatReliabilityState {
+    if (!key) return DEFAULT_EAT_RELIABILITY;
+    return reliabilityFromConditions(findOwnedCondition(this.filterQuery, 'eat-reliability', key));
   }
 
   private _handleQueryReset() {

--- a/packages/core/src/components/control-bar/eat-reliability.test.ts
+++ b/packages/core/src/components/control-bar/eat-reliability.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, it } from 'vitest';
+import {
+  DEFAULT_EAT_RELIABILITY,
+  conditionsForReliability,
+  reliabilityFromConditions,
+} from './eat-reliability';
+import type { EatReliabilityState } from './eat-reliability';
+
+const KEY = 'ec__eat_confidence';
+
+describe('conditionsForReliability', () => {
+  it('emits nothing at the default, so a fresh dataset has a clean filter box', () => {
+    expect(conditionsForReliability(KEY, DEFAULT_EAT_RELIABILITY)).toEqual([]);
+  });
+
+  it('expresses every mode as a NOT, so curated points are retained by construction', () => {
+    const states: EatReliabilityState[] = [
+      { mode: 'atLeast', min: 0.3, max: 1 },
+      { mode: 'atMost', min: 0, max: 0.7 },
+      { mode: 'between', min: 0.3, max: 0.7 },
+    ];
+    for (const state of states) {
+      const conditions = conditionsForReliability(KEY, state);
+      expect(conditions.length).toBeGreaterThan(0);
+      // A positive operator would exclude null-confidence (curated) proteins; only the
+      // NOT index-complement re-includes them. See query-numeric-helpers.ts.
+      expect(conditions.every((c) => c.logicalOp === 'NOT')).toBe(true);
+      expect(conditions.every((c) => c.owner === 'eat-reliability')).toBe(true);
+      expect(conditions.every((c) => c.annotation === KEY)).toBe(true);
+    }
+  });
+
+  it('keeps "at least" on the shape the shipped bundles already carry', () => {
+    const [condition] = conditionsForReliability(KEY, { mode: 'atLeast', min: 0.4, max: 1 });
+    expect(condition).toMatchObject({ operator: 'lt', max: 0.4, logicalOp: 'NOT' });
+  });
+
+  it('uses a single upper-bound condition for "at most"', () => {
+    const [condition] = conditionsForReliability(KEY, { mode: 'atMost', min: 0, max: 0.6 });
+    expect(condition).toMatchObject({ operator: 'gt', min: 0.6, logicalOp: 'NOT' });
+  });
+
+  it('uses two conditions for a band, not a single between()', () => {
+    // NOT(between(a,b)) is the band's complement — the inverse of what the slider means.
+    const conditions = conditionsForReliability(KEY, { mode: 'between', min: 0.3, max: 0.7 });
+    expect(conditions).toHaveLength(2);
+    expect(conditions.map((c) => c.operator).sort()).toEqual(['gt', 'lt']);
+  });
+
+  it('omits a bound that is not constraining', () => {
+    expect(conditionsForReliability(KEY, { mode: 'between', min: 0, max: 1 })).toHaveLength(0);
+    expect(conditionsForReliability(KEY, { mode: 'between', min: 0.5, max: 1 })).toHaveLength(1);
+  });
+});
+
+describe('reliabilityFromConditions', () => {
+  it('round-trips every mode', () => {
+    const states: EatReliabilityState[] = [
+      { mode: 'atLeast', min: 0.3, max: 1 },
+      { mode: 'atMost', min: 0, max: 0.7 },
+      { mode: 'between', min: 0.25, max: 0.75 },
+    ];
+    for (const state of states) {
+      expect(reliabilityFromConditions(conditionsForReliability(KEY, state))).toEqual(state);
+    }
+  });
+
+  it('reads no conditions as the default', () => {
+    expect(reliabilityFromConditions([])).toEqual(DEFAULT_EAT_RELIABILITY);
+  });
+});
+
+describe('reliabilityFromConditions — the logical op flips the bound', () => {
+  it('reads NOT(conf < X) as a lower bound but a bare conf < X as an upper bound', () => {
+    const negated = reliabilityFromConditions([
+      {
+        id: 'a',
+        kind: 'numeric',
+        annotation: KEY,
+        operator: 'lt',
+        min: null,
+        max: 0.5,
+        logicalOp: 'NOT',
+      },
+    ]);
+    expect(negated).toEqual({ mode: 'atLeast', min: 0.5, max: 1 });
+
+    const bare = reliabilityFromConditions([
+      { id: 'b', kind: 'numeric', annotation: KEY, operator: 'lt', min: null, max: 0.5 },
+    ]);
+    expect(bare).toEqual({ mode: 'atMost', min: 0, max: 0.5 });
+  });
+
+  it('reads NOT(conf > X) as an upper bound but a bare conf > X as a lower bound', () => {
+    const negated = reliabilityFromConditions([
+      {
+        id: 'a',
+        kind: 'numeric',
+        annotation: KEY,
+        operator: 'gt',
+        min: 0.5,
+        max: null,
+        logicalOp: 'NOT',
+      },
+    ]);
+    expect(negated).toEqual({ mode: 'atMost', min: 0, max: 0.5 });
+
+    const bare = reliabilityFromConditions([
+      { id: 'b', kind: 'numeric', annotation: KEY, operator: 'gt', min: 0.5, max: null },
+    ]);
+    expect(bare).toEqual({ mode: 'atLeast', min: 0.5, max: 1 });
+  });
+});

--- a/packages/core/src/components/control-bar/eat-reliability.ts
+++ b/packages/core/src/components/control-bar/eat-reliability.ts
@@ -1,5 +1,8 @@
 import { createNumericCondition } from './query-types';
 import type { NumericCondition } from './query-types';
+import type { EatReliabilityState } from '@protspace/utils';
+
+export type { EatReliabilityState };
 
 /**
  * The EAT reliability filter's user-facing model, and its translation to and from
@@ -25,16 +28,6 @@ import type { NumericCondition } from './query-types';
  * A band needs two conditions rather than one `between`: `NOT(between(a,b))` is the
  * band's *complement*, the inverse of what the control means.
  */
-
-export type EatReliabilityMode = 'atLeast' | 'atMost' | 'between';
-
-export interface EatReliabilityState {
-  mode: EatReliabilityMode;
-  /** Lower bound, used by `atLeast` and `between`. 0 means "no lower bound". */
-  min: number;
-  /** Upper bound, used by `atMost` and `between`. 1 means "no upper bound". */
-  max: number;
-}
 
 /**
  * "Show everything." Emits no condition at all, so a fresh dataset — or a bundle with

--- a/packages/core/src/components/control-bar/eat-reliability.ts
+++ b/packages/core/src/components/control-bar/eat-reliability.ts
@@ -1,0 +1,135 @@
+import { createNumericCondition } from './query-types';
+import type { NumericCondition } from './query-types';
+
+/**
+ * The EAT reliability filter's user-facing model, and its translation to and from
+ * query conditions.
+ *
+ * ## Why every mode is a NOT
+ *
+ * `matchesNumericValue` returns false for a null value, and curated proteins carry
+ * null in the eat-confidence column because they have no prediction to score. Only
+ * the `NOT` index-complement in `query-evaluate.ts` puts them back. So a positive
+ * `confidence > X` hides the entire curated background — typically most of the
+ * dataset — which is the opposite of what the slider promises ("curated annotations
+ * always stay visible").
+ *
+ * Expressing all three modes as NOT-complements makes that promise true by
+ * construction, in every mode, without touching the evaluator's null semantics —
+ * which are deliberate and locked by characterization tests in query-evaluate.test.ts.
+ *
+ *   at least X    ->  NOT(conf < X)                    (the shape shipped bundles carry)
+ *   at most  X    ->  NOT(conf > X)
+ *   between A,B   ->  NOT(conf < A) AND NOT(conf > B)
+ *
+ * A band needs two conditions rather than one `between`: `NOT(between(a,b))` is the
+ * band's *complement*, the inverse of what the control means.
+ */
+
+export type EatReliabilityMode = 'atLeast' | 'atMost' | 'between';
+
+export interface EatReliabilityState {
+  mode: EatReliabilityMode;
+  /** Lower bound, used by `atLeast` and `between`. 0 means "no lower bound". */
+  min: number;
+  /** Upper bound, used by `atMost` and `between`. 1 means "no upper bound". */
+  max: number;
+}
+
+/**
+ * "Show everything." Emits no condition at all, so a fresh dataset — or a bundle with
+ * no saved position — leaves the filter box clean, the contract the EAT e2e asserts.
+ */
+export const DEFAULT_EAT_RELIABILITY: EatReliabilityState = { mode: 'atLeast', min: 0, max: 1 };
+
+const clamp01 = (value: number): number =>
+  Number.isFinite(value) ? Math.min(1, Math.max(0, value)) : 0;
+
+function lowerBound(annotation: string, min: number): NumericCondition {
+  return createNumericCondition({
+    annotation,
+    owner: 'eat-reliability',
+    operator: 'lt',
+    max: min,
+    logicalOp: 'NOT',
+  });
+}
+
+function upperBound(annotation: string, max: number): NumericCondition {
+  return createNumericCondition({
+    annotation,
+    owner: 'eat-reliability',
+    operator: 'gt',
+    min: max,
+    logicalOp: 'NOT',
+  });
+}
+
+/** The owned conditions expressing `state`. Empty when nothing is constrained. */
+export function conditionsForReliability(
+  annotation: string,
+  state: EatReliabilityState,
+): NumericCondition[] {
+  const min = clamp01(state.min);
+  const max = clamp01(state.max);
+  const conditions: NumericCondition[] = [];
+  if (state.mode !== 'atMost' && min > 0) conditions.push(lowerBound(annotation, min));
+  if (state.mode !== 'atLeast' && max < 1) conditions.push(upperBound(annotation, max));
+  return conditions;
+}
+
+/**
+ * Recover the slider position from the conditions it owns — the reverse mirror.
+ * Unrecognised or partial sets degrade to whichever bounds are present rather than
+ * silently resetting to 0, which is what made a hand-built condition invisible.
+ */
+export function reliabilityFromConditions(
+  conditions: readonly NumericCondition[],
+): EatReliabilityState {
+  let min = 0;
+  let max = 1;
+  let hasLower = false;
+  let hasUpper = false;
+
+  for (const condition of conditions) {
+    // The logical op flips which side of the bound is kept, so it cannot be ignored:
+    // `NOT(conf < X)` keeps confidence AT OR ABOVE X (a lower bound), while a bare
+    // `conf < X` keeps confidence BELOW X (an upper bound) — opposite meanings from
+    // the same operator. Reading a bare `lt` as a lower bound made the slider believe
+    // a hand-built condition already said what it was about to write, so it skipped
+    // the replacement and left the contradiction in place.
+    const negated = condition.logicalOp === 'NOT';
+    if (condition.operator === 'lt' && condition.max !== null) {
+      if (negated) {
+        min = clamp01(condition.max);
+        hasLower = true;
+      } else {
+        max = clamp01(condition.max);
+        hasUpper = true;
+      }
+    } else if (condition.operator === 'gt' && condition.min !== null) {
+      if (negated) {
+        max = clamp01(condition.min);
+        hasUpper = true;
+      } else {
+        min = clamp01(condition.min);
+        hasLower = true;
+      }
+    } else if (condition.operator === 'between') {
+      // A hand-built band the user tagged onto this column; read both bounds.
+      if (condition.min !== null) {
+        min = clamp01(condition.min);
+        hasLower = true;
+      }
+      if (condition.max !== null) {
+        max = clamp01(condition.max);
+        hasUpper = true;
+      }
+    }
+  }
+
+  if (hasLower && hasUpper) return { mode: 'between', min, max };
+  if (hasUpper) return { mode: 'atMost', min: 0, max };
+  if (hasLower) return { mode: 'atLeast', min, max: 1 };
+  return DEFAULT_EAT_RELIABILITY;
+}

--- a/packages/core/src/components/control-bar/query-owned.test.ts
+++ b/packages/core/src/components/control-bar/query-owned.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from 'vitest';
+import { createGroup, createNumericCondition, isFilterGroup } from './query-types';
+import type { FilterQuery, NumericCondition } from './query-types';
+import { findOwnedCondition, replaceOwnedConditions } from './query-owned';
+
+const KEY = 'ec__eat_confidence';
+
+function owned(overrides: Partial<NumericCondition> = {}): NumericCondition {
+  return createNumericCondition({
+    annotation: KEY,
+    owner: 'eat-reliability',
+    operator: 'lt',
+    max: 0.5,
+    logicalOp: 'NOT',
+    ...overrides,
+  });
+}
+
+describe('findOwnedCondition', () => {
+  it('finds an owned condition whatever its operator', () => {
+    for (const operator of ['gt', 'lt', 'between'] as const) {
+      const query: FilterQuery = [owned({ operator })];
+      expect(findOwnedCondition(query, 'eat-reliability', KEY)).toHaveLength(1);
+    }
+  });
+
+  it('finds an owned condition nested inside a group', () => {
+    const query: FilterQuery = [createGroup({ conditions: [owned()] })];
+    expect(findOwnedCondition(query, 'eat-reliability', KEY)).toHaveLength(1);
+  });
+
+  it('finds every owned condition when the slider owns a two-sided band', () => {
+    const query: FilterQuery = [
+      owned({ operator: 'lt', max: 0.3 }),
+      owned({ operator: 'gt', min: 0.9 }),
+    ];
+    expect(findOwnedCondition(query, 'eat-reliability', KEY)).toHaveLength(2);
+  });
+
+  it('claims an untagged condition on the same column, whatever its operator', () => {
+    // This is the heart of #380: a condition the user hand-built in the query builder
+    // carries no owner tag, and the eat-confidence column exists only to drive the
+    // reliability filter — so the slider must recognise it rather than append a
+    // second, contradictory condition beside it. `gt` matters most: it is what the
+    // query builder produces by default when an eat-confidence column is picked.
+    for (const operator of ['gt', 'lt', 'between'] as const) {
+      const query: FilterQuery = [createNumericCondition({ annotation: KEY, operator, min: 0.5 })];
+      expect(findOwnedCondition(query, 'eat-reliability', KEY)).toHaveLength(1);
+    }
+  });
+
+  it('ignores an owned condition belonging to a different base annotation', () => {
+    const query: FilterQuery = [owned({ annotation: 'go__eat_confidence' })];
+    expect(findOwnedCondition(query, 'eat-reliability', KEY)).toHaveLength(0);
+  });
+});
+
+describe('replaceOwnedConditions', () => {
+  it('removes owned conditions at any depth and appends the replacements', () => {
+    const untouched = createNumericCondition({ annotation: 'length', operator: 'gt', min: 10 });
+    const query: FilterQuery = [untouched, createGroup({ conditions: [owned()] })];
+
+    const next = replaceOwnedConditions(query, 'eat-reliability', KEY, [
+      owned({ operator: 'gt', min: 0.8 }),
+    ]);
+
+    const flat = next.filter((i): i is NumericCondition => !isFilterGroup(i));
+    expect(flat.some((c) => c.annotation === 'length')).toBe(true);
+    expect(findOwnedCondition(next, 'eat-reliability', KEY)).toHaveLength(1);
+    expect(findOwnedCondition(next, 'eat-reliability', KEY)[0]?.operator).toBe('gt');
+  });
+
+  it('drops the owned conditions entirely when given none', () => {
+    const query: FilterQuery = [owned()];
+    expect(
+      findOwnedCondition(
+        replaceOwnedConditions(query, 'eat-reliability', KEY, []),
+        'eat-reliability',
+        KEY,
+      ),
+    ).toHaveLength(0);
+  });
+
+  it('leaves another base annotation’s owned condition alone', () => {
+    const other = owned({ annotation: 'go__eat_confidence' });
+    const next = replaceOwnedConditions([other, owned()], 'eat-reliability', KEY, []);
+    expect(findOwnedCondition(next, 'eat-reliability', 'go__eat_confidence')).toHaveLength(1);
+  });
+
+  it('prunes a group left empty so it cannot AND-kill the query', () => {
+    const query: FilterQuery = [createGroup({ conditions: [owned()] })];
+    const next = replaceOwnedConditions(query, 'eat-reliability', KEY, []);
+    expect(next.filter(isFilterGroup)).toHaveLength(0);
+  });
+});

--- a/packages/core/src/components/control-bar/query-owned.ts
+++ b/packages/core/src/components/control-bar/query-owned.ts
@@ -1,0 +1,84 @@
+import type { ConditionOwner, FilterQuery, FilterQueryItem, NumericCondition } from './query-types';
+import { isFilterGroup } from './query-types';
+
+/**
+ * Locating and replacing the conditions a dedicated control owns.
+ *
+ * The EAT reliability slider used to identify "its" condition by matching the shape
+ * `NOT(<eatKey> < X)` on operator and logical op, at the top level only. That made
+ * `>`, `between`, a non-negated `<`, and anything nested in a group invisible to it —
+ * so a drag appended a second, contradictory condition instead of replacing the first
+ * (#380). Matching on a declared owner instead makes every operator ownable, and
+ * recursing makes depth irrelevant.
+ */
+
+/**
+ * A numeric condition counts as owned when it targets the owning control's column and
+ * carries either that owner's tag or no tag at all.
+ *
+ * Untagged counts deliberately. An eat-confidence column exists *only* to drive the
+ * reliability filter — the frontend synthesises it and keeps it out of the colour-by
+ * dropdown — so a condition on it is a reliability filter however it was built. If
+ * ownership required the tag, a condition the user hand-built in the query builder
+ * would stay invisible to the slider, which is the bug (#380), and a condition
+ * restored from a bundle written before the tag existed would too.
+ */
+function isOwnedBy(
+  item: FilterQueryItem,
+  owner: ConditionOwner,
+  annotation: string,
+): item is NumericCondition {
+  return (
+    !isFilterGroup(item) &&
+    item.kind === 'numeric' &&
+    item.annotation === annotation &&
+    (item.owner === owner || item.owner === undefined)
+  );
+}
+
+/** Every condition `owner` owns for `annotation`, at any depth, in document order. */
+export function findOwnedCondition(
+  query: FilterQuery,
+  owner: ConditionOwner,
+  annotation: string,
+): NumericCondition[] {
+  const found: NumericCondition[] = [];
+  const walk = (items: readonly FilterQueryItem[]) => {
+    for (const item of items) {
+      if (isFilterGroup(item)) walk(item.conditions);
+      else if (isOwnedBy(item, owner, annotation)) found.push(item);
+    }
+  };
+  walk(query);
+  return found;
+}
+
+/**
+ * Drop every condition `owner` owns for `annotation` (at any depth) and append
+ * `next` at the top level. Conditions owned for a DIFFERENT annotation, and every
+ * hand-built condition, are preserved untouched.
+ *
+ * A group left empty by the removal is pruned: `evaluateItems` treats an empty group
+ * as match-all, but keeping a visibly empty group in the builder is confusing, and an
+ * empty group is never something the user authored.
+ */
+export function replaceOwnedConditions(
+  query: FilterQuery,
+  owner: ConditionOwner,
+  annotation: string,
+  next: readonly NumericCondition[],
+): FilterQuery {
+  const strip = (items: readonly FilterQueryItem[]): FilterQueryItem[] => {
+    const out: FilterQueryItem[] = [];
+    for (const item of items) {
+      if (isFilterGroup(item)) {
+        const conditions = strip(item.conditions);
+        if (conditions.length > 0) out.push({ ...item, conditions });
+      } else if (!isOwnedBy(item, owner, annotation)) {
+        out.push(item);
+      }
+    }
+    return out;
+  };
+  return [...strip(query), ...next];
+}

--- a/packages/core/src/components/control-bar/query-types.ts
+++ b/packages/core/src/components/control-bar/query-types.ts
@@ -1,10 +1,22 @@
 export type LogicalOp = 'AND' | 'OR' | 'NOT';
 export type NumericOperator = 'gt' | 'lt' | 'between';
 
+/**
+ * Marks a condition as owned by a dedicated control rather than hand-built.
+ *
+ * The EAT reliability slider used to find "its" condition by pattern-matching the
+ * shape `NOT(<eatKey> < X)` — operator AND logical op — which made every other
+ * operator invisible to it (#380). Ownership is now declared, so the slider can own
+ * `<`, `>` or a two-sided band and still recognise it, and a condition the user built
+ * by hand on an eat-confidence column is the same object the slider owns.
+ */
+export type ConditionOwner = 'eat-reliability';
+
 interface BaseCondition {
   id: string;
   logicalOp?: LogicalOp;
   annotation: string;
+  owner?: ConditionOwner;
 }
 
 export interface CategoricalCondition extends BaseCondition {

--- a/packages/core/src/components/legend/legend.eat-controls.test.ts
+++ b/packages/core/src/components/legend/legend.eat-controls.test.ts
@@ -96,7 +96,7 @@ describe('legend-owned EAT controls', () => {
     ).toBe('73');
     expect(listener).toHaveBeenLastCalledWith(
       expect.objectContaining({
-        detail: { enabled: true, confidenceThreshold: 0.73 },
+        detail: expect.objectContaining({ enabled: true, confidenceThreshold: 0.73 }),
       }),
     );
 
@@ -106,7 +106,9 @@ describe('legend-owned EAT controls', () => {
     percent.dispatchEvent(new Event('change'));
     await legend.updateComplete;
     expect(listener).toHaveBeenLastCalledWith(
-      expect.objectContaining({ detail: { enabled: true, confidenceThreshold: 0.34 } }),
+      expect.objectContaining({
+        detail: expect.objectContaining({ enabled: true, confidenceThreshold: 0.34 }),
+      }),
     );
     expect(range.value).toBe('0.34');
   });
@@ -136,7 +138,9 @@ describe('legend-owned EAT controls', () => {
     vi.advanceTimersByTime(150);
     expect(listener).toHaveBeenCalledTimes(1);
     expect(listener).toHaveBeenLastCalledWith(
-      expect.objectContaining({ detail: { enabled: true, confidenceThreshold: 0.62 } }),
+      expect.objectContaining({
+        detail: expect.objectContaining({ enabled: true, confidenceThreshold: 0.62 }),
+      }),
     );
   });
 
@@ -158,7 +162,9 @@ describe('legend-owned EAT controls', () => {
     vi.advanceTimersByTime(150);
     expect(listener).toHaveBeenCalledTimes(1);
     expect(listener).toHaveBeenLastCalledWith(
-      expect.objectContaining({ detail: { enabled: true, confidenceThreshold: 0.45 } }),
+      expect.objectContaining({
+        detail: expect.objectContaining({ enabled: true, confidenceThreshold: 0.45 }),
+      }),
     );
   });
 
@@ -179,7 +185,9 @@ describe('legend-owned EAT controls', () => {
     range.dispatchEvent(new Event('change'));
     expect(listener).toHaveBeenCalledTimes(1);
     expect(listener).toHaveBeenLastCalledWith(
-      expect.objectContaining({ detail: { enabled: true, confidenceThreshold: 0.4 } }),
+      expect.objectContaining({
+        detail: expect.objectContaining({ enabled: true, confidenceThreshold: 0.4 }),
+      }),
     );
 
     // The already-flushed timer must not fire a duplicate emit.
@@ -200,7 +208,9 @@ describe('legend-owned EAT controls', () => {
     // The toggle is a discrete action, not a drag — it emits synchronously.
     expect(listener).toHaveBeenCalledTimes(1);
     expect(listener).toHaveBeenLastCalledWith(
-      expect.objectContaining({ detail: { enabled: false, confidenceThreshold: 0 } }),
+      expect.objectContaining({
+        detail: expect.objectContaining({ enabled: false, confidenceThreshold: 0 }),
+      }),
     );
   });
 
@@ -284,5 +294,72 @@ describe('legend-owned EAT controls', () => {
     legend.requestUpdate();
     await legend.updateComplete;
     expect(legend.shadowRoot!.querySelector('.eat-legend')).toBeNull();
+  });
+});
+
+/**
+ * #380 — the legend must be able to express the three filter directions the issue
+ * names, not just "hide below". Each mode emits the full state so the control bar
+ * can translate it into NOT-form conditions that keep curated points visible.
+ */
+describe('legend EAT reliability modes (#380)', () => {
+  afterEach(() => {
+    document.body.innerHTML = '';
+    vi.restoreAllMocks();
+    vi.useRealTimers();
+  });
+
+  async function selectMode(mode: 'atLeast' | 'atMost' | 'between') {
+    const { legend } = await setup();
+    const listener = vi.fn();
+    legend.addEventListener('eat-overlay-change', listener);
+    const select = legend.shadowRoot!.querySelector<HTMLSelectElement>('.eat-threshold-mode')!;
+    select.value = mode;
+    select.dispatchEvent(new Event('change'));
+    await legend.updateComplete;
+    return { legend, listener };
+  }
+
+  it('offers all three directions', async () => {
+    const { legend } = await setup();
+    const options = Array.from(
+      legend.shadowRoot!.querySelectorAll<HTMLOptionElement>('.eat-threshold-mode option'),
+    ).map((o) => o.value);
+    expect(options).toEqual(['atLeast', 'atMost', 'between']);
+  });
+
+  it('emits the mode immediately, without waiting out the drag debounce', async () => {
+    const { listener } = await selectMode('atMost');
+    expect(listener).toHaveBeenCalled();
+    expect(listener.mock.lastCall?.[0].detail.reliability.mode).toBe('atMost');
+  });
+
+  it('reveals a second bound only for a band', async () => {
+    const { legend } = await selectMode('between');
+    expect(legend.shadowRoot!.querySelector('#eat-reliability-upper')).not.toBeNull();
+
+    const { legend: atLeast } = await selectMode('atLeast');
+    expect(atLeast.shadowRoot!.querySelector('#eat-reliability-upper')).toBeNull();
+  });
+
+  it('clears the bound a mode no longer uses, so no invisible constraint survives', async () => {
+    const { legend } = await setup();
+    legend.setReliabilityState({ mode: 'between', min: 0.2, max: 0.6 });
+    await legend.updateComplete;
+
+    const select = legend.shadowRoot!.querySelector<HTMLSelectElement>('.eat-threshold-mode')!;
+    select.value = 'atLeast';
+    select.dispatchEvent(new Event('change'));
+    await legend.updateComplete;
+
+    // The upper bound is no longer editable, so it must not still be filtering.
+    expect(legend.reliabilityState.max).toBe(1);
+  });
+
+  it('round-trips the full state through the reverse mirror', async () => {
+    const { legend } = await setup();
+    legend.setReliabilityState({ mode: 'between', min: 0.25, max: 0.75 });
+    await legend.updateComplete;
+    expect(legend.reliabilityState).toEqual({ mode: 'between', min: 0.25, max: 0.75 });
   });
 });

--- a/packages/core/src/components/legend/legend.ts
+++ b/packages/core/src/components/legend/legend.ts
@@ -26,6 +26,8 @@ import {
   type NumericBinningStrategy,
   type NumericAnnotationDisplaySettingsMap,
   type CategoryScore,
+  type EatReliabilityMode,
+  type EatReliabilityState,
 } from '@protspace/utils';
 import type { LegendSettingsMap } from '@protspace/utils';
 
@@ -185,6 +187,16 @@ export class ProtspaceLegend extends LitElement {
   @state() private _hoveredCategory: string | null = null;
   @state() private _eatOverlayEnabled = true;
   @state() private _eatConfidenceThreshold = DEFAULT_EAT_CONFIDENCE_THRESHOLD;
+  /**
+   * Which side(s) of the reliability scale the filter constrains (#380).
+   * `atLeast` hides low-confidence predictions (the original, default behaviour);
+   * `atMost` hides high-confidence ones, which is how you inspect what you would
+   * throw away; `between` isolates a band — the mid-confidence transfers worth
+   * reviewing by hand. Curated proteins stay visible in all three.
+   */
+  @state() private _eatReliabilityMode: EatReliabilityMode = 'atLeast';
+  /** Upper bound, used by `atMost` and `between`. 1 means "no upper bound". */
+  @state() private _eatConfidenceUpper = 1;
   @state() private _keyboardDragValue: string | null = null;
   private _announceManualPromotionOnNextReorder = false;
   private _keyboardReorderSnapshot: {
@@ -1128,12 +1140,35 @@ export class ProtspaceLegend extends LitElement {
       : DEFAULT_EAT_CONFIDENCE_THRESHOLD;
   }
 
+  /** The reliability filter as the control bar models it: a mode plus bounds. */
+  public get reliabilityState(): EatReliabilityState {
+    return {
+      mode: this._eatReliabilityMode,
+      min: this._eatConfidenceThreshold,
+      max: this._eatConfidenceUpper,
+    };
+  }
+
+  /**
+   * Reverse mirror for the full state. Cancels any pending drag commit first: a
+   * discrete update from the query side supersedes an in-flight drag, and leaving
+   * the timer armed let a stale late emit overwrite what the user had just typed
+   * into the Filter builder (#380).
+   */
+  public setReliabilityState(state: EatReliabilityState): void {
+    this._cancelEatThresholdCommit();
+    this._eatReliabilityMode = state.mode;
+    this._eatConfidenceThreshold = clamp01(state.min);
+    this._eatConfidenceUpper = clamp01(state.max);
+  }
+
   private _emitEatOverlayChange(): void {
     this.dispatchEvent(
       new CustomEvent('eat-overlay-change', {
         detail: {
           enabled: this._eatOverlayEnabled,
           confidenceThreshold: this._eatConfidenceThreshold,
+          reliability: this.reliabilityState,
         },
         bubbles: true,
         composed: true,
@@ -1150,6 +1185,33 @@ export class ProtspaceLegend extends LitElement {
 
   private _handleEatThresholdInput(event: Event): void {
     this._setEatConfidenceThresholdLive(Number((event.currentTarget as HTMLInputElement).value));
+  }
+
+  private _handleEatModeChange(event: Event): void {
+    const mode = (event.currentTarget as HTMLSelectElement).value as EatReliabilityMode;
+    this._eatReliabilityMode = mode;
+    // Reset the bound the new mode does not use, so switching modes cannot leave a
+    // stale constraint applied from a side the user can no longer see or edit.
+    if (mode === 'atLeast') this._eatConfidenceUpper = 1;
+    if (mode === 'atMost') this._eatConfidenceThreshold = 0;
+    // A mode change is a discrete decision, not a drag — apply it immediately.
+    this._cancelEatThresholdCommit();
+    this._emitEatOverlayChange();
+  }
+
+  private _handleEatUpperInput(event: Event): void {
+    this._setEatUpperLive(Number((event.currentTarget as HTMLInputElement).value));
+  }
+
+  private _handleEatUpperPercentInput(event: Event): void {
+    const value = Number((event.currentTarget as HTMLInputElement).value);
+    if (!Number.isFinite(value)) return;
+    this._setEatUpperLive(value / 100);
+  }
+
+  private _setEatUpperLive(value: number): void {
+    this._eatConfidenceUpper = Number.isFinite(value) ? clamp01(value) : 1;
+    this._debounceEatThresholdCommit();
   }
 
   private _handleEatThresholdPercentInput(event: Event): void {
@@ -2325,7 +2387,17 @@ export class ProtspaceLegend extends LitElement {
                 </div>
                 <div class="eat-threshold">
                   <div class="eat-threshold-heading">
-                    <label for="eat-reliability-threshold">Hide below reliability</label>
+                    <select
+                      class="eat-threshold-mode"
+                      aria-label="EAT reliability filter mode"
+                      .value=${this._eatReliabilityMode}
+                      ?disabled=${!this._eatOverlayEnabled}
+                      @change=${this._handleEatModeChange}
+                    >
+                      <option value="atLeast">Hide below</option>
+                      <option value="atMost">Hide above</option>
+                      <option value="between">Keep between</option>
+                    </select>
                     <span class="eat-threshold-value">
                       <input
                         class="eat-threshold-percent"
@@ -2355,11 +2427,47 @@ export class ProtspaceLegend extends LitElement {
                     max="1"
                     step="0.01"
                     .value=${String(this._eatConfidenceThreshold)}
-                    ?disabled=${!this._eatOverlayEnabled}
-                    aria-label="EAT reliability filter threshold"
+                    ?disabled=${!this._eatOverlayEnabled || this._eatReliabilityMode === 'atMost'}
+                    aria-label=${this._eatReliabilityMode === 'between'
+                      ? 'EAT reliability filter lower bound'
+                      : 'EAT reliability filter threshold'}
                     @input=${this._handleEatThresholdInput}
                     @change=${this._flushEatThresholdCommit}
                   />
+                  ${this._eatReliabilityMode !== 'atLeast'
+                    ? html`
+                        <div class="eat-threshold-heading">
+                          <label for="eat-reliability-upper">Upper bound</label>
+                          <span class="eat-threshold-value">
+                            <input
+                              class="eat-threshold-percent"
+                              type="number"
+                              min="0"
+                              max="100"
+                              step="1"
+                              .value=${String(Math.round(this._eatConfidenceUpper * 100))}
+                              ?disabled=${!this._eatOverlayEnabled}
+                              aria-label="EAT reliability upper bound percentage"
+                              @input=${this._handleEatUpperPercentInput}
+                              @change=${this._flushEatThresholdCommit}
+                            />
+                            <span aria-hidden="true">%</span>
+                          </span>
+                        </div>
+                        <input
+                          id="eat-reliability-upper"
+                          type="range"
+                          min="0"
+                          max="1"
+                          step="0.01"
+                          .value=${String(this._eatConfidenceUpper)}
+                          ?disabled=${!this._eatOverlayEnabled}
+                          aria-label="EAT reliability filter upper bound"
+                          @input=${this._handleEatUpperInput}
+                          @change=${this._flushEatThresholdCommit}
+                        />
+                      `
+                    : ''}
                 </div>
                 ${this._eatOverlayEnabled && this._eatCounts
                   ? html`

--- a/packages/core/src/components/legend/styles/layout.ts
+++ b/packages/core/src/components/legend/styles/layout.ts
@@ -172,6 +172,29 @@ export const layoutStyles = css`
     flex: 0 0 auto;
   }
 
+  /*
+   * The mode select replaces what used to be a static "Hide below reliability"
+   * label, so it must not grow the row: the EAT legend is asserted to stay inside
+   * its group with no horizontal overflow down to a 320px viewport.
+   */
+  .eat-threshold-mode {
+    box-sizing: border-box;
+    min-width: 0;
+    max-width: 100%;
+    padding: 0.1rem 0.2rem;
+    border: 1px solid var(--legend-border);
+    border-radius: 0.25rem;
+    background: var(--legend-bg);
+    color: var(--legend-text-color);
+    font: inherit;
+    cursor: pointer;
+  }
+
+  .eat-threshold-mode:disabled {
+    cursor: default;
+    opacity: 0.6;
+  }
+
   .eat-legend-counts {
     display: grid;
     gap: 0.1rem;

--- a/packages/core/src/components/scatter-plot/webgl/renderer/export-shaders.test.ts
+++ b/packages/core/src/components/scatter-plot/webgl/renderer/export-shaders.test.ts
@@ -18,7 +18,10 @@ describe('point shaders', () => {
       'mix(finalColor * v_color.a, linearKnockoutColor * PREDICTED_INTERIOR_FILL, predictedInterior)',
     );
     expect(POINT_FRAGMENT_SHADER).toContain('uniform vec3 u_knockoutColor;');
-    expect(POINT_FRAGMENT_SHADER).toContain('v_predicted < 0.5');
+    // The interior cut-out is the ONLY thing still gated on the predicted flag. This used to
+    // also assert `v_predicted < 0.5`, which pinned the outline being skipped on rings — the
+    // exact behaviour #369 asked to reconcile. The outline now applies to both classes (see
+    // the outline describe block), so the hollow interior is what distinguishes them.
     expect(POINT_FRAGMENT_SHADER).toContain('clamp(pixelScale * 1.75, 0.30, 0.55)');
     expect(POINT_FRAGMENT_SHADER).toContain('min(pixelScale, (1.0 - ringWidth) * 0.5)');
   });
@@ -42,5 +45,53 @@ describe('point shaders', () => {
     expect(POINT_FRAGMENT_SHADER).toContain(
       'mix(v_color.a, PREDICTED_INTERIOR_FILL, predictedInterior)',
     );
+  });
+
+  describe('outline (#369)', () => {
+    // The outline used to be a fraction of the sprite (strokeWidth = 0.15), so its absolute
+    // width shrank with point size AND with export scale. At the app's own nature-1col preset
+    // (89 mm @ 300 dpi) that put it below the reproducible-line floor for print, while the
+    // predicted ring survived — so the published figure had an outline on one glyph class only.
+    it('measures the outline in device pixels, not as a fraction of the sprite', () => {
+      expect(POINT_FRAGMENT_SHADER).toContain('OUTLINE_DEVICE_PX');
+      // The old sprite-fraction constant must be gone, or the width is size-dependent again.
+      expect(POINT_FRAGMENT_SHADER).not.toContain('float strokeWidth = 0.15;');
+    });
+
+    it('derives the outline width from the same isotropic pixel scale as the ring', () => {
+      // pixelScale is hoisted so both the ring and the outline share one definition; deriving
+      // the outline from fwidth() instead would make it ~41% wider on the diagonals.
+      const shader = POINT_FRAGMENT_SHADER;
+      const scaleDecl = shader.indexOf(
+        'float pixelScale = max(length(dFdx(coord)), length(dFdy(coord)));',
+      );
+      const ringBlock = shader.indexOf('if (v_predicted > 0.5)');
+      expect(scaleDecl).toBeGreaterThan(-1);
+      expect(scaleDecl).toBeLessThan(ringBlock);
+      expect(shader).toContain('OUTLINE_DEVICE_PX * pixelScale');
+    });
+
+    it('outlines predicted rings as well as filled dots', () => {
+      // The literal "reconcile" of #369: both glyph classes get the same outline treatment,
+      // and each keeps its own identity (filled vs hollow) as the primary encoding.
+      expect(POINT_FRAGMENT_SHADER).not.toContain('v_predicted < 0.5 && v_color.a > 0.5');
+    });
+
+    it('budget-caps the outline against ring width so it cannot eat the annulus', () => {
+      // An unclamped outer darken consumes 27-50% of the ring at every size, and specifically
+      // the outer part, where shapeAlpha is already fading it out.
+      expect(POINT_FRAGMENT_SHADER).toContain('OUTLINE_RING_BUDGET');
+    });
+
+    it('anti-aliases the outline inner edge', () => {
+      // The old inner edge was a hard `if` threshold on a field whose outer edge is smoothed.
+      expect(POINT_FRAGMENT_SHADER).toMatch(/smoothstep\([^)]*outline/i);
+    });
+
+    it('keeps the ring width free of any angle-dependent term', () => {
+      const ringStart = POINT_FRAGMENT_SHADER.indexOf('if (v_predicted > 0.5)');
+      const ringEnd = POINT_FRAGMENT_SHADER.indexOf('if (shapeAlpha < 0.001)');
+      expect(POINT_FRAGMENT_SHADER.slice(ringStart, ringEnd)).not.toMatch(/\baa\b/);
+    });
   });
 });

--- a/packages/core/src/components/scatter-plot/webgl/renderer/export-shaders.ts
+++ b/packages/core/src/components/scatter-plot/webgl/renderer/export-shaders.ts
@@ -70,6 +70,19 @@ const float PI = 3.14159265359;
 const float SQRT3 = 1.73205080757;
 const float PREDICTED_INTERIOR_FILL = 0.0; // 1.0 = filled knockout (old), 0.0 = hollow
 
+// Outline width in DEVICE PIXELS. It used to be a fraction of the sprite (0.15), which meant
+// the absolute width shrank with point size and with export scale: 0.35px at gl_PointSize 48,
+// 1.13px at 512. At the app's own nature-1col preset (89mm @ 300dpi) that put the observed-dot
+// outline at ~0.24pt of tint — below the reproducible-line floor — while the predicted ring
+// (0.49pt solid) survived, so a published figure carried an outline on one glyph class only.
+// Measuring in device pixels makes the outline reproduce at the same physical weight at any
+// point size, any dpr and any export scale.
+const float OUTLINE_DEVICE_PX = 1.0;
+// Share of the ring an outline may consume. The ring IS the predicted glyph's border, and its
+// outer edge is already where shapeAlpha fades to zero, so an unbudgeted outer darken would
+// eat 27-50% of the annulus at every size and smear the hollow cue the encoding depends on.
+const float OUTLINE_RING_BUDGET = 0.35;
+
 void main() {
   vec2 coord = gl_PointCoord * 2.0 - 1.0;
 
@@ -113,18 +126,20 @@ void main() {
   // screen-space derivatives of the distance field.
   float aa = fwidth(edgeDist);
   float shapeAlpha = smoothstep(0.0, aa, edgeDist);
+  // Isotropic field-units-per-pixel. Hoisted out of the predicted branch so the ring and the
+  // outline share one definition: dFdx/dFdy of coord are 2/gl_PointSize in every direction,
+  // whereas fwidth is the L1 norm of the partials and reads ~41% larger along the diagonals.
+  float pixelScale = max(length(dFdx(coord)), length(dFdy(coord)));
   float predictedInterior = 0.0;
+  float ringWidth = 0.0;
   if (v_predicted > 0.5) {
     // Keep the ring legible at every sprite size without allowing derivative scaling to consume
     // the interior. With PREDICTED_INTERIOR_FILL = 1.0 the opaque surface-color knockout would
     // prevent earlier overlapping points from showing through the hole; at 0.0 (hollow) that
     // show-through is allowed for densely overlapping markers — an accepted trade-off.
-    // The scale MUST come from gl_PointCoord, never from fwidth(edgeDist). fwidth is the L1 norm
-    // of the partials, so on a radial distance field it reads ~41% larger along the diagonals
-    // than along the axes; driving the ring width with it thickened the ring diagonally and
-    // pinched the hole into a cross. dFdx/dFdy of coord are 2/gl_PointSize in every direction.
-    float pixelScale = max(length(dFdx(coord)), length(dFdy(coord)));
-    float ringWidth = clamp(pixelScale * 1.75, 0.30, 0.55);
+    // The scale MUST come from gl_PointCoord, never from fwidth(edgeDist) — see the pixelScale
+    // definition above, which is hoisted for exactly that reason.
+    ringWidth = clamp(pixelScale * 1.75, 0.30, 0.55);
     float interiorAa = min(pixelScale, (1.0 - ringWidth) * 0.5);
     predictedInterior = smoothstep(ringWidth, ringWidth + interiorAa, edgeDist);
   }
@@ -157,11 +172,22 @@ void main() {
     finalColor = pow(max(texColor.rgb, vec3(0.0)), vec3(u_gamma));
   }
 
-  // Darken near the edge to mimic a border/outline.
-  // Skip for faded points (low alpha) where the darkening is disproportionately visible.
-  float strokeWidth = 0.15;
-  if (v_predicted < 0.5 && v_color.a > 0.5 && max(edgeDist, 0.0) < strokeWidth) {
-    finalColor = finalColor * 0.5;
+  // Darken near the edge to mimic a border/outline. Applied to BOTH filled dots and predicted
+  // rings so the two glyph classes share one outline treatment (#369) — filled-vs-hollow stays
+  // the encoding that tells them apart, which is a pre-attentive categorical difference and far
+  // stronger than a difference in outline weight.
+  // Still skipped for faded points (low alpha), where the darkening is disproportionately visible.
+  float outlineWidth = OUTLINE_DEVICE_PX * pixelScale;
+  // On a ring, cap the outline so it can never eat into the annulus (see OUTLINE_RING_BUDGET).
+  if (v_predicted > 0.5) {
+    outlineWidth = min(outlineWidth, ringWidth * OUTLINE_RING_BUDGET);
+  }
+  if (v_color.a > 0.5 && outlineWidth > 0.0) {
+    // Smooth the inner edge over one pixel. The outer edge is already anti-aliased by
+    // shapeAlpha, so a hard threshold here left the outline smooth outside and stepped inside.
+    float outlineMix =
+      1.0 - smoothstep(outlineWidth - pixelScale, outlineWidth, max(edgeDist, 0.0));
+    finalColor = mix(finalColor, finalColor * 0.5, outlineMix);
   }
 
   // Predicted interiors mix toward PREDICTED_INTERIOR_FILL (hollow=0.0, filled-knockout=1.0).

--- a/packages/utils/src/visualization/eat-overlay.ts
+++ b/packages/utils/src/visualization/eat-overlay.ts
@@ -15,6 +15,23 @@ export const EAT_COMPANION_SUFFIXES = {
 export type EatCompanionKind = keyof typeof EAT_COMPANION_SUFFIXES;
 
 export const EAT_CONFIDENCE_SUFFIX = '__eat_confidence';
+
+/**
+ * Which side(s) of the reliability scale the EAT filter constrains (#380).
+ *
+ * Lives here rather than beside the query-condition translation in `core` because
+ * both the legend control and the control bar need the vocabulary, and neither
+ * should have to import from the other.
+ */
+export type EatReliabilityMode = 'atLeast' | 'atMost' | 'between';
+
+export interface EatReliabilityState {
+  mode: EatReliabilityMode;
+  /** Lower bound, used by `atLeast` and `between`. 0 means "no lower bound". */
+  min: number;
+  /** Upper bound, used by `atMost` and `between`. 1 means "no upper bound". */
+  max: number;
+}
 /**
  * Default reliability-slider position. `0` means "show everything": the slider
  * derives a `NOT(EAT_confidence < x)` filter only when dragged above 0, so a


### PR DESCRIPTION
Closes #393. Closes #380. Closes #369. Groundwork for #424.

Four EAT items needed for the Nature Methods submission. Each turned out to be materially larger than its issue text, so the findings are written up here: **[implementation plan](https://claude.ai/code/artifact/e4a7b78b-b95d-4cf2-9a2b-d7cbe81cb501)**.

> **Do not squash-merge** — this touches `apps/protspace/`. Squashing collapses the branch into one commit touching every path and destroys semantic-release's per-commit path scoping.

---

## #393 — EAT within one dataset

An empty `Rule` matched nothing rather than everything, so running `protspace transfer` without `--query-*`/`--reference-*` raised *"Classifier matched no query proteins"*. Users had to invent a column describing "the rows that are empty" — producing the shipped EAT demo bundle needed exactly that, a synthetic `eat_split` column plus two flags.

An empty rule now reads as **open**. Self-transfer needed no new transfer logic: `run_transfer` already split queries from references *per column* on missing-vs-present, and those sets are exact complements of `_is_missing`, so **a protein can never be its own reference**.

Making empty rules match everything was **not sufficient on its own**, which is the part worth reviewing. `classify()` partitioned with `if`/`elif`, so two open rules handed every protein to the query list and left references empty — transfer would then skip every column and write the bundle back unchanged **at exit 0**. Precedence now applies only between two *explicit* rules.

That also fixes two pre-existing silent no-ops: passing only `--query-*`, and the `--query-where 'col~'` match-everything workaround.

**Verified on the 832-protein phosphatase fixture**, with no rules at all:

| Column | Held-out | Exact | Manuscript (`05.methods.md:95`) | Self-sourced |
|---|---|---|---|---|
| `ec` | 213 | 91.55% | 91.55% | 0 |
| `protein_families` | 213 | 99.06% | 99.06% | 0 |

## #380 — the reliability filter

The legend slider identified its condition by pattern-matching `NOT(conf < X)` on operator *and* logical op, at the top level only. That is the shape the UI is least likely to produce: picking an eat-confidence column in the query builder creates a condition defaulting to `gt`. So the most natural gesture left the slider reading 0% while the plot was filtered, and the next drag **appended** a contradictory condition instead of replacing it.

- Conditions are now identified by **ownership of the eat-confidence column**, at any depth, tagged or not — so a hand-built condition mirrors instead of being duplicated, and one restored from an older bundle still works.
- The control gains **three modes** (`Hide below` / `Hide above` / `Keep between`), each expressed as NOT-form conditions. Only the NOT index-complement re-includes null-confidence rows, so **curated proteins stay visible in every mode by construction** — the slider's help text promised exactly that, and it was false for three of the five reachable shapes. The evaluator's deliberate null semantics are untouched.
- Deriving the state back respects the logical op: `NOT(conf < X)` is a lower bound, a bare `conf < X` is an upper one. Reading a bare `lt` as a lower bound made the slider skip a replacement and leave a contradiction in place — caught by a regression test, not by inspection.
- The mirror's de-dupe guard was one shared scalar, so a drag on one base was compared against another's; it is now keyed per column, and switching the coloured-by annotation force-emits.
- A query matching nothing was pushed as an **active** filter, which reads as "hide everything" and blanked the canvas with no way back. It now clears instead.

## #369 — glyph outlines

Neither option in the issue is right. Adding the existing darkening to rings would consume 27–50% of the annulus at every size, smearing the hollow cue; removing it everywhere costs dense clusters their only separator between adjacent same-hue dots.

The real defect is the mechanism. The band was a **fraction of the sprite** (`0.15`), so its absolute width shrank with point size and export scale — 0.35px at `gl_PointSize` 48, 1.13px at 512. At the app's own `nature-1col` preset (89mm @ 300dpi) that put the observed-dot outline at ~0.24pt of tint, **below the reproducible-line floor**, while the predicted ring at 0.49pt solid survived. In a published figure only one glyph class had an outline at all.

The outline is now measured in **device pixels**, derived from the isotropic `pixelScale` the ring already used, applied to both classes and budget-capped on the ring. Filled-vs-hollow remains what tells them apart. The inner edge is anti-aliased; it was a hard threshold on a field whose outer edge was already smoothed.

## #424 — audit mode (filed, not implemented)

The manuscript's headline audit result is computed in the space its own Methods section forbids: `03.results.md:37` derives ~860 candidate misannotations from *"50 nearest **UMAP** neighbors"*, while `05.methods.md:73` states that using the 2-D projection rather than the embedding space is *"a correctness requirement rather than a performance choice"*. `COVER_LETTER_NOTES.md` already self-flags this, and `STORY_v2` stages that panel as **Figure 2C, the paper's climax**.

#424 captures the design — `--mode audit`, leave-one-out keyed on identifier rather than distance, a reliability-margin score, a distinct `__audit_*` column family (reusing `__pred_*` would let `materializeEatOverlay` overwrite curated biology) — plus the prior art that must be cited, including **Heinzinger 2022, already cited in the manuscript, which does this and calls it essential for cleaning up databases**, and **CLEAN (Science 2023)**, which is not from this lab.

---

## Verification

- `uv run pytest` — **840 passed**; `uv run ruff check` clean
- `pnpm test:ci` — core **1551**, utils **371**, app **165**; `pnpm format:check` clean; `pnpm precommit` on every commit
- Playwright `eat-visualization` against the real phosphatase bundle — proves the shader **compiles** (string tests cannot) and the legend layout holds at 320/390/601/800px
- `openspec validate --strict` passes

Every new test was watched failing first. For #393 the tests were re-run against the pre-change `classify()` to confirm all five fail there and pass here.

## Deliberately not in this PR

Audit mode (#424); persisting the reliability *mode* to bundle settings (schema addition needing a migration story for the legacy scalar); export legend renderers drawing EAT rings, so exported figures explain the encoding; and an EAT docs page — `transfer` is only name-checked at `python-cli.md:125`, and NM's code checklist wants install time, demo run time and expected output.

Three pre-existing defects the shader audit surfaced, unrelated to the border question and worth their own issues: `edgeDist` is not gradient-normalised so glyphs are half as thick on diamonds; `u_knockoutColor` is dead but still costs a forced `getComputedStyle()` per frame; and the Observed/Predicted key never reaches any exported figure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016tSUUWsGomA4BFoVFGvSwj
