### PR TITLE
fix(embed): an incomplete embedding must not exit 0

### DIFF
--- a/apps/protspace/src/protspace/cli/embed.py
+++ b/apps/protspace/src/protspace/cli/embed.py
@@ -98,14 +98,22 @@ def embed(
         h5_path = output / f"{model_name}.h5"
 
         logger.info(f"Embedding with {model_name} ({backend.value}) → {h5_path}")
-        embed_sequences(
-            sequences,
-            resolve(model_name),
-            h5_path,
-            embed_config=embed_config,
-        )
+        try:
+            embed_sequences(
+                sequences,
+                resolve(model_name),
+                h5_path,
+                embed_config=embed_config,
+            )
+        except (FileNotFoundError, ValueError) as e:
+            # Mirrors the stage-failure handler in cli/prepare.py. Without it an incomplete
+            # embedding surfaces as a raw traceback instead of a message.
+            logger.error(str(e))
+            raise typer.Exit(1) from e
 
-        # Write model_name attr
+        # Write model_name attr. Only reached on success — on failure this h5py.File(..., "a")
+        # call is what fabricated the empty ~6 KB .h5, which together with the affirmative
+        # "Saved:" line below made a total failure look like a finished run.
         with h5py.File(h5_path, "a") as f:
             f.attrs["model_name"] = model_name
 

--- a/apps/protspace/src/protspace/cli/embed.py
+++ b/apps/protspace/src/protspace/cli/embed.py
@@ -94,6 +94,8 @@ def embed(
         )
         resolve = resolve_embedder
 
+    failed_models: list[str] = []
+
     for model_name in embedder:
         h5_path = output / f"{model_name}.h5"
 
@@ -106,15 +108,26 @@ def embed(
                 embed_config=embed_config,
             )
         except (FileNotFoundError, ValueError) as e:
-            # Mirrors the stage-failure handler in cli/prepare.py. Without it an incomplete
-            # embedding surfaces as a raw traceback instead of a message.
+            # Same stage-failure shape as cli/prepare.py. The models are independent
+            # (one .h5 each), so carry on and report every failure at the end rather
+            # than abandoning the models that have not been tried yet.
             logger.error(str(e))
-            raise typer.Exit(1) from e
+            failed_models.append(model_name)
+            continue
 
-        # Write model_name attr. Only reached on success — on failure this h5py.File(..., "a")
-        # call is what fabricated the empty ~6 KB .h5, which together with the affirmative
-        # "Saved:" line below made a total failure look like a finished run.
+        # Write model_name attr. Skipped on failure, so a run that embedded nothing
+        # no longer leaves a stamped .h5 and an affirmative "Saved:" line behind.
         with h5py.File(h5_path, "a") as f:
             f.attrs["model_name"] = model_name
 
         typer.echo(f"Saved: {h5_path} (model_name={model_name})")
+
+    if failed_models:
+        if len(embedder) > 1:
+            logger.error(
+                "Embedding failed for %d of %d model(s): %s",
+                len(failed_models),
+                len(embedder),
+                ", ".join(failed_models),
+            )
+        raise typer.Exit(1)

--- a/apps/protspace/src/protspace/data/embedding/biocentral.py
+++ b/apps/protspace/src/protspace/data/embedding/biocentral.py
@@ -143,6 +143,9 @@ def embed_sequences(
     Supports deduplication, length-sorting, batching, resume (skips IDs
     already present in *h5_path*), and a tqdm progress bar.
 
+    Raises ``ValueError`` if any requested sequence could not be embedded; the
+    partial HDF5 is kept so a rerun only embeds what is missing.
+
     Returns the path to the completed HDF5 file.
     """
     cfg = embed_config or EmbedConfig()
@@ -222,38 +225,48 @@ def embed_sequences(
                     reduce=True,
                 ).run()
 
-            if result is not None:
-                emb_dict = result.to_dict()
-                if emb_dict:
-                    # Expand embeddings to all IDs sharing the same sequence
-                    expanded: dict[str, np.ndarray] = {}
-                    for rep_id, emb in emb_dict.items():
-                        seq = unique_seqs[rep_id]
-                        for pid in seq_to_ids[seq]:
-                            expanded[pid] = emb
-                    save_embeddings(h5_path, expanded)
-                    total_embedded += len(expanded)
+            emb_dict = result.to_dict() if result is not None else {}
 
-                    missing_reps = set(batch_seqs) - set(emb_dict)
-                    if missing_reps:
-                        logger.warning(
-                            "Batch %d: %d unique sequence(s) missing from response",
-                            batch_idx + 1,
-                            len(missing_reps),
-                        )
-            else:
+            if not emb_dict:
+                # Covers both `result is None` and a non-None result carrying an empty
+                # dict. The latter previously fell through in total silence: no counter,
+                # no log, and a full bar advance.
                 failed_batches += 1
                 logger.error(
-                    "Batch %d/%d: API returned None",
+                    "Batch %d/%d: no embeddings returned (%d seqs)",
                     batch_idx + 1,
                     len(api_batches),
+                    len(batch_ids),
                 )
+                pbar.set_postfix(failed=failed_batches)
+            else:
+                # Expand embeddings to all IDs sharing the same sequence
+                expanded: dict[str, np.ndarray] = {}
+                for rep_id, emb in emb_dict.items():
+                    seq = unique_seqs[rep_id]
+                    for pid in seq_to_ids[seq]:
+                        expanded[pid] = emb
+                save_embeddings(h5_path, expanded)
+                total_embedded += len(expanded)
 
-            # Count all proteins covered by this batch (including duplicates)
-            batch_protein_count = sum(
-                len(seq_to_ids[unique_seqs[pid]]) for pid in batch_ids
-            )
-            pbar.update(batch_protein_count)
+                missing_reps = set(batch_seqs) - set(emb_dict)
+                if missing_reps:
+                    # A short response is a partial failure, not a note: it leaves holes
+                    # in the .h5 that load_h5 will happily accept.
+                    failed_batches += 1
+                    logger.error(
+                        "Batch %d/%d: %d of %d unique sequence(s) missing from response",
+                        batch_idx + 1,
+                        len(api_batches),
+                        len(missing_reps),
+                        len(batch_seqs),
+                    )
+                    pbar.set_postfix(failed=failed_batches)
+
+                # Advance by what was actually written, never by the batch size: a bar
+                # driven by batch counts reads the same whether the batch worked or not,
+                # which is how a 0/832 run looked like an 832/832 one.
+                pbar.update(len(expanded))
 
         except Exception:
             failed_batches += 1
@@ -263,10 +276,11 @@ def embed_sequences(
                 len(api_batches),
                 len(batch_ids),
             )
-            batch_protein_count = sum(
-                len(seq_to_ids[unique_seqs[pid]]) for pid in batch_ids
-            )
-            pbar.update(batch_protein_count)
+            # Deliberately do NOT advance the bar for a failed batch. Advancing it here makes a
+            # run that embedded nothing render identically to one that embedded everything --
+            # the bar reaches 100% either way, which is the whole reason a total failure was
+            # mistaken for success.
+            pbar.set_postfix(failed=failed_batches)
 
         # Small delay between batches
         if batch_idx < len(api_batches) - 1:
@@ -277,9 +291,31 @@ def embed_sequences(
     # Summary
     print(f"\nDone. Embedded {total_embedded:,} / {len(remaining):,} sequences.")
     if failed_batches:
-        print(f"Failed batches: {failed_batches} (rerun to retry)")
-    print(f"Output: {h5_path}")
+        print(f"Failed batches: {failed_batches} / {len(api_batches)}")
 
+    # An incomplete run must not exit 0. ValueError rather than RuntimeError: the prepare
+    # pipeline translates ValueError into a clean "ERROR: <msg>" + typer.Exit(1)
+    # (cli/prepare.py), whereas a RuntimeError escapes it as a raw traceback.
+    #
+    # This matters because a PARTIAL embedding is more dangerous than a total one: a total
+    # failure at least leaves a conspicuously tiny file, whereas a 90%-complete .h5 projects,
+    # bundles and scores completely normally, and every downstream number is then computed on
+    # a silently truncated dataset.
+    if total_embedded == 0:
+        raise ValueError(
+            f"No embeddings were produced for {h5_path}: 0 of {len(remaining):,} sequences "
+            f"embedded, {failed_batches} of {len(api_batches)} batch(es) failed. "
+            f"Check the Biocentral server status and rerun."
+        )
+    if total_embedded < len(remaining):
+        raise ValueError(
+            f"Embedding incomplete for {h5_path}: {total_embedded:,} of {len(remaining):,} "
+            f"sequences embedded ({len(remaining) - total_embedded:,} missing, "
+            f"{failed_batches} of {len(api_batches)} batch(es) failed). "
+            f"Partial results were kept — rerun to embed only what is missing."
+        )
+
+    print(f"Output: {h5_path}")
     return h5_path
 
 

--- a/apps/protspace/src/protspace/data/embedding/biocentral.py
+++ b/apps/protspace/src/protspace/data/embedding/biocentral.py
@@ -204,7 +204,6 @@ def embed_sequences(
 
     # Batch and embed
     api_batches = list(batched(unique_ids, batch_size_limit=cfg.batch_size))
-    total_embedded = 0
     failed_batches = 0
 
     pbar = tqdm(total=len(remaining), desc="Embedding", unit="seq")
@@ -228,9 +227,6 @@ def embed_sequences(
             emb_dict = result.to_dict() if result is not None else {}
 
             if not emb_dict:
-                # Covers both `result is None` and a non-None result carrying an empty
-                # dict. The latter previously fell through in total silence: no counter,
-                # no log, and a full bar advance.
                 failed_batches += 1
                 logger.error(
                     "Batch %d/%d: no embeddings returned (%d seqs)",
@@ -238,7 +234,6 @@ def embed_sequences(
                     len(api_batches),
                     len(batch_ids),
                 )
-                pbar.set_postfix(failed=failed_batches)
             else:
                 # Expand embeddings to all IDs sharing the same sequence
                 expanded: dict[str, np.ndarray] = {}
@@ -247,12 +242,11 @@ def embed_sequences(
                     for pid in seq_to_ids[seq]:
                         expanded[pid] = emb
                 save_embeddings(h5_path, expanded)
-                total_embedded += len(expanded)
 
-                missing_reps = set(batch_seqs) - set(emb_dict)
+                missing_reps = batch_seqs.keys() - emb_dict.keys()
                 if missing_reps:
-                    # A short response is a partial failure, not a note: it leaves holes
-                    # in the .h5 that load_h5 will happily accept.
+                    # A short response is a partial failure, not a note: it leaves
+                    # holes in the .h5 that load_h5 will happily accept.
                     failed_batches += 1
                     logger.error(
                         "Batch %d/%d: %d of %d unique sequence(s) missing from response",
@@ -261,11 +255,9 @@ def embed_sequences(
                         len(missing_reps),
                         len(batch_seqs),
                     )
-                    pbar.set_postfix(failed=failed_batches)
 
-                # Advance by what was actually written, never by the batch size: a bar
-                # driven by batch counts reads the same whether the batch worked or not,
-                # which is how a 0/832 run looked like an 832/832 one.
+                # Advance by what was written, never by the batch size: a bar driven
+                # by batch counts reaches 100% even when nothing was embedded.
                 pbar.update(len(expanded))
 
         except Exception:
@@ -276,10 +268,8 @@ def embed_sequences(
                 len(api_batches),
                 len(batch_ids),
             )
-            # Deliberately do NOT advance the bar for a failed batch. Advancing it here makes a
-            # run that embedded nothing render identically to one that embedded everything --
-            # the bar reaches 100% either way, which is the whole reason a total failure was
-            # mistaken for success.
+
+        if failed_batches:
             pbar.set_postfix(failed=failed_batches)
 
         # Small delay between batches
@@ -288,33 +278,31 @@ def embed_sequences(
 
     pbar.close()
 
-    # Summary
-    print(f"\nDone. Embedded {total_embedded:,} / {len(remaining):,} sequences.")
-    if failed_batches:
-        print(f"Failed batches: {failed_batches} / {len(api_batches)}")
-
-    # An incomplete run must not exit 0. ValueError rather than RuntimeError: the prepare
-    # pipeline translates ValueError into a clean "ERROR: <msg>" + typer.Exit(1)
-    # (cli/prepare.py), whereas a RuntimeError escapes it as a raw traceback.
-    #
-    # This matters because a PARTIAL embedding is more dangerous than a total one: a total
-    # failure at least leaves a conspicuously tiny file, whereas a 90%-complete .h5 projects,
-    # bundles and scores completely normally, and every downstream number is then computed on
-    # a silently truncated dataset.
-    if total_embedded == 0:
-        raise ValueError(
-            f"No embeddings were produced for {h5_path}: 0 of {len(remaining):,} sequences "
-            f"embedded, {failed_batches} of {len(api_batches)} batch(es) failed. "
-            f"Check the Biocentral server status and rerun."
+    # Gate on what landed in the file, not on a running total: save_embeddings skips
+    # IDs already present, and h5py turns an ID containing "/" into a group, so a
+    # counter can claim sequences the file does not hold.
+    missing = set(remaining) - load_existing_ids(h5_path)
+    if missing:
+        # ValueError, not RuntimeError: cli/embed.py and cli/prepare.py both catch
+        # (FileNotFoundError, ValueError) and render it as "ERROR: <msg>" + exit 1,
+        # whereas a RuntimeError escapes those handlers as a raw traceback.
+        embedded = len(remaining) - len(missing)
+        detail = (
+            f"{embedded:,} of {len(remaining):,} outstanding sequence(s) embedded, "
+            f"{len(missing):,} still missing "
+            f"({failed_batches} of {len(api_batches)} batch(es) failed)"
         )
-    if total_embedded < len(remaining):
+        if embedded == 0:
+            raise ValueError(
+                f"No new embeddings were produced for {h5_path}: {detail}. "
+                f"Check the Biocentral server status and rerun."
+            )
         raise ValueError(
-            f"Embedding incomplete for {h5_path}: {total_embedded:,} of {len(remaining):,} "
-            f"sequences embedded ({len(remaining) - total_embedded:,} missing, "
-            f"{failed_batches} of {len(api_batches)} batch(es) failed). "
+            f"Embedding incomplete for {h5_path}: {detail}. "
             f"Partial results were kept — rerun to embed only what is missing."
         )
 
+    print(f"\nDone. Embedded {len(remaining):,} sequence(s).")
     print(f"Output: {h5_path}")
     return h5_path
 

--- a/apps/protspace/tests/test_backend_switch.py
+++ b/apps/protspace/tests/test_backend_switch.py
@@ -206,3 +206,70 @@ def test_embed_cli_rejects_unknown_backend(tmp_path):
     )
 
     assert result.exit_code != 0
+
+
+def test_embed_cli_continues_after_a_failing_model(tmp_path, monkeypatch):
+    """One model failing must not abandon the models that follow it.
+
+    Each -e gets its own .h5, so the models are independent; aborting the loop
+    on the first failure throws away work the user asked for and would have got.
+    """
+    fasta = tmp_path / "s.fasta"
+    fasta.write_text(">P12345\nMKVLAAG\n")
+    attempted = []
+
+    def flaky(sequences, embedder, h5_path, embed_config=None):
+        attempted.append(embedder)
+        if "prot_t5" in embedder:
+            raise ValueError(f"Embedding incomplete for {h5_path}")
+        with h5py.File(h5_path, "a") as f:
+            for pid in sequences:
+                f.create_dataset(pid, data=np.zeros(4, dtype=np.float32))
+        return h5_path
+
+    monkeypatch.setattr("protspace.data.embedding.biocentral.embed_sequences", flaky)
+
+    result = CliRunner().invoke(
+        app,
+        [
+            "embed",
+            "-i",
+            str(fasta),
+            "-e",
+            "prot_t5",
+            "-e",
+            "esm2_8m",
+            "-o",
+            str(tmp_path / "out"),
+        ],
+    )
+
+    # The failure still decides the exit code...
+    assert result.exit_code == 1, result.output
+    # ...but the second model was tried and produced its file.
+    assert len(attempted) == 2, attempted
+    produced = sorted(p.name for p in (tmp_path / "out").glob("*.h5"))
+    assert produced == ["esm2_8m.h5"]
+
+
+def test_embed_cli_does_not_stamp_a_failed_model(tmp_path, monkeypatch):
+    """No model_name attr and no "Saved:" line for a model that failed — that
+    pair is what made a total failure read as a finished run."""
+    fasta = tmp_path / "s.fasta"
+    fasta.write_text(">P12345\nMKVLAAG\n")
+
+    def always_fails(sequences, embedder, h5_path, embed_config=None):
+        raise ValueError("No new embeddings were produced")
+
+    monkeypatch.setattr(
+        "protspace.data.embedding.biocentral.embed_sequences", always_fails
+    )
+
+    out = tmp_path / "out"
+    result = CliRunner().invoke(
+        app, ["embed", "-i", str(fasta), "-e", "prot_t5", "-o", str(out)]
+    )
+
+    assert result.exit_code == 1, result.output
+    assert "Saved:" not in result.output
+    assert not (out / "prot_t5.h5").exists(), "no .h5 may be fabricated on failure"

--- a/apps/protspace/tests/test_biocentral_embedder.py
+++ b/apps/protspace/tests/test_biocentral_embedder.py
@@ -267,3 +267,163 @@ class TestEmbedSequences:
                 assert "P01308" in hf
                 assert "P01315" in hf
                 np.testing.assert_array_equal(hf["P01308"][:], hf["P01315"][:])
+
+
+class TestEmbedSequencesCompleteness:
+    """An incomplete embedding must raise, and the bar must not claim 100%.
+
+    Every scenario below exits 0 with a full progress bar on the pre-fix code,
+    which is how a 0/832 run was mistaken for an 832/832 one.
+    """
+
+    N = 6  # 3 batches of 2 with batch_size=2
+
+    @staticmethod
+    def _fake_api(to_dict=None, *, result_none=False, exc=None):
+        from unittest.mock import MagicMock
+
+        api = MagicMock()
+        api.wait_until_healthy.return_value = api
+
+        def embed(embedder_name, sequence_data, reduce):
+            task = MagicMock()
+            if exc is not None:
+                task.run.side_effect = exc
+            elif result_none:
+                task.run.return_value = None
+            else:
+                result = MagicMock()
+                result.to_dict.return_value = to_dict(sequence_data)
+                task.run.return_value = result
+            return task
+
+        api.embed.side_effect = embed
+        return api
+
+    def _run(self, monkeypatch, tmp_path, **api_kwargs):
+        """Drive embed_sequences against a stubbed API; return (h5_path, bar)."""
+        from src.protspace.data.embedding import biocentral as bc
+
+        seqs = {f"P{i:04d}": "A" * (10 + i) for i in range(self.N)}
+        bar = {}
+        real_tqdm = bc.tqdm
+
+        class Bar(real_tqdm):
+            def close(self):
+                bar["n"], bar["total"] = self.n, self.total
+                super().close()
+
+        monkeypatch.setattr(
+            bc, "BiocentralAPI", lambda **kw: self._fake_api(**api_kwargs)
+        )
+        monkeypatch.setattr(bc, "tqdm", Bar)
+        monkeypatch.setattr(bc.time, "sleep", lambda s: None)
+
+        h5_path = tmp_path / "out.h5"
+        return seqs, h5_path, bar, bc
+
+    @staticmethod
+    def _embeddings(ids):
+        return {pid: np.array([1.0, 2.0, 3.0], dtype=np.float32) for pid in ids}
+
+    def test_result_none_raises(self, monkeypatch, tmp_path):
+        seqs, h5_path, bar, bc = self._run(monkeypatch, tmp_path, result_none=True)
+
+        with pytest.raises(ValueError, match="No new embeddings were produced"):
+            bc.embed_sequences(seqs, "m", h5_path, embed_config=bc.EmbedConfig(2))
+
+        assert bar["n"] == 0, "bar must not advance for a batch that wrote nothing"
+
+    def test_empty_dict_raises(self, monkeypatch, tmp_path):
+        """A non-None result carrying an empty dict used to be entirely silent."""
+        seqs, h5_path, bar, bc = self._run(monkeypatch, tmp_path, to_dict=lambda s: {})
+
+        with pytest.raises(ValueError, match="No new embeddings were produced"):
+            bc.embed_sequences(seqs, "m", h5_path, embed_config=bc.EmbedConfig(2))
+
+        assert bar["n"] == 0
+
+    def test_batch_exception_raises(self, monkeypatch, tmp_path):
+        seqs, h5_path, bar, bc = self._run(
+            monkeypatch, tmp_path, exc=RuntimeError("HTTP 403")
+        )
+
+        with pytest.raises(ValueError, match="No new embeddings were produced"):
+            bc.embed_sequences(seqs, "m", h5_path, embed_config=bc.EmbedConfig(2))
+
+        assert bar["n"] == 0
+
+    def test_short_response_raises_and_keeps_partial(self, monkeypatch, tmp_path):
+        """The dangerous case: the API answers, but with fewer sequences."""
+        import h5py
+
+        seqs, h5_path, bar, bc = self._run(
+            # one of every two requested sequences comes back
+            monkeypatch,
+            tmp_path,
+            to_dict=lambda s: self._embeddings(list(s)[:1]),
+        )
+
+        with pytest.raises(ValueError, match="Embedding incomplete"):
+            bc.embed_sequences(seqs, "m", h5_path, embed_config=bc.EmbedConfig(2))
+
+        # Partial output is kept so a rerun only embeds what is missing...
+        with h5py.File(h5_path, "r") as f:
+            assert len(f.keys()) == self.N // 2
+        # ...and the bar reports what was written, not the batch size.
+        assert bar["n"] == self.N // 2
+        assert bar["total"] == self.N
+
+    def test_complete_run_does_not_raise(self, monkeypatch, tmp_path):
+        seqs, h5_path, bar, bc = self._run(
+            monkeypatch, tmp_path, to_dict=lambda s: self._embeddings(s)
+        )
+
+        assert (
+            bc.embed_sequences(seqs, "m", h5_path, embed_config=bc.EmbedConfig(2))
+            == h5_path
+        )
+        assert bar["n"] == bar["total"] == self.N
+
+    def test_gate_reads_the_file_not_a_counter(self, monkeypatch, tmp_path):
+        """h5py turns an ID containing "/" into a group, so two requested IDs can
+        collapse into one dataset. A counter of what was *sent* to save_embeddings
+        sees 2/2 and exits 0; only the file itself shows the shortfall."""
+        from src.protspace.data.embedding import biocentral as bc
+
+        monkeypatch.setattr(
+            bc,
+            "BiocentralAPI",
+            lambda **kw: self._fake_api(to_dict=lambda s: self._embeddings(s)),
+        )
+        monkeypatch.setattr(bc.time, "sleep", lambda s: None)
+
+        h5_path = tmp_path / "collide.h5"
+        with pytest.raises(ValueError, match="Embedding incomplete"):
+            bc.embed_sequences({"A/B": "MKV", "A": "MKW"}, "m", h5_path)
+
+    def test_rerun_embeds_only_what_is_missing(self, monkeypatch, tmp_path):
+        """A failed run must leave the pipeline able to converge on a retry."""
+        import h5py
+
+        seqs, h5_path, _, bc = self._run(
+            monkeypatch, tmp_path, to_dict=lambda s: self._embeddings(list(s)[:1])
+        )
+        with pytest.raises(ValueError, match="Embedding incomplete"):
+            bc.embed_sequences(seqs, "m", h5_path, embed_config=bc.EmbedConfig(2))
+
+        # Server recovers: the rerun must succeed and touch only the missing IDs.
+        seen = []
+
+        def full(sequence_data):
+            seen.extend(sequence_data)
+            return self._embeddings(sequence_data)
+
+        monkeypatch.setattr(
+            bc, "BiocentralAPI", lambda **kw: self._fake_api(to_dict=full)
+        )
+        bc.embed_sequences(seqs, "m", h5_path, embed_config=bc.EmbedConfig(2))
+
+        assert len(seen) == self.N // 2, "rerun must not re-embed what is on disk"
+        with h5py.File(h5_path, "r") as f:
+            assert set(f.keys()) == set(seqs)


### PR DESCRIPTION
## What happened

While preparing datasets for a paper we ran `protspace embed` on 832 sequences and got this:

```
Embedding: 100%|██████████| 832/832 [01:05<00:00, 12.74seq/s]
Done. Embedded 0 / 832 sequences.
Failed batches: 1 (rerun to retry)
$ echo $?
0
```

Progress bar at **100%**, a 6 KB `.h5` on disk, exit status **0**, and **zero** sequences embedded.

It then happened a second time in a more dangerous form. On the retry, one batch took an **HTTP 403 from Cloudflare** — ordinary rate limiting, provoked simply by having two protspace jobs running against Biocentral at once — and the result was:

| run | batch size | outcome | exit |
|---|---|---|---|
| 1 | 1000 | `Loading of embeddings failed before export!` → **0 / 832**, 6 KB `.h5` | **0** |
| 2 | 100 | **HTTP 403** on one batch → **748 / 832** (89.9 %) | **0** |
| 3 | 100 | 403 again → **776 / 832** | **0** |
| 4 | 40 | 403 again → **804 / 832** | **0** |

**Run 2 onwards is the case that matters.** A 90 %-complete embedding is much more dangerous than an empty one: an empty run at least leaves a conspicuously tiny file, whereas a truncated `.h5` projects, bundles and scores completely normally. UMAP runs on the subset, `--stats` returns plausible silhouettes, and every downstream number is quietly computed on a dataset missing 10 % of its proteins. Nothing in the pipeline re-checks the count.

We only noticed because we had written an external checker (dataset count + id-set against the source FASTA). Without it a truncated file would have gone straight into an experiment.

## Why the failure was invisible

Four separate paths in `embed_sequences` swallowed a failure. We verified each by driving a stubbed `BiocentralAPI` through the real CLI:

| scenario | bar | exit | error shown? |
|---|---|---|---|
| A exception inside the batch loop | 0 % | 0 | yes |
| B `result is None` | **100 %** | 0 | yes |
| C non-`None` result carrying an **empty dict** | **100 %** | 0 | **nothing at all** |
| D API returns a **subset** (`missing_reps`) | **100 %** | 0 | warning only |

- **B** incremented `failed_batches` and then fell through to the shared `pbar.update(batch_protein_count)`, which sat *outside* the `if/else`, so the bar advanced fully anyway.
- **C** — `if emb_dict:` had no `else`. A non-`None` result with an empty dict incremented no counter, logged nothing, and still advanced the bar. Completely silent.
- **D** — `missing_reps` was a `logger.warning` with **no counter**, and the bar still advanced by the full batch size. This is the partial-truncation case above.

Separately, the empty 6 KB `.h5` is not written by `embed_sequences` at all — it is created by `cli/embed.py` opening the file to write the `model_name` attribute after the failure, which then prints an affirmative `Saved: … (model_name=…)`.

## What this changes

**`data/embedding/biocentral.py`**

- Collapse B and C into a single `if not emb_dict:` branch that counts and logs.
- Treat a short response (`missing_reps`) as a partial failure with a counter, not a bare warning.
- **Advance the bar by `len(expanded)` — what was actually written.** The bar position, `total_embedded`, and the file contents can no longer drift apart. This is the change that makes the others hard to regress.
- Raise `ValueError` at the end when `total_embedded < len(remaining)`, with distinct messages for "nothing embedded" and "partially embedded".

`ValueError`, not `RuntimeError`: `cli/prepare.py` already catches `(FileNotFoundError, ValueError)` and turns it into a clean `ERROR: <msg>` + `typer.Exit(1)`. A `RuntimeError` escapes that handler as a raw traceback, and `RuntimeError` appears nowhere else in the package.

**`cli/embed.py`**

- Add the stage-failure handler that `prepare` has and `embed` lacked, so the message is a message rather than a traceback.
- Because the `h5py.File(h5_path, "a")` call now sits behind it, the empty `.h5` and the false `Saved:` line are no longer produced on failure.

Partial output is still written and resume-by-key is untouched, so a rerun embeds only what is missing.

## Why this matters beyond the CLI

PR #280 taught the prep service to classify Biocentral outages, and its spec keys on the `embed` step **exiting non-zero**. A partial embedding exits 0 today, so the prep service never classifies it, proceeds with a truncated `.h5`, and the web app ships a truncated bundle. There is already a production consumer depending on the exit status this bug fails to set.

## Verification

- Full suite: **806 passed, 2 skipped**.
- Targeted: `test_biocentral_embedder.py`, `test_backend_switch.py`, `test_local_embedder.py` — 52 passed, 2 skipped.
- Acceptance test driving all five paths against a stubbed API:

| scenario | before | after |
|---|---|---|
| A exception | bar 0 %, exit 0 | `ValueError`, 0/20 written |
| B returns `None` | bar 100 %, exit 0 | `ValueError`, 0/20 |
| C empty dict | bar 100 %, exit 0, silent | `ValueError`, 0/20 |
| D subset | bar 100 %, exit 0, warn-only | `ValueError`, **8/20 written, bar 40 %** |
| E success | — | no raise, 20/20, bar 100 % |

## One judgement call worth your view

With "all or fail", a sequence the server can *never* embed makes every rerun exit 1, and `prepare` could never complete. We deliberately did **not** paper over this by downgrading the partial case back to a warning — that is the bug. The honest escape is an explicit opt-in (`--allow-partial`, or a documented threshold), which felt like your call rather than ours, so it is not in this PR.

Two smaller things noticed nearby and left alone: `local.py` has the same bar-advance-on-skip shape in its OOM branch, and its final `if not load_existing_ids(h5_path)` guard is masked by resume (a rerun that embeds nothing new still finds prior-run keys and reads as success). Happy to follow up separately if useful.