### PR TITLE
docs(openspec): record the filter-query semantics #416 shipped

### DIFF
--- a/openspec/changes/archive/2026-08-11-add-filter-presence-semantics/.openspec.yaml
+++ b/openspec/changes/archive/2026-08-11-add-filter-presence-semantics/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-11

--- a/openspec/changes/archive/2026-08-11-add-filter-presence-semantics/design.md
+++ b/openspec/changes/archive/2026-08-11-add-filter-presence-semantics/design.md
@@ -1,0 +1,138 @@
+## Context
+
+The query builder evaluates a `FilterQuery` — a list of conditions and groups — into a `Set<number>`
+of protein indices (`query-evaluate.ts`). Conditions come in two kinds that had drifted apart:
+categorical conditions selected values from a list that already contained the `NA_VALUE` sentinel,
+while numeric conditions had only an operator and one or two bounds and no concept of a missing
+value at all.
+
+`NOT` lived at the combining level, applied as `allIndices ∖ itemResult`. Because a protein missing
+a value simply fails every condition, complementing swept all of them in. Two consequences shaped
+this change:
+
+1. Users wrote `NOT (X) AND NOT (is N/A)` by hand, and the second half is the part that is hard to
+   discover — a negation that silently answers with the un-annotated majority looks like a data bug,
+   not a semantics choice.
+2. The EAT reliability slider (`control-bar.setEatConfidenceThreshold`) had been built to exploit the
+   sweep: `NOT(EAT_confidence < x)` kept curated proteins visible only because they are null and the
+   complement returned them. That made the reliability filter's correctness depend on a defect.
+
+The description of what a filter means also had no home. `openspec/specs/` carries no filter-query
+capability, so nothing outside the source recorded that `NOT` had changed meaning for every saved
+query.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Make `NOT` mean what a user reading it expects, without a companion guard condition.
+- Give both condition kinds one shared vocabulary for presence (`has a value` / `has no value`), so
+  the numeric side can express what the categorical side already could.
+- Let the EAT reliability filter state its intent directly rather than depend on `NOT`'s behaviour.
+- Record the resulting semantics in `openspec/specs/` so the next change reads them as current.
+
+**Non-Goals:**
+
+- Reworking the evaluator into a three-valued (Kleene / SQL-NULL) model — see Risks.
+- Teaching the numeric row's live match count about `logicalOp`. The categorical picker was made
+  `NOT`-aware; the numeric preview still shows the un-negated count for a negated row. It is a
+  behaviour change that needs its own decision, and it affects a preview rather than a result.
+- Fixing reliability-condition ownership (removing the N/A chip in the builder orphans the slider).
+  #427 fixes it by keying on a declared owner instead of the condition's shape.
+- Migrating stored queries. See Migration Plan.
+
+## Decisions
+
+**`NOT` scopes to "has a value", it does not complement.**
+`itemResult = proteinsWithAnyValue(annotations(item)) ∖ itemResult`. The alternative — keeping the
+complement and having the UI append an implicit `AND NOT (is N/A)` — was rejected because it puts
+the semantics in the builder, so a query constructed anywhere else (bundle settings, the EAT mirror,
+a future API) gets the old behaviour. Scoping inside the evaluator makes `NOT` self-contained.
+
+For a group, the scope is the proteins carrying a value for **at least one** of the annotations the
+group touches, not all of them. "All" would drop a protein annotated for one of two columns, which
+is a stricter reading than a user negating a group intends; for the single-condition case that
+dominates, the two coincide.
+
+**Presence sentinels rather than a `nullHandling` mode.**
+`ANY_VALUE = '__ANY__'` joins the existing `NA_VALUE = '__NA__'`, and both are values the condition
+carries — in `values` for a categorical condition, in a new optional `presence` array for a numeric
+one. A per-condition enum (`includeNulls: 'never' | 'always'`) was the alternative; sentinels won
+because the categorical side already worked that way, so the picker, the chip row, the counts and
+the evaluator all needed one rule instead of two. The cost is that `presence` is a three-state
+concept modelled as an unbounded array (only `[]`, `[NA_VALUE]` and `[ANY_VALUE]` are reachable).
+
+`ANY_VALUE` lives in `query-types.ts`, not in `missing-values.ts` next to `NA_VALUE`: it is a
+filter-query concept and nothing in the data pipeline ever produces it. Its display label lives in
+`query-presence.ts` instead, which keeps `query-types.ts` presentation-free while still giving the
+three components that render a sentinel — picker, categorical chip row, numeric chip row — a single
+`displayFilterValue` to read it through.
+
+**Presence unions with the comparison; nulls are outside the numeric domain.**
+`matchesNumericValue` returns `presence.includes(NA_VALUE)` for a null before it looks at the
+operator, and `true` for any non-null when `ANY_VALUE` is present. So `>= 0.5` + N/A is a union, not
+a modified comparison. This is what lets the reliability filter be written as one condition.
+
+**`ANY_VALUE` is exclusive, enforced in three places.**
+"Any value OR X" is just "any value". The picker locks the remaining entries (`is-disabled` +
+`aria-disabled`, click and keyboard both inert), the categorical select handler replaces the
+selection, and the numeric chip handler clears both bounds and disables the operator. Locking rather
+than silently ignoring is deliberate: a selection that has no effect is worse than one that is
+visibly unavailable.
+
+**One readiness rule, derived from one operator table.**
+`numericFieldsFor(operator)` is the only statement of which bounds an operator needs; `hasNumericBounds`
+derives from it and `isNumericConditionReady` is `hasNumericBounds || presence.length > 0`. Adding
+`gte`/`lte` therefore touched one table. The `<option>` list in `query-numeric-input` is the one
+un-type-checked half of that table — a sixth operator would type-check while the dropdown silently
+omitted it.
+
+**Previews are computed from the same definitions as results.**
+The value picker's `NOT` count is `|matched ∩ has-value| − |that slice carrying v|` rather than
+`|matched| − |carriers|`, which fixes both old errors at once (N/A proteins swept in; a multi-label
+protein removed once per missing label). It is cross-checked against `evaluateQuery` for the same
+single condition in `query-value-picker.test.ts`. `countNumericMatches` walks `protein_ids.length`
+and normalizes a missing slot to null, matching `evaluateNumericCondition` exactly, so a sparse
+column cannot make the preview undershoot the result.
+
+Both count paths run per keystroke, so the picker memoizes its dataset walk and invalidates on the
+four inputs the counts depend on (`data`, `annotation`, `matchedIndices`, `logicalOp`).
+`matchedIndices` compares by reference, which holds because the builder hands down a freshly built
+`Set` on each evaluation rather than mutating one in place.
+
+## Risks / Trade-offs
+
+**Saved `NOT` queries silently change result.** → Accepted, and the reason this is marked BREAKING.
+The old result was the one users worked around, and a migration that appended `AND NOT (is N/A)` to
+every stored `NOT` would preserve a behaviour nobody asked for. The one stored form that mattered —
+the EAT reliability filter — is rewritten by the slider on load rather than migrated.
+
+**The reliability condition is recognized by shape, not identity.** → `_isReliabilityConditionForKey`
+matches "numeric, this column, `gte`, not negated, carries N/A". A user who hand-builds that exact
+condition adopts the slider, and removing the N/A chip in the builder orphans it. Mitigated by
+scoping the match to the resolved eat-confidence column of a specific base; fixed properly in #427.
+
+**`proteinsWithAnyValue` walks the dataset once per `NOT` evaluation.** → Mitigated by hoisting the
+record lookups out of the row loop and precomputing an `isRealValue` table per _declared_ value
+rather than calling `toInternalValue` per label per protein — the table is as long as the category
+list, not the protein list.
+
+**A three-valued evaluator would be simpler.** → If `evaluateCondition` returned `{matched, defined}`
+pairs, `NOT` would fall out as `defined ∖ matched` and both `collectAnnotations` and
+`proteinsWithAnyValue` would disappear. Not taken here: it rewrites every combinator and the counting
+paths that mirror them, for no user-visible difference. Recorded as the natural next refactor.
+
+## Migration Plan
+
+No data migration. `FilterQuery` is persisted in bundle settings; `presence` is optional and absent
+in old bundles, `ANY_VALUE` never appears in one, so old queries load unchanged. A stored `NOT`
+evaluates under the new rule, which is the intended change. A stored `NOT(EAT_confidence < x)` is
+not migrated — on load the slider seeds from `eatConfidenceThreshold` and writes the new
+`>= x` + N/A condition, so the reliability filter is re-derived rather than converted.
+
+## Open Questions
+
+- Should the numeric row's live count become `logicalOp`-aware, matching the categorical picker? It
+  is the one place a preview can still disagree with the result.
+- Should `presence` become a nullable enum now that only three states are reachable, or wait for the
+  Kleene refactor that would remove it entirely?

--- a/openspec/changes/archive/2026-08-11-add-filter-presence-semantics/proposal.md
+++ b/openspec/changes/archive/2026-08-11-add-filter-presence-semantics/proposal.md
@@ -1,0 +1,71 @@
+## Why
+
+`NOT` in the query builder was a bare index complement, so `NOT (annotation is X)` also returned
+every protein with no value for that annotation. "Not an enzyme" answered with the un-annotated
+majority, and asking the intended question meant bolting `AND NOT (is N/A)` onto every negated
+condition. There was no way to say "has a value, whichever one", and the numeric side had no
+presence concept at all, so `>` and `<` could never keep a null.
+
+The EAT reliability slider was built on the defect: it spelled its filter `NOT(EAT_confidence < x)`
+and relied on the complement sweeping curated proteins (which carry no confidence score) back in.
+Fixing `NOT` without restating that filter would have hidden every curated point.
+
+Retroactive: the code shipped in #416 and is on `main`. Written now because `openspec/specs/` is the
+source of truth and holds no filter-query capability at all — nothing records what `NOT` means,
+which every saved query depends on.
+
+## What Changes
+
+- **BREAKING** `NOT` means "has a value **and** does not match" — the matches subtracted from the
+  proteins carrying a value — instead of a set complement. Every existing saved query containing a
+  `NOT` changes result: proteins that are N/A on the negated annotation are no longer returned. In exchange
+  `NOT (is N/A)` now means exactly "has any value", and the hand-written `AND NOT (is N/A)` guard
+  becomes redundant.
+- New presence sentinel `ANY_VALUE` (`'__ANY__'`), the exact complement of the existing `NA_VALUE`
+  over a given annotation. Categorical conditions carry it among their `values`; numeric conditions
+  carry it in a new `presence` field.
+- Presence sentinels are **unioned** with the comparison rather than replacing it, so
+  `>= 0.5` plus an N/A chip reads "at least 0.5, or no value at all". No comparison operator ever
+  matches a null on its own.
+- `ANY_VALUE` is **exclusive**: selecting it replaces the rest of the selection and locks the
+  remaining options out, because "any value OR X" is just "any value".
+- New inclusive numeric operators `gte` and `lte` alongside the existing exclusive `gt`/`lt`.
+- Readiness rule stated once for both kinds: a numeric condition constrains the result when it has
+  the bounds its operator requires **OR** it carries a presence chip. An unready condition stays a
+  match-all no-op.
+- The EAT reliability filter is restated as `EAT_confidence >= x` **plus an N/A presence chip**,
+  replacing `NOT(EAT_confidence < x)`. It now states "confidence at least x, or no confidence score
+  at all" directly instead of depending on `NOT`'s old null-sweeping side effect.
+
+## Capabilities
+
+### New Capabilities
+
+- `filter-query-semantics`: what a filter condition matches — the presence sentinels, how `AND`/`OR`/`NOT`
+  combine conditions, when a condition constrains anything at all, and the live match counts the
+  builder previews before Apply.
+
+### Modified Capabilities
+
+<!-- The EAT overlay requirements live in the unarchived `add-eat-visualization` change rather
+     than in openspec/specs/, so there is no committed requirement to modify. Its five stale
+     `NOT(EAT_confidence < x)` requirements were corrected in place by #416; this change owns the
+     filter-side rule they now depend on. -->
+
+## Impact
+
+- **Query semantics:** `packages/core/src/components/control-bar/query-evaluate.ts` (NOT scoping,
+  `proteinsWithAnyValue`, `collectAnnotations`), `query-numeric-helpers.ts` (operator table,
+  readiness, `matchesNumericValue`, `countNumericMatches`), `query-types.ts` (`ANY_VALUE`,
+  `NumericCondition.presence`, `gte`/`lte`).
+- **Query builder UI:** `query-condition-row.ts`, `query-value-picker.ts`, `query-numeric-input.ts`,
+  and the shared `query-presence.ts` chip/label renderer.
+- **EAT mirror:** `control-bar.ts` — `setEatConfidenceThreshold` and the reliability-condition
+  recognizer that keys the legend slider off the query.
+- **Saved queries:** `FilterQuery` is persisted in bundle settings. Old queries still load — the new
+  fields are optional — but a stored `NOT` evaluates differently, and a stored
+  `NOT(EAT_confidence < x)` no longer keeps curated points. There is no migration.
+- **Not included:** making the numeric row's live match count `logicalOp`-aware (a `NOT`'d numeric
+  row still previews the un-negated count — the categorical picker was taught about `NOT`, the
+  numeric side never receives it); reliability-condition ownership, which is fixed separately in
+  #427 by keying on a declared owner instead of the condition's shape.

--- a/openspec/changes/archive/2026-08-11-add-filter-presence-semantics/specs/filter-query-semantics/spec.md
+++ b/openspec/changes/archive/2026-08-11-add-filter-presence-semantics/specs/filter-query-semantics/spec.md
@@ -1,0 +1,265 @@
+## ADDED Requirements
+
+### Requirement: NOT is scoped to proteins that carry a value
+
+`NOT` SHALL mean "carries a value for the negated annotation **and** does not match", i.e.
+`difference(proteinsWithAnyValue(annotations), matches)` — NOT a complement of the matched set over
+all protein indices. The scope SHALL be the proteins holding at least one real (non-N/A) label for
+at least one annotation the negated item references; for a group, "at least one" rather than "all"
+keeps the negation as permissive as possible. A protein that is N/A on the negated annotation SHALL
+NOT be returned by a `NOT`.
+
+#### Scenario: Negating a categorical value
+
+- **WHEN** a condition is `NOT (family is Kinase)` and the dataset holds kinases, non-kinases, and
+  proteins with no family annotation
+- **THEN** the non-kinases are returned
+- **AND** the proteins with no family annotation are not returned
+
+#### Scenario: Negating N/A means "has any value"
+
+- **WHEN** a condition is `NOT (family is N/A)`
+- **THEN** exactly the proteins carrying at least one real family label are returned
+- **AND** the result equals the condition `family is Any value`
+
+#### Scenario: The old N/A guard is now redundant
+
+- **WHEN** a query pairs `NOT (family is Kinase)` with the hand-written guard
+  `AND NOT (family is N/A)`
+- **THEN** the result is the same as the first condition alone
+
+#### Scenario: Negating a group
+
+- **WHEN** a group over two annotations is negated
+- **THEN** the scope is the proteins carrying a value for either annotation
+- **AND** only a protein that is N/A across both is dropped by the scoping
+
+#### Scenario: Negating a numeric annotation
+
+- **WHEN** a condition is `NOT (confidence > 0.8)` and some proteins have no confidence value
+- **THEN** the proteins whose confidence is at most `0.8` are returned
+- **AND** the proteins with no confidence value are not returned
+
+#### Scenario: Negating an unconfigured condition
+
+- **WHEN** a `NOT` is applied to a condition that has no selected values and no bounds
+- **THEN** the condition matches every protein, so the negation matches none
+- **AND** Apply remains disabled because no condition is configured
+
+### Requirement: Presence sentinels select proteins by whether a value exists
+
+The system SHALL provide two presence sentinels that are exact complements of each other over a
+given annotation: `NA_VALUE` (`'__NA__'`) selects the proteins missing a value, and `ANY_VALUE`
+(`'__ANY__'`) selects precisely the rest. Categorical conditions SHALL carry them among their
+`values`; numeric conditions SHALL carry them in a separate `presence` field. Both kinds SHALL
+evaluate them identically. `ANY_VALUE` SHALL be offered first in the value picker, ahead of the
+declared values, and SHALL be rendered as "Any value" through the same label path as N/A.
+
+#### Scenario: Any value on a categorical annotation
+
+- **WHEN** a condition is `family is Any value`
+- **THEN** every protein carrying at least one real family label is returned
+- **AND** proteins with no family label are not returned
+
+#### Scenario: Multi-label protein carrying both real labels and nulls
+
+- **WHEN** a protein resolves to a mix of real labels and N/A for the annotation
+- **THEN** it matches `Any value`
+- **AND** it also matches `is N/A`, because it carries that label too
+
+#### Scenario: Any value leads the picker
+
+- **WHEN** the value picker opens for an annotation and `Any value` is not already selected
+- **THEN** `Any value` is the first entry, ahead of the annotation's declared values
+
+#### Scenario: A sentinel reads the same wherever it is shown
+
+- **WHEN** a sentinel is rendered in the value picker, on a categorical value chip, or on a numeric
+  presence chip
+- **THEN** all three show the same label for it, resolved through one shared display function
+- **AND** searching the picker for that label matches the sentinel entry
+
+### Requirement: A presence chip is unioned with the numeric comparison
+
+A numeric condition's presence chips SHALL be unioned with its comparison, not replace it: `>= 0.5`
+carrying an N/A chip SHALL read "at least 0.5, or no value at all". A null (missing) value SHALL be
+matched ONLY by an explicit `NA_VALUE` chip — no comparison operator SHALL ever match a null, since
+a missing value sits outside the numeric domain. An `ANY_VALUE` chip SHALL match every non-null
+value regardless of the comparison.
+
+#### Scenario: Threshold plus N/A
+
+- **WHEN** a condition is `confidence >= 0.5` carrying an N/A chip
+- **THEN** proteins whose confidence is at least `0.5` are returned
+- **AND** proteins with no confidence value are also returned
+- **AND** proteins whose confidence is below `0.5` are not returned
+
+#### Scenario: A comparison alone never keeps a null
+
+- **WHEN** a condition is `confidence < 0.5` with no presence chip
+- **THEN** proteins with no confidence value are not returned
+
+#### Scenario: Any value on a numeric annotation
+
+- **WHEN** a condition carries an `Any value` chip
+- **THEN** every protein with a non-null value for that annotation is returned
+- **AND** proteins with no value are not returned
+
+### Requirement: Any value is exclusive
+
+Selecting `ANY_VALUE` SHALL replace the rest of the selection rather than join it, because "any
+value OR X" is just "any value" and "any value OR N/A" is everything. While it is selected the
+remaining choices SHALL be locked out rather than silently ignored. On the categorical side the
+picker SHALL mark every entry `aria-disabled` and refuse selection by pointer or keyboard. On the
+numeric side adding the chip SHALL clear both bounds and disable the operator and value fields, and
+the N/A chip SHALL no longer be offered.
+
+#### Scenario: Selecting Any value over an existing selection
+
+- **WHEN** a categorical condition already selects `Kinase` and the user picks `Any value`
+- **THEN** the condition's values become exactly `[Any value]`
+
+#### Scenario: The picker locks out while Any value is selected
+
+- **WHEN** `Any value` is selected and the user clicks or presses Enter on another entry
+- **THEN** the selection does not change
+- **AND** every entry reports `aria-disabled="true"`
+
+#### Scenario: Adding the Any value chip to a numeric condition
+
+- **WHEN** a numeric condition is `>= 0.5` and the user adds the `Any value` chip
+- **THEN** its presence becomes exactly `[Any value]` and both bounds are cleared
+- **AND** the operator dropdown and the value fields are disabled
+- **AND** the `+ N/A` chip button is no longer offered
+
+### Requirement: A condition constrains the result only when it is configured
+
+A condition SHALL constrain the result when it is _configured_, and SHALL otherwise be a match-all
+no-op, symmetric across the two kinds. A categorical condition SHALL be configured when it has at
+least one selected value. A numeric condition SHALL be configured when it has every bound its
+operator requires **OR** it carries a presence chip — a presence chip is meaningful on its own. The
+operator → required-bounds table SHALL be stated once (`gt`/`gte` need `min`, `lt`/`lte` need `max`,
+`between` needs both) and readiness SHALL be derived from it. Apply SHALL be gated on at least one
+configured condition existing anywhere in the query — alongside the result being neither empty nor
+the whole dataset — so a query of nothing but no-ops cannot be applied as if it were a real filter.
+
+#### Scenario: A presence chip alone is enough
+
+- **WHEN** a numeric condition has no bounds but carries an N/A chip
+- **THEN** it is configured, it returns the proteins with no value, and Apply is enabled
+
+#### Scenario: A bound-less comparison is a no-op
+
+- **WHEN** a numeric condition is `>` with an empty min field and no presence chip
+- **THEN** it matches every protein
+- **AND** Apply is disabled unless some other condition is configured
+
+#### Scenario: An empty categorical condition is a no-op
+
+- **WHEN** a categorical condition has no selected values
+- **THEN** it matches every protein
+
+#### Scenario: An emptied group is a no-op
+
+- **WHEN** a group's last condition is removed
+- **THEN** the empty group matches every protein rather than intersecting the query down to nothing
+
+#### Scenario: A configured condition on a missing column
+
+- **WHEN** a configured condition names an annotation the dataset does not carry
+- **THEN** it matches no protein
+
+### Requirement: Numeric comparisons offer inclusive and exclusive operators
+
+The numeric operator set SHALL be `gt`, `gte`, `lt`, `lte`, and `between`. `>` and `<` SHALL be
+exclusive at the boundary; `>=`, `<=` and `between` SHALL be inclusive at both ends. Switching
+operator SHALL null out the bound the new operator does not use, so a hidden value cannot linger and
+silently re-constrain the filter on switching back.
+
+#### Scenario: Inclusive versus exclusive at the boundary
+
+- **WHEN** a protein's value is exactly `0.5`
+- **THEN** it matches `>= 0.5` and `<= 0.5` and `between 0.5 and 0.9`
+- **AND** it does not match `> 0.5` or `< 0.5`
+
+#### Scenario: Switching operator drops the unused bound
+
+- **WHEN** a condition is `between 0.2 and 0.8` and the operator changes to `>=`
+- **THEN** `min` is kept and `max` is set to null
+- **AND** switching back to `between` leaves the condition unconfigured until a new max is entered
+
+### Requirement: The EAT reliability filter retains proteins with no confidence score
+
+The legend's reliability slider SHALL drive a single query condition of the form
+`<eat-confidence column> >= x` carrying an `NA_VALUE` presence chip — stating "confidence at least
+x, or no confidence score at all" directly, so curated proteins (which carry no confidence value)
+stay visible. It SHALL NOT be expressed as `NOT (confidence < x)`, which retained nulls only as a
+side effect of the old complement semantics and would now hide every curated protein. A threshold of
+`0` or below SHALL remove the condition. The eat-confidence column SHALL be resolved by runtime
+identity (role plus base annotation) rather than by name suffix, and only the selected base's
+condition SHALL be replaced, leaving other bases' filters and unrelated user conditions untouched.
+
+#### Scenario: Raising the slider above zero
+
+- **WHEN** the reliability slider for a transferred base moves to `0.75`
+- **THEN** the query gains exactly one condition `<base's eat-confidence column> >= 0.75` with an
+  N/A presence chip
+- **AND** predictions below `0.75` are filtered out while curated proteins remain visible
+
+#### Scenario: Returning the slider to zero
+
+- **WHEN** the slider returns to `0`
+- **THEN** that base's reliability condition is removed from the query
+- **AND** if no configured condition remains, the filter is cleared and every protein returns
+
+#### Scenario: Two transferred bases
+
+- **WHEN** one base's slider is tuned while another base already has a reliability condition
+- **THEN** only the tuned base's condition is replaced
+- **AND** the other base's condition and any unrelated user conditions are preserved
+
+#### Scenario: Reading the threshold back out of the query
+
+- **WHEN** the slider needs to reflect the query
+- **THEN** a condition counts as this base's reliability filter only when it is numeric, names that
+  exact column, uses `gte`, is not negated, and carries the N/A presence chip
+- **AND** its `min` is the threshold shown, defaulting to `0` when no such condition exists
+
+### Requirement: Live match previews agree with the applied filter
+
+The counts the builder shows before Apply SHALL be computed the same way the filter itself matches,
+so a preview never disagrees with the result it predicts. The value picker's per-value counts SHALL
+be relative to the query with the current condition excluded, and SHALL account for the row's
+logical operator: `AND` counts the carriers within the already-matched set; `OR` counts the union of
+the matched set with the whole-dataset carriers; `NOT` counts the has-a-value slice of the matched
+set minus the proteins in that slice carrying the value, which equals evaluating the same single
+`NOT` condition. A multi-label protein SHALL be counted once per value, however many of its labels
+miss. The numeric row's count SHALL walk the protein count rather than the value array's length,
+normalizing a missing slot to null, and SHALL be `0` for an unconfigured condition or a missing
+column.
+
+#### Scenario: NOT preview matches the applied result
+
+- **WHEN** a categorical row's operator is `NOT` and the picker lists per-value counts
+- **THEN** each count equals the number of proteins that applying that single `NOT` condition would
+  return
+- **AND** proteins that are N/A on the annotation are not counted
+
+#### Scenario: Multi-label protein counted once
+
+- **WHEN** a protein carries three labels and the `NOT` preview is computed for a value it does not
+  carry
+- **THEN** the protein is removed from the count at most once
+
+#### Scenario: Numeric count over a sparse column
+
+- **WHEN** a numeric column holds fewer entries than the dataset has proteins and the condition
+  carries an N/A chip
+- **THEN** the missing rows count as null and are matched by the chip
+- **AND** the preview equals the number of proteins the applied filter returns
+
+#### Scenario: Typing in the value search does not rescan the dataset
+
+- **WHEN** the user types into the value picker's search box
+- **THEN** the per-value counts are reused rather than recomputed, and are invalidated only when the
+  data, annotation, matched set, or logical operator changes

--- a/openspec/changes/archive/2026-08-11-add-filter-presence-semantics/tasks.md
+++ b/openspec/changes/archive/2026-08-11-add-filter-presence-semantics/tasks.md
@@ -1,0 +1,97 @@
+> Retroactive change: the work shipped in #416 (`feat/improved_filtering`, merged as `81ad450b`)
+> before this OpenSpec entry existed. Every task below is recorded against the commit that did it.
+
+## 1. Presence model (#416, `e27c7be8`)
+
+- [x] 1.1 Add the `ANY_VALUE = '__ANY__'` sentinel to `query-types.ts` as the exact complement of
+      `NA_VALUE`, with the rationale for keeping it out of `missing-values.ts`.
+- [x] 1.2 Add the optional `presence?: string[]` field to `NumericCondition` and seed it in
+      `createNumericCondition`.
+- [x] 1.3 Add the inclusive `gte` / `lte` operators to `NumericOperator` and to the
+      `numericFieldsFor` bounds table.
+- [x] 1.4 Teach `matchesNumericValue` the union rule: a null matches only an explicit `NA_VALUE`
+      chip; `ANY_VALUE` matches every non-null; the comparison is otherwise unchanged.
+- [x] 1.5 State readiness once — `isNumericConditionReady = hasNumericBounds || presence.length > 0`
+      — derived from `numericFieldsFor` rather than a second operator switch.
+- [x] 1.6 Honour `ANY_VALUE` in `evaluateCondition` for categorical conditions, including
+      multi-label proteins whose labels mix real values and nulls.
+
+## 2. N/A-aware NOT (#416, `e27c7be8`)
+
+- [x] 2.1 Add `collectAnnotations` (every annotation a condition or group references) and
+      `proteinsWithAnyValue` (carriers of at least one real label across those annotations).
+- [x] 2.2 Redefine `NOT` in `evaluateItems` as `difference(proteinsWithAnyValue, matches)` instead
+      of a complement over all indices.
+- [x] 2.3 Keep an unconfigured condition a match-all no-op so `NOT (unconfigured)` matches nothing
+      rather than isolating every protein, and keep Apply gated by `hasConfiguredCondition`.
+- [x] 2.4 Handle numeric annotations in `proteinsWithAnyValue` via `numeric_annotation_data`
+      (non-null), not the categorical index path.
+
+## 3. Query builder UI (#416, `e27c7be8`)
+
+- [x] 3.1 Offer `ANY_VALUE` first in the value picker, ahead of the annotation's declared values.
+- [x] 3.2 Make `ANY_VALUE` exclusive on the categorical side: selecting it replaces the selection,
+      and the picker locks the rest out (`is-disabled`, `aria-disabled`, inert click).
+- [x] 3.3 Add presence chips (`+ N/A`, `+ Any value`) to the numeric row, styled as the categorical
+      value chips they mirror.
+- [x] 3.4 Make `ANY_VALUE` exclusive on the numeric side: it clears both bounds, disables the
+      operator and value fields, and withdraws the `+ N/A` offer.
+- [x] 3.5 Make the value picker's live counts `NOT`-aware —
+      `|matched ∩ has-value| − |that slice carrying v|` — and cross-check them against
+      `evaluateQuery` for the same single condition.
+
+## 4. EAT reliability filter (#416, `e27c7be8`)
+
+- [x] 4.1 Rewrite `setEatConfidenceThreshold` to upsert `<eat-confidence column> >= x` with an
+      `NA_VALUE` presence chip, replacing `NOT(EAT_confidence < x)`.
+- [x] 4.2 Update the reverse mirror's recognizer to match the new shape (numeric, that exact column,
+      `gte`, un-negated, carries the N/A chip) and scope both directions to one base's column.
+- [x] 4.3 Correct the five stale `NOT(EAT_confidence < x)` requirements in
+      `openspec/changes/add-eat-visualization/specs/eat-annotation-overlay/spec.md`.
+
+## 5. Deduplication pass (#416, `1aedc853` + `082b8b75`)
+
+- [x] 5.1 Extract `query-presence.ts` with `displayFilterValue` and `renderValueChip`, and delete the
+      three copies of the sentinel-display rule and the two copies of the chip markup.
+- [x] 5.2 Keep `ANY_DISPLAY` module-private — nothing imports it, and exporting it fails `knip`.
+- [x] 5.3 Restore the side-effect `import './query-value-picker'` in `query-condition-row.ts`, which
+      had been getting element registration for free via the dropped `ANY_DISPLAY` named import.
+- [x] 5.4 Extract `presenceOf(condition)` returning a frozen shared empty array, so a chip-less
+      condition cannot be given a chip through a stray mutation.
+
+## 6. Preview correctness and cost (#416, `a3b65b2a` + `082b8b75`)
+
+- [x] 6.1 Make `countNumericMatches` walk `protein_ids.length` and normalize a missing slot to null,
+      so a sparse column cannot make the preview undershoot the applied result.
+- [x] 6.2 Memoize the value picker's dataset walk, invalidating on `data`, `annotation`,
+      `matchedIndices` and `logicalOp`, so typing in the search box stops re-scanning ~570K rows per
+      character.
+- [x] 6.3 Fold `anyCount` and `mixedNaCount` into the single count-map walk and delete
+      `_proteinsWithValue`, so the `NOT` preview needs no second scan.
+- [x] 6.4 Precompute an `isRealValue` table per _declared_ value in `proteinsWithAnyValue` instead of
+      calling `toInternalValue` per label per protein.
+
+## 7. Tests and docs (#416)
+
+- [x] 7.1 `query-evaluate.test.ts` — NOT scoping, `NOT (is N/A)` ≡ `is Any value`, group scoping,
+      NOT over unconfigured, missing columns.
+- [x] 7.2 `query-value-picker.test.ts` — AND/OR/NOT count arithmetic, multi-label counted once, and
+      the cross-check against `evaluateQuery`.
+- [x] 7.3 `query-numeric-input.test.ts` / `query-numeric-helpers.test.ts` — presence chips,
+      exclusivity, inclusive operators, sparse-column counting.
+- [x] 7.4 `control-bar.query-apply.test.ts` + Playwright `eat-visualization` — the reliability
+      slider's two-way mirror against the real phosphatase bundle.
+- [x] 7.5 Update `docs/explore/control-bar.md` for the new `NOT`, the presence chips and the
+      inclusive operators.
+
+## 8. Spec wrap-up (this change)
+
+- [x] 8.1 Write `proposal.md`, `design.md` and the `filter-query-semantics` spec delta covering the
+      semantics #416 shipped.
+- [x] 8.2 Record the deliberately-unfixed findings as Non-Goals / Open Questions rather than as
+      requirements: the numeric row's `logicalOp`-blind live count, reliability-condition ownership
+      (#427), `presence` as a 3-state enum, the un-type-checked `<option>` list, and the Kleene
+      refactor that would delete `collectAnnotations` + `proteinsWithAnyValue`.
+- [x] 8.3 `openspec validate --strict` clean.
+- [x] 8.4 Archive so `openspec/specs/filter-query-semantics/` becomes the source of truth, on the
+      branch and before the merge.

--- a/openspec/specs/filter-query-semantics/spec.md
+++ b/openspec/specs/filter-query-semantics/spec.md
@@ -1,0 +1,271 @@
+# filter-query-semantics Specification
+
+## Purpose
+
+What a filter condition in the query builder matches: the presence sentinels that select proteins by whether they have a value at all, how `AND`/`OR`/`NOT` combine conditions once a missing value is a first-class case, when a condition constrains the result at all, and the live match counts the builder previews before Apply.
+
+## Requirements
+
+### Requirement: NOT is scoped to proteins that carry a value
+
+`NOT` SHALL mean "carries a value for the negated annotation **and** does not match", i.e.
+`difference(proteinsWithAnyValue(annotations), matches)` — NOT a complement of the matched set over
+all protein indices. The scope SHALL be the proteins holding at least one real (non-N/A) label for
+at least one annotation the negated item references; for a group, "at least one" rather than "all"
+keeps the negation as permissive as possible. A protein that is N/A on the negated annotation SHALL
+NOT be returned by a `NOT`.
+
+#### Scenario: Negating a categorical value
+
+- **WHEN** a condition is `NOT (family is Kinase)` and the dataset holds kinases, non-kinases, and
+  proteins with no family annotation
+- **THEN** the non-kinases are returned
+- **AND** the proteins with no family annotation are not returned
+
+#### Scenario: Negating N/A means "has any value"
+
+- **WHEN** a condition is `NOT (family is N/A)`
+- **THEN** exactly the proteins carrying at least one real family label are returned
+- **AND** the result equals the condition `family is Any value`
+
+#### Scenario: The old N/A guard is now redundant
+
+- **WHEN** a query pairs `NOT (family is Kinase)` with the hand-written guard
+  `AND NOT (family is N/A)`
+- **THEN** the result is the same as the first condition alone
+
+#### Scenario: Negating a group
+
+- **WHEN** a group over two annotations is negated
+- **THEN** the scope is the proteins carrying a value for either annotation
+- **AND** only a protein that is N/A across both is dropped by the scoping
+
+#### Scenario: Negating a numeric annotation
+
+- **WHEN** a condition is `NOT (confidence > 0.8)` and some proteins have no confidence value
+- **THEN** the proteins whose confidence is at most `0.8` are returned
+- **AND** the proteins with no confidence value are not returned
+
+#### Scenario: Negating an unconfigured condition
+
+- **WHEN** a `NOT` is applied to a condition that has no selected values and no bounds
+- **THEN** the condition matches every protein, so the negation matches none
+- **AND** Apply remains disabled because no condition is configured
+
+### Requirement: Presence sentinels select proteins by whether a value exists
+
+The system SHALL provide two presence sentinels that are exact complements of each other over a
+given annotation: `NA_VALUE` (`'__NA__'`) selects the proteins missing a value, and `ANY_VALUE`
+(`'__ANY__'`) selects precisely the rest. Categorical conditions SHALL carry them among their
+`values`; numeric conditions SHALL carry them in a separate `presence` field. Both kinds SHALL
+evaluate them identically. `ANY_VALUE` SHALL be offered first in the value picker, ahead of the
+declared values, and SHALL be rendered as "Any value" through the same label path as N/A.
+
+#### Scenario: Any value on a categorical annotation
+
+- **WHEN** a condition is `family is Any value`
+- **THEN** every protein carrying at least one real family label is returned
+- **AND** proteins with no family label are not returned
+
+#### Scenario: Multi-label protein carrying both real labels and nulls
+
+- **WHEN** a protein resolves to a mix of real labels and N/A for the annotation
+- **THEN** it matches `Any value`
+- **AND** it also matches `is N/A`, because it carries that label too
+
+#### Scenario: Any value leads the picker
+
+- **WHEN** the value picker opens for an annotation and `Any value` is not already selected
+- **THEN** `Any value` is the first entry, ahead of the annotation's declared values
+
+#### Scenario: A sentinel reads the same wherever it is shown
+
+- **WHEN** a sentinel is rendered in the value picker, on a categorical value chip, or on a numeric
+  presence chip
+- **THEN** all three show the same label for it, resolved through one shared display function
+- **AND** searching the picker for that label matches the sentinel entry
+
+### Requirement: A presence chip is unioned with the numeric comparison
+
+A numeric condition's presence chips SHALL be unioned with its comparison, not replace it: `>= 0.5`
+carrying an N/A chip SHALL read "at least 0.5, or no value at all". A null (missing) value SHALL be
+matched ONLY by an explicit `NA_VALUE` chip — no comparison operator SHALL ever match a null, since
+a missing value sits outside the numeric domain. An `ANY_VALUE` chip SHALL match every non-null
+value regardless of the comparison.
+
+#### Scenario: Threshold plus N/A
+
+- **WHEN** a condition is `confidence >= 0.5` carrying an N/A chip
+- **THEN** proteins whose confidence is at least `0.5` are returned
+- **AND** proteins with no confidence value are also returned
+- **AND** proteins whose confidence is below `0.5` are not returned
+
+#### Scenario: A comparison alone never keeps a null
+
+- **WHEN** a condition is `confidence < 0.5` with no presence chip
+- **THEN** proteins with no confidence value are not returned
+
+#### Scenario: Any value on a numeric annotation
+
+- **WHEN** a condition carries an `Any value` chip
+- **THEN** every protein with a non-null value for that annotation is returned
+- **AND** proteins with no value are not returned
+
+### Requirement: Any value is exclusive
+
+Selecting `ANY_VALUE` SHALL replace the rest of the selection rather than join it, because "any
+value OR X" is just "any value" and "any value OR N/A" is everything. While it is selected the
+remaining choices SHALL be locked out rather than silently ignored. On the categorical side the
+picker SHALL mark every entry `aria-disabled` and refuse selection by pointer or keyboard. On the
+numeric side adding the chip SHALL clear both bounds and disable the operator and value fields, and
+the N/A chip SHALL no longer be offered.
+
+#### Scenario: Selecting Any value over an existing selection
+
+- **WHEN** a categorical condition already selects `Kinase` and the user picks `Any value`
+- **THEN** the condition's values become exactly `[Any value]`
+
+#### Scenario: The picker locks out while Any value is selected
+
+- **WHEN** `Any value` is selected and the user clicks or presses Enter on another entry
+- **THEN** the selection does not change
+- **AND** every entry reports `aria-disabled="true"`
+
+#### Scenario: Adding the Any value chip to a numeric condition
+
+- **WHEN** a numeric condition is `>= 0.5` and the user adds the `Any value` chip
+- **THEN** its presence becomes exactly `[Any value]` and both bounds are cleared
+- **AND** the operator dropdown and the value fields are disabled
+- **AND** the `+ N/A` chip button is no longer offered
+
+### Requirement: A condition constrains the result only when it is configured
+
+A condition SHALL constrain the result when it is _configured_, and SHALL otherwise be a match-all
+no-op, symmetric across the two kinds. A categorical condition SHALL be configured when it has at
+least one selected value. A numeric condition SHALL be configured when it has every bound its
+operator requires **OR** it carries a presence chip — a presence chip is meaningful on its own. The
+operator → required-bounds table SHALL be stated once (`gt`/`gte` need `min`, `lt`/`lte` need `max`,
+`between` needs both) and readiness SHALL be derived from it. Apply SHALL be gated on at least one
+configured condition existing anywhere in the query — alongside the result being neither empty nor
+the whole dataset — so a query of nothing but no-ops cannot be applied as if it were a real filter.
+
+#### Scenario: A presence chip alone is enough
+
+- **WHEN** a numeric condition has no bounds but carries an N/A chip
+- **THEN** it is configured, it returns the proteins with no value, and Apply is enabled
+
+#### Scenario: A bound-less comparison is a no-op
+
+- **WHEN** a numeric condition is `>` with an empty min field and no presence chip
+- **THEN** it matches every protein
+- **AND** Apply is disabled unless some other condition is configured
+
+#### Scenario: An empty categorical condition is a no-op
+
+- **WHEN** a categorical condition has no selected values
+- **THEN** it matches every protein
+
+#### Scenario: An emptied group is a no-op
+
+- **WHEN** a group's last condition is removed
+- **THEN** the empty group matches every protein rather than intersecting the query down to nothing
+
+#### Scenario: A configured condition on a missing column
+
+- **WHEN** a configured condition names an annotation the dataset does not carry
+- **THEN** it matches no protein
+
+### Requirement: Numeric comparisons offer inclusive and exclusive operators
+
+The numeric operator set SHALL be `gt`, `gte`, `lt`, `lte`, and `between`. `>` and `<` SHALL be
+exclusive at the boundary; `>=`, `<=` and `between` SHALL be inclusive at both ends. Switching
+operator SHALL null out the bound the new operator does not use, so a hidden value cannot linger and
+silently re-constrain the filter on switching back.
+
+#### Scenario: Inclusive versus exclusive at the boundary
+
+- **WHEN** a protein's value is exactly `0.5`
+- **THEN** it matches `>= 0.5` and `<= 0.5` and `between 0.5 and 0.9`
+- **AND** it does not match `> 0.5` or `< 0.5`
+
+#### Scenario: Switching operator drops the unused bound
+
+- **WHEN** a condition is `between 0.2 and 0.8` and the operator changes to `>=`
+- **THEN** `min` is kept and `max` is set to null
+- **AND** switching back to `between` leaves the condition unconfigured until a new max is entered
+
+### Requirement: The EAT reliability filter retains proteins with no confidence score
+
+The legend's reliability slider SHALL drive a single query condition of the form
+`<eat-confidence column> >= x` carrying an `NA_VALUE` presence chip — stating "confidence at least
+x, or no confidence score at all" directly, so curated proteins (which carry no confidence value)
+stay visible. It SHALL NOT be expressed as `NOT (confidence < x)`, which retained nulls only as a
+side effect of the old complement semantics and would now hide every curated protein. A threshold of
+`0` or below SHALL remove the condition. The eat-confidence column SHALL be resolved by runtime
+identity (role plus base annotation) rather than by name suffix, and only the selected base's
+condition SHALL be replaced, leaving other bases' filters and unrelated user conditions untouched.
+
+#### Scenario: Raising the slider above zero
+
+- **WHEN** the reliability slider for a transferred base moves to `0.75`
+- **THEN** the query gains exactly one condition `<base's eat-confidence column> >= 0.75` with an
+  N/A presence chip
+- **AND** predictions below `0.75` are filtered out while curated proteins remain visible
+
+#### Scenario: Returning the slider to zero
+
+- **WHEN** the slider returns to `0`
+- **THEN** that base's reliability condition is removed from the query
+- **AND** if no configured condition remains, the filter is cleared and every protein returns
+
+#### Scenario: Two transferred bases
+
+- **WHEN** one base's slider is tuned while another base already has a reliability condition
+- **THEN** only the tuned base's condition is replaced
+- **AND** the other base's condition and any unrelated user conditions are preserved
+
+#### Scenario: Reading the threshold back out of the query
+
+- **WHEN** the slider needs to reflect the query
+- **THEN** a condition counts as this base's reliability filter only when it is numeric, names that
+  exact column, uses `gte`, is not negated, and carries the N/A presence chip
+- **AND** its `min` is the threshold shown, defaulting to `0` when no such condition exists
+
+### Requirement: Live match previews agree with the applied filter
+
+The counts the builder shows before Apply SHALL be computed the same way the filter itself matches,
+so a preview never disagrees with the result it predicts. The value picker's per-value counts SHALL
+be relative to the query with the current condition excluded, and SHALL account for the row's
+logical operator: `AND` counts the carriers within the already-matched set; `OR` counts the union of
+the matched set with the whole-dataset carriers; `NOT` counts the has-a-value slice of the matched
+set minus the proteins in that slice carrying the value, which equals evaluating the same single
+`NOT` condition. A multi-label protein SHALL be counted once per value, however many of its labels
+miss. The numeric row's count SHALL walk the protein count rather than the value array's length,
+normalizing a missing slot to null, and SHALL be `0` for an unconfigured condition or a missing
+column.
+
+#### Scenario: NOT preview matches the applied result
+
+- **WHEN** a categorical row's operator is `NOT` and the picker lists per-value counts
+- **THEN** each count equals the number of proteins that applying that single `NOT` condition would
+  return
+- **AND** proteins that are N/A on the annotation are not counted
+
+#### Scenario: Multi-label protein counted once
+
+- **WHEN** a protein carries three labels and the `NOT` preview is computed for a value it does not
+  carry
+- **THEN** the protein is removed from the count at most once
+
+#### Scenario: Numeric count over a sparse column
+
+- **WHEN** a numeric column holds fewer entries than the dataset has proteins and the condition
+  carries an N/A chip
+- **THEN** the missing rows count as null and are matched by the chip
+- **AND** the preview equals the number of proteins the applied filter returns
+
+#### Scenario: Typing in the value search does not rescan the dataset
+
+- **WHEN** the user types into the value picker's search box
+- **THEN** the per-value counts are reused rather than recomputed, and are invalidated only when the
+  data, annotation, matched set, or logical operator changes


### PR DESCRIPTION
Closes the OpenSpec debt left by #416.

#416 was ~1,600 lines across 22 files. It **redefined `NOT`** for every saved query, added the `ANY_VALUE` presence sentinel, added the inclusive `gte`/`lte` operators, and rewrote the EAT reliability filter — and it shipped with no `openspec/changes/` entry. `AGENTS.md` makes `openspec/specs/` the source of truth for current behaviour, and `openspec/specs/` carried **no filter-query capability at all**, so nothing outside the source recorded the one rule every saved query depends on.

This adds the change retroactively and archives it, so `openspec/specs/filter-query-semantics/` becomes true.

## What the spec now states

Eight requirements, each with scenarios, all derived from the code on `main`:

- **`NOT` is scoped to proteins that carry a value** — `difference(proteinsWithAnyValue(annotations), matches)`, not a set complement. That is what makes `NOT (is N/A)` mean exactly "has any value", and what makes the hand-written `AND NOT (is N/A)` guard redundant. For a group the scope is "carries a value for **at least one** of the annotations", not all.
- **Presence sentinels** — `NA_VALUE` / `ANY_VALUE` as exact complements, carried in `values` on the categorical side and `presence` on the numeric side, evaluated identically.
- **Presence unions with the comparison** — `>= 0.5` plus an N/A chip reads "at least 0.5, or no value at all". A null is matched *only* by an explicit N/A chip; no comparison operator ever matches one.
- **`ANY_VALUE` is exclusive** — selecting it replaces the selection and locks the rest out, enforced in the picker, the categorical select handler and the numeric chip handler.
- **One readiness rule** — a numeric condition is configured when it has its operator's bounds **or** a presence chip; an unready condition stays a match-all no-op.
- **Inclusive `gte`/`lte`**, and switching operator nulls the bound the new operator does not use.
- **The EAT reliability filter** is `EAT_confidence >= x` + N/A chip. It was `NOT(EAT_confidence < x)`, which kept curated points only as a side effect of the old complement — under the new `NOT` it would have hidden every one of them.
- **Previews agree with results** — the picker's `NOT` count is the has-a-value slice minus the carriers *inside that slice*, cross-checked against `evaluateQuery`; `countNumericMatches` walks `protein_ids` so a sparse column can't undershoot.

## What it deliberately does not state

The findings from the #416 review that were reported and left unfixed are recorded as **Non-Goals / Open Questions in `design.md`**, not as requirements — a spec should not bless a known gap:

- the numeric row's live count ignores `logicalOp`, so a `NOT`'d numeric row previews the un-negated count;
- reliability-condition orphaning, fixed separately in #427 by keying on a declared owner rather than the condition's shape;
- `presence?: string[]` as a 3-state enum modelled as an unbounded array;
- the Kleene / SQL-NULL refactor that would make `NOT` fall out as `defined ∖ matched` and delete `collectAnnotations` + `proteinsWithAnyValue`;
- the `<option>` list being the one un-type-checked half of the operator table.

`tasks.md` records every task against the commit that actually did it (`e27c7be8`, `1aedc853`, `a3b65b2a`, `082b8b75`), since the work is already on `main`.

The five stale `NOT(EAT_confidence < x)` requirements in `add-eat-visualization` were already corrected in #416 and are untouched here.

## Verification

- `openspec validate --all --strict` — **16 passed, 0 failed**, including the new `spec/filter-query-semantics`
- `pnpm format:check` clean
- Docs-only: no source, no tests, no behaviour change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HGVhbzHK79uUDaJPhTDu9c
