### PR TITLE
refactor(filter): align query builder with the design system, add picker a11y

### DIFF
--- a/openspec/changes/archive/2026-08-11-add-filter-presence-semantics/.openspec.yaml
+++ b/openspec/changes/archive/2026-08-11-add-filter-presence-semantics/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-11

--- a/openspec/changes/archive/2026-08-11-add-filter-presence-semantics/design.md
+++ b/openspec/changes/archive/2026-08-11-add-filter-presence-semantics/design.md
@@ -1,0 +1,138 @@
+## Context
+
+The query builder evaluates a `FilterQuery` — a list of conditions and groups — into a `Set<number>`
+of protein indices (`query-evaluate.ts`). Conditions come in two kinds that had drifted apart:
+categorical conditions selected values from a list that already contained the `NA_VALUE` sentinel,
+while numeric conditions had only an operator and one or two bounds and no concept of a missing
+value at all.
+
+`NOT` lived at the combining level, applied as `allIndices ∖ itemResult`. Because a protein missing
+a value simply fails every condition, complementing swept all of them in. Two consequences shaped
+this change:
+
+1. Users wrote `NOT (X) AND NOT (is N/A)` by hand, and the second half is the part that is hard to
+   discover — a negation that silently answers with the un-annotated majority looks like a data bug,
+   not a semantics choice.
+2. The EAT reliability slider (`control-bar.setEatConfidenceThreshold`) had been built to exploit the
+   sweep: `NOT(EAT_confidence < x)` kept curated proteins visible only because they are null and the
+   complement returned them. That made the reliability filter's correctness depend on a defect.
+
+The description of what a filter means also had no home. `openspec/specs/` carries no filter-query
+capability, so nothing outside the source recorded that `NOT` had changed meaning for every saved
+query.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Make `NOT` mean what a user reading it expects, without a companion guard condition.
+- Give both condition kinds one shared vocabulary for presence (`has a value` / `has no value`), so
+  the numeric side can express what the categorical side already could.
+- Let the EAT reliability filter state its intent directly rather than depend on `NOT`'s behaviour.
+- Record the resulting semantics in `openspec/specs/` so the next change reads them as current.
+
+**Non-Goals:**
+
+- Reworking the evaluator into a three-valued (Kleene / SQL-NULL) model — see Risks.
+- Teaching the numeric row's live match count about `logicalOp`. The categorical picker was made
+  `NOT`-aware; the numeric preview still shows the un-negated count for a negated row. It is a
+  behaviour change that needs its own decision, and it affects a preview rather than a result.
+- Fixing reliability-condition ownership (removing the N/A chip in the builder orphans the slider).
+  #427 fixes it by keying on a declared owner instead of the condition's shape.
+- Migrating stored queries. See Migration Plan.
+
+## Decisions
+
+**`NOT` scopes to "has a value", it does not complement.**
+`itemResult = proteinsWithAnyValue(annotations(item)) ∖ itemResult`. The alternative — keeping the
+complement and having the UI append an implicit `AND NOT (is N/A)` — was rejected because it puts
+the semantics in the builder, so a query constructed anywhere else (bundle settings, the EAT mirror,
+a future API) gets the old behaviour. Scoping inside the evaluator makes `NOT` self-contained.
+
+For a group, the scope is the proteins carrying a value for **at least one** of the annotations the
+group touches, not all of them. "All" would drop a protein annotated for one of two columns, which
+is a stricter reading than a user negating a group intends; for the single-condition case that
+dominates, the two coincide.
+
+**Presence sentinels rather than a `nullHandling` mode.**
+`ANY_VALUE = '__ANY__'` joins the existing `NA_VALUE = '__NA__'`, and both are values the condition
+carries — in `values` for a categorical condition, in a new optional `presence` array for a numeric
+one. A per-condition enum (`includeNulls: 'never' | 'always'`) was the alternative; sentinels won
+because the categorical side already worked that way, so the picker, the chip row, the counts and
+the evaluator all needed one rule instead of two. The cost is that `presence` is a three-state
+concept modelled as an unbounded array (only `[]`, `[NA_VALUE]` and `[ANY_VALUE]` are reachable).
+
+`ANY_VALUE` lives in `query-types.ts`, not in `missing-values.ts` next to `NA_VALUE`: it is a
+filter-query concept and nothing in the data pipeline ever produces it. Its display label lives in
+`query-presence.ts` instead, which keeps `query-types.ts` presentation-free while still giving the
+three components that render a sentinel — picker, categorical chip row, numeric chip row — a single
+`displayFilterValue` to read it through.
+
+**Presence unions with the comparison; nulls are outside the numeric domain.**
+`matchesNumericValue` returns `presence.includes(NA_VALUE)` for a null before it looks at the
+operator, and `true` for any non-null when `ANY_VALUE` is present. So `>= 0.5` + N/A is a union, not
+a modified comparison. This is what lets the reliability filter be written as one condition.
+
+**`ANY_VALUE` is exclusive, enforced in three places.**
+"Any value OR X" is just "any value". The picker locks the remaining entries (`is-disabled` +
+`aria-disabled`, click and keyboard both inert), the categorical select handler replaces the
+selection, and the numeric chip handler clears both bounds and disables the operator. Locking rather
+than silently ignoring is deliberate: a selection that has no effect is worse than one that is
+visibly unavailable.
+
+**One readiness rule, derived from one operator table.**
+`numericFieldsFor(operator)` is the only statement of which bounds an operator needs; `hasNumericBounds`
+derives from it and `isNumericConditionReady` is `hasNumericBounds || presence.length > 0`. Adding
+`gte`/`lte` therefore touched one table. The `<option>` list in `query-numeric-input` is the one
+un-type-checked half of that table — a sixth operator would type-check while the dropdown silently
+omitted it.
+
+**Previews are computed from the same definitions as results.**
+The value picker's `NOT` count is `|matched ∩ has-value| − |that slice carrying v|` rather than
+`|matched| − |carriers|`, which fixes both old errors at once (N/A proteins swept in; a multi-label
+protein removed once per missing label). It is cross-checked against `evaluateQuery` for the same
+single condition in `query-value-picker.test.ts`. `countNumericMatches` walks `protein_ids.length`
+and normalizes a missing slot to null, matching `evaluateNumericCondition` exactly, so a sparse
+column cannot make the preview undershoot the result.
+
+Both count paths run per keystroke, so the picker memoizes its dataset walk and invalidates on the
+four inputs the counts depend on (`data`, `annotation`, `matchedIndices`, `logicalOp`).
+`matchedIndices` compares by reference, which holds because the builder hands down a freshly built
+`Set` on each evaluation rather than mutating one in place.
+
+## Risks / Trade-offs
+
+**Saved `NOT` queries silently change result.** → Accepted, and the reason this is marked BREAKING.
+The old result was the one users worked around, and a migration that appended `AND NOT (is N/A)` to
+every stored `NOT` would preserve a behaviour nobody asked for. The one stored form that mattered —
+the EAT reliability filter — is rewritten by the slider on load rather than migrated.
+
+**The reliability condition is recognized by shape, not identity.** → `_isReliabilityConditionForKey`
+matches "numeric, this column, `gte`, not negated, carries N/A". A user who hand-builds that exact
+condition adopts the slider, and removing the N/A chip in the builder orphans it. Mitigated by
+scoping the match to the resolved eat-confidence column of a specific base; fixed properly in #427.
+
+**`proteinsWithAnyValue` walks the dataset once per `NOT` evaluation.** → Mitigated by hoisting the
+record lookups out of the row loop and precomputing an `isRealValue` table per _declared_ value
+rather than calling `toInternalValue` per label per protein — the table is as long as the category
+list, not the protein list.
+
+**A three-valued evaluator would be simpler.** → If `evaluateCondition` returned `{matched, defined}`
+pairs, `NOT` would fall out as `defined ∖ matched` and both `collectAnnotations` and
+`proteinsWithAnyValue` would disappear. Not taken here: it rewrites every combinator and the counting
+paths that mirror them, for no user-visible difference. Recorded as the natural next refactor.
+
+## Migration Plan
+
+No data migration. `FilterQuery` is persisted in bundle settings; `presence` is optional and absent
+in old bundles, `ANY_VALUE` never appears in one, so old queries load unchanged. A stored `NOT`
+evaluates under the new rule, which is the intended change. A stored `NOT(EAT_confidence < x)` is
+not migrated — on load the slider seeds from `eatConfidenceThreshold` and writes the new
+`>= x` + N/A condition, so the reliability filter is re-derived rather than converted.
+
+## Open Questions
+
+- Should the numeric row's live count become `logicalOp`-aware, matching the categorical picker? It
+  is the one place a preview can still disagree with the result.
+- Should `presence` become a nullable enum now that only three states are reachable, or wait for the
+  Kleene refactor that would remove it entirely?

--- a/openspec/changes/archive/2026-08-11-add-filter-presence-semantics/proposal.md
+++ b/openspec/changes/archive/2026-08-11-add-filter-presence-semantics/proposal.md
@@ -1,0 +1,71 @@
+## Why
+
+`NOT` in the query builder was a bare index complement, so `NOT (annotation is X)` also returned
+every protein with no value for that annotation. "Not an enzyme" answered with the un-annotated
+majority, and asking the intended question meant bolting `AND NOT (is N/A)` onto every negated
+condition. There was no way to say "has a value, whichever one", and the numeric side had no
+presence concept at all, so `>` and `<` could never keep a null.
+
+The EAT reliability slider was built on the defect: it spelled its filter `NOT(EAT_confidence < x)`
+and relied on the complement sweeping curated proteins (which carry no confidence score) back in.
+Fixing `NOT` without restating that filter would have hidden every curated point.
+
+Retroactive: the code shipped in #416 and is on `main`. Written now because `openspec/specs/` is the
+source of truth and holds no filter-query capability at all — nothing records what `NOT` means,
+which every saved query depends on.
+
+## What Changes
+
+- **BREAKING** `NOT` means "has a value **and** does not match" — the matches subtracted from the
+  proteins carrying a value — instead of a set complement. Every existing saved query containing a
+  `NOT` changes result: proteins that are N/A on the negated annotation are no longer returned. In exchange
+  `NOT (is N/A)` now means exactly "has any value", and the hand-written `AND NOT (is N/A)` guard
+  becomes redundant.
+- New presence sentinel `ANY_VALUE` (`'__ANY__'`), the exact complement of the existing `NA_VALUE`
+  over a given annotation. Categorical conditions carry it among their `values`; numeric conditions
+  carry it in a new `presence` field.
+- Presence sentinels are **unioned** with the comparison rather than replacing it, so
+  `>= 0.5` plus an N/A chip reads "at least 0.5, or no value at all". No comparison operator ever
+  matches a null on its own.
+- `ANY_VALUE` is **exclusive**: selecting it replaces the rest of the selection and locks the
+  remaining options out, because "any value OR X" is just "any value".
+- New inclusive numeric operators `gte` and `lte` alongside the existing exclusive `gt`/`lt`.
+- Readiness rule stated once for both kinds: a numeric condition constrains the result when it has
+  the bounds its operator requires **OR** it carries a presence chip. An unready condition stays a
+  match-all no-op.
+- The EAT reliability filter is restated as `EAT_confidence >= x` **plus an N/A presence chip**,
+  replacing `NOT(EAT_confidence < x)`. It now states "confidence at least x, or no confidence score
+  at all" directly instead of depending on `NOT`'s old null-sweeping side effect.
+
+## Capabilities
+
+### New Capabilities
+
+- `filter-query-semantics`: what a filter condition matches — the presence sentinels, how `AND`/`OR`/`NOT`
+  combine conditions, when a condition constrains anything at all, and the live match counts the
+  builder previews before Apply.
+
+### Modified Capabilities
+
+<!-- The EAT overlay requirements live in the unarchived `add-eat-visualization` change rather
+     than in openspec/specs/, so there is no committed requirement to modify. Its five stale
+     `NOT(EAT_confidence < x)` requirements were corrected in place by #416; this change owns the
+     filter-side rule they now depend on. -->
+
+## Impact
+
+- **Query semantics:** `packages/core/src/components/control-bar/query-evaluate.ts` (NOT scoping,
+  `proteinsWithAnyValue`, `collectAnnotations`), `query-numeric-helpers.ts` (operator table,
+  readiness, `matchesNumericValue`, `countNumericMatches`), `query-types.ts` (`ANY_VALUE`,
+  `NumericCondition.presence`, `gte`/`lte`).
+- **Query builder UI:** `query-condition-row.ts`, `query-value-picker.ts`, `query-numeric-input.ts`,
+  and the shared `query-presence.ts` chip/label renderer.
+- **EAT mirror:** `control-bar.ts` — `setEatConfidenceThreshold` and the reliability-condition
+  recognizer that keys the legend slider off the query.
+- **Saved queries:** `FilterQuery` is persisted in bundle settings. Old queries still load — the new
+  fields are optional — but a stored `NOT` evaluates differently, and a stored
+  `NOT(EAT_confidence < x)` no longer keeps curated points. There is no migration.
+- **Not included:** making the numeric row's live match count `logicalOp`-aware (a `NOT`'d numeric
+  row still previews the un-negated count — the categorical picker was taught about `NOT`, the
+  numeric side never receives it); reliability-condition ownership, which is fixed separately in
+  #427 by keying on a declared owner instead of the condition's shape.

--- a/openspec/changes/archive/2026-08-11-add-filter-presence-semantics/specs/filter-query-semantics/spec.md
+++ b/openspec/changes/archive/2026-08-11-add-filter-presence-semantics/specs/filter-query-semantics/spec.md
@@ -1,0 +1,265 @@
+## ADDED Requirements
+
+### Requirement: NOT is scoped to proteins that carry a value
+
+`NOT` SHALL mean "carries a value for the negated annotation **and** does not match", i.e.
+`difference(proteinsWithAnyValue(annotations), matches)` — NOT a complement of the matched set over
+all protein indices. The scope SHALL be the proteins holding at least one real (non-N/A) label for
+at least one annotation the negated item references; for a group, "at least one" rather than "all"
+keeps the negation as permissive as possible. A protein that is N/A on the negated annotation SHALL
+NOT be returned by a `NOT`.
+
+#### Scenario: Negating a categorical value
+
+- **WHEN** a condition is `NOT (family is Kinase)` and the dataset holds kinases, non-kinases, and
+  proteins with no family annotation
+- **THEN** the non-kinases are returned
+- **AND** the proteins with no family annotation are not returned
+
+#### Scenario: Negating N/A means "has any value"
+
+- **WHEN** a condition is `NOT (family is N/A)`
+- **THEN** exactly the proteins carrying at least one real family label are returned
+- **AND** the result equals the condition `family is Any value`
+
+#### Scenario: The old N/A guard is now redundant
+
+- **WHEN** a query pairs `NOT (family is Kinase)` with the hand-written guard
+  `AND NOT (family is N/A)`
+- **THEN** the result is the same as the first condition alone
+
+#### Scenario: Negating a group
+
+- **WHEN** a group over two annotations is negated
+- **THEN** the scope is the proteins carrying a value for either annotation
+- **AND** only a protein that is N/A across both is dropped by the scoping
+
+#### Scenario: Negating a numeric annotation
+
+- **WHEN** a condition is `NOT (confidence > 0.8)` and some proteins have no confidence value
+- **THEN** the proteins whose confidence is at most `0.8` are returned
+- **AND** the proteins with no confidence value are not returned
+
+#### Scenario: Negating an unconfigured condition
+
+- **WHEN** a `NOT` is applied to a condition that has no selected values and no bounds
+- **THEN** the condition matches every protein, so the negation matches none
+- **AND** Apply remains disabled because no condition is configured
+
+### Requirement: Presence sentinels select proteins by whether a value exists
+
+The system SHALL provide two presence sentinels that are exact complements of each other over a
+given annotation: `NA_VALUE` (`'__NA__'`) selects the proteins missing a value, and `ANY_VALUE`
+(`'__ANY__'`) selects precisely the rest. Categorical conditions SHALL carry them among their
+`values`; numeric conditions SHALL carry them in a separate `presence` field. Both kinds SHALL
+evaluate them identically. `ANY_VALUE` SHALL be offered first in the value picker, ahead of the
+declared values, and SHALL be rendered as "Any value" through the same label path as N/A.
+
+#### Scenario: Any value on a categorical annotation
+
+- **WHEN** a condition is `family is Any value`
+- **THEN** every protein carrying at least one real family label is returned
+- **AND** proteins with no family label are not returned
+
+#### Scenario: Multi-label protein carrying both real labels and nulls
+
+- **WHEN** a protein resolves to a mix of real labels and N/A for the annotation
+- **THEN** it matches `Any value`
+- **AND** it also matches `is N/A`, because it carries that label too
+
+#### Scenario: Any value leads the picker
+
+- **WHEN** the value picker opens for an annotation and `Any value` is not already selected
+- **THEN** `Any value` is the first entry, ahead of the annotation's declared values
+
+#### Scenario: A sentinel reads the same wherever it is shown
+
+- **WHEN** a sentinel is rendered in the value picker, on a categorical value chip, or on a numeric
+  presence chip
+- **THEN** all three show the same label for it, resolved through one shared display function
+- **AND** searching the picker for that label matches the sentinel entry
+
+### Requirement: A presence chip is unioned with the numeric comparison
+
+A numeric condition's presence chips SHALL be unioned with its comparison, not replace it: `>= 0.5`
+carrying an N/A chip SHALL read "at least 0.5, or no value at all". A null (missing) value SHALL be
+matched ONLY by an explicit `NA_VALUE` chip — no comparison operator SHALL ever match a null, since
+a missing value sits outside the numeric domain. An `ANY_VALUE` chip SHALL match every non-null
+value regardless of the comparison.
+
+#### Scenario: Threshold plus N/A
+
+- **WHEN** a condition is `confidence >= 0.5` carrying an N/A chip
+- **THEN** proteins whose confidence is at least `0.5` are returned
+- **AND** proteins with no confidence value are also returned
+- **AND** proteins whose confidence is below `0.5` are not returned
+
+#### Scenario: A comparison alone never keeps a null
+
+- **WHEN** a condition is `confidence < 0.5` with no presence chip
+- **THEN** proteins with no confidence value are not returned
+
+#### Scenario: Any value on a numeric annotation
+
+- **WHEN** a condition carries an `Any value` chip
+- **THEN** every protein with a non-null value for that annotation is returned
+- **AND** proteins with no value are not returned
+
+### Requirement: Any value is exclusive
+
+Selecting `ANY_VALUE` SHALL replace the rest of the selection rather than join it, because "any
+value OR X" is just "any value" and "any value OR N/A" is everything. While it is selected the
+remaining choices SHALL be locked out rather than silently ignored. On the categorical side the
+picker SHALL mark every entry `aria-disabled` and refuse selection by pointer or keyboard. On the
+numeric side adding the chip SHALL clear both bounds and disable the operator and value fields, and
+the N/A chip SHALL no longer be offered.
+
+#### Scenario: Selecting Any value over an existing selection
+
+- **WHEN** a categorical condition already selects `Kinase` and the user picks `Any value`
+- **THEN** the condition's values become exactly `[Any value]`
+
+#### Scenario: The picker locks out while Any value is selected
+
+- **WHEN** `Any value` is selected and the user clicks or presses Enter on another entry
+- **THEN** the selection does not change
+- **AND** every entry reports `aria-disabled="true"`
+
+#### Scenario: Adding the Any value chip to a numeric condition
+
+- **WHEN** a numeric condition is `>= 0.5` and the user adds the `Any value` chip
+- **THEN** its presence becomes exactly `[Any value]` and both bounds are cleared
+- **AND** the operator dropdown and the value fields are disabled
+- **AND** the `+ N/A` chip button is no longer offered
+
+### Requirement: A condition constrains the result only when it is configured
+
+A condition SHALL constrain the result when it is _configured_, and SHALL otherwise be a match-all
+no-op, symmetric across the two kinds. A categorical condition SHALL be configured when it has at
+least one selected value. A numeric condition SHALL be configured when it has every bound its
+operator requires **OR** it carries a presence chip — a presence chip is meaningful on its own. The
+operator → required-bounds table SHALL be stated once (`gt`/`gte` need `min`, `lt`/`lte` need `max`,
+`between` needs both) and readiness SHALL be derived from it. Apply SHALL be gated on at least one
+configured condition existing anywhere in the query — alongside the result being neither empty nor
+the whole dataset — so a query of nothing but no-ops cannot be applied as if it were a real filter.
+
+#### Scenario: A presence chip alone is enough
+
+- **WHEN** a numeric condition has no bounds but carries an N/A chip
+- **THEN** it is configured, it returns the proteins with no value, and Apply is enabled
+
+#### Scenario: A bound-less comparison is a no-op
+
+- **WHEN** a numeric condition is `>` with an empty min field and no presence chip
+- **THEN** it matches every protein
+- **AND** Apply is disabled unless some other condition is configured
+
+#### Scenario: An empty categorical condition is a no-op
+
+- **WHEN** a categorical condition has no selected values
+- **THEN** it matches every protein
+
+#### Scenario: An emptied group is a no-op
+
+- **WHEN** a group's last condition is removed
+- **THEN** the empty group matches every protein rather than intersecting the query down to nothing
+
+#### Scenario: A configured condition on a missing column
+
+- **WHEN** a configured condition names an annotation the dataset does not carry
+- **THEN** it matches no protein
+
+### Requirement: Numeric comparisons offer inclusive and exclusive operators
+
+The numeric operator set SHALL be `gt`, `gte`, `lt`, `lte`, and `between`. `>` and `<` SHALL be
+exclusive at the boundary; `>=`, `<=` and `between` SHALL be inclusive at both ends. Switching
+operator SHALL null out the bound the new operator does not use, so a hidden value cannot linger and
+silently re-constrain the filter on switching back.
+
+#### Scenario: Inclusive versus exclusive at the boundary
+
+- **WHEN** a protein's value is exactly `0.5`
+- **THEN** it matches `>= 0.5` and `<= 0.5` and `between 0.5 and 0.9`
+- **AND** it does not match `> 0.5` or `< 0.5`
+
+#### Scenario: Switching operator drops the unused bound
+
+- **WHEN** a condition is `between 0.2 and 0.8` and the operator changes to `>=`
+- **THEN** `min` is kept and `max` is set to null
+- **AND** switching back to `between` leaves the condition unconfigured until a new max is entered
+
+### Requirement: The EAT reliability filter retains proteins with no confidence score
+
+The legend's reliability slider SHALL drive a single query condition of the form
+`<eat-confidence column> >= x` carrying an `NA_VALUE` presence chip — stating "confidence at least
+x, or no confidence score at all" directly, so curated proteins (which carry no confidence value)
+stay visible. It SHALL NOT be expressed as `NOT (confidence < x)`, which retained nulls only as a
+side effect of the old complement semantics and would now hide every curated protein. A threshold of
+`0` or below SHALL remove the condition. The eat-confidence column SHALL be resolved by runtime
+identity (role plus base annotation) rather than by name suffix, and only the selected base's
+condition SHALL be replaced, leaving other bases' filters and unrelated user conditions untouched.
+
+#### Scenario: Raising the slider above zero
+
+- **WHEN** the reliability slider for a transferred base moves to `0.75`
+- **THEN** the query gains exactly one condition `<base's eat-confidence column> >= 0.75` with an
+  N/A presence chip
+- **AND** predictions below `0.75` are filtered out while curated proteins remain visible
+
+#### Scenario: Returning the slider to zero
+
+- **WHEN** the slider returns to `0`
+- **THEN** that base's reliability condition is removed from the query
+- **AND** if no configured condition remains, the filter is cleared and every protein returns
+
+#### Scenario: Two transferred bases
+
+- **WHEN** one base's slider is tuned while another base already has a reliability condition
+- **THEN** only the tuned base's condition is replaced
+- **AND** the other base's condition and any unrelated user conditions are preserved
+
+#### Scenario: Reading the threshold back out of the query
+
+- **WHEN** the slider needs to reflect the query
+- **THEN** a condition counts as this base's reliability filter only when it is numeric, names that
+  exact column, uses `gte`, is not negated, and carries the N/A presence chip
+- **AND** its `min` is the threshold shown, defaulting to `0` when no such condition exists
+
+### Requirement: Live match previews agree with the applied filter
+
+The counts the builder shows before Apply SHALL be computed the same way the filter itself matches,
+so a preview never disagrees with the result it predicts. The value picker's per-value counts SHALL
+be relative to the query with the current condition excluded, and SHALL account for the row's
+logical operator: `AND` counts the carriers within the already-matched set; `OR` counts the union of
+the matched set with the whole-dataset carriers; `NOT` counts the has-a-value slice of the matched
+set minus the proteins in that slice carrying the value, which equals evaluating the same single
+`NOT` condition. A multi-label protein SHALL be counted once per value, however many of its labels
+miss. The numeric row's count SHALL walk the protein count rather than the value array's length,
+normalizing a missing slot to null, and SHALL be `0` for an unconfigured condition or a missing
+column.
+
+#### Scenario: NOT preview matches the applied result
+
+- **WHEN** a categorical row's operator is `NOT` and the picker lists per-value counts
+- **THEN** each count equals the number of proteins that applying that single `NOT` condition would
+  return
+- **AND** proteins that are N/A on the annotation are not counted
+
+#### Scenario: Multi-label protein counted once
+
+- **WHEN** a protein carries three labels and the `NOT` preview is computed for a value it does not
+  carry
+- **THEN** the protein is removed from the count at most once
+
+#### Scenario: Numeric count over a sparse column
+
+- **WHEN** a numeric column holds fewer entries than the dataset has proteins and the condition
+  carries an N/A chip
+- **THEN** the missing rows count as null and are matched by the chip
+- **AND** the preview equals the number of proteins the applied filter returns
+
+#### Scenario: Typing in the value search does not rescan the dataset
+
+- **WHEN** the user types into the value picker's search box
+- **THEN** the per-value counts are reused rather than recomputed, and are invalidated only when the
+  data, annotation, matched set, or logical operator changes

--- a/openspec/changes/archive/2026-08-11-add-filter-presence-semantics/tasks.md
+++ b/openspec/changes/archive/2026-08-11-add-filter-presence-semantics/tasks.md
@@ -1,0 +1,97 @@
+> Retroactive change: the work shipped in #416 (`feat/improved_filtering`, merged as `81ad450b`)
+> before this OpenSpec entry existed. Every task below is recorded against the commit that did it.
+
+## 1. Presence model (#416, `e27c7be8`)
+
+- [x] 1.1 Add the `ANY_VALUE = '__ANY__'` sentinel to `query-types.ts` as the exact complement of
+      `NA_VALUE`, with the rationale for keeping it out of `missing-values.ts`.
+- [x] 1.2 Add the optional `presence?: string[]` field to `NumericCondition` and seed it in
+      `createNumericCondition`.
+- [x] 1.3 Add the inclusive `gte` / `lte` operators to `NumericOperator` and to the
+      `numericFieldsFor` bounds table.
+- [x] 1.4 Teach `matchesNumericValue` the union rule: a null matches only an explicit `NA_VALUE`
+      chip; `ANY_VALUE` matches every non-null; the comparison is otherwise unchanged.
+- [x] 1.5 State readiness once — `isNumericConditionReady = hasNumericBounds || presence.length > 0`
+      — derived from `numericFieldsFor` rather than a second operator switch.
+- [x] 1.6 Honour `ANY_VALUE` in `evaluateCondition` for categorical conditions, including
+      multi-label proteins whose labels mix real values and nulls.
+
+## 2. N/A-aware NOT (#416, `e27c7be8`)
+
+- [x] 2.1 Add `collectAnnotations` (every annotation a condition or group references) and
+      `proteinsWithAnyValue` (carriers of at least one real label across those annotations).
+- [x] 2.2 Redefine `NOT` in `evaluateItems` as `difference(proteinsWithAnyValue, matches)` instead
+      of a complement over all indices.
+- [x] 2.3 Keep an unconfigured condition a match-all no-op so `NOT (unconfigured)` matches nothing
+      rather than isolating every protein, and keep Apply gated by `hasConfiguredCondition`.
+- [x] 2.4 Handle numeric annotations in `proteinsWithAnyValue` via `numeric_annotation_data`
+      (non-null), not the categorical index path.
+
+## 3. Query builder UI (#416, `e27c7be8`)
+
+- [x] 3.1 Offer `ANY_VALUE` first in the value picker, ahead of the annotation's declared values.
+- [x] 3.2 Make `ANY_VALUE` exclusive on the categorical side: selecting it replaces the selection,
+      and the picker locks the rest out (`is-disabled`, `aria-disabled`, inert click).
+- [x] 3.3 Add presence chips (`+ N/A`, `+ Any value`) to the numeric row, styled as the categorical
+      value chips they mirror.
+- [x] 3.4 Make `ANY_VALUE` exclusive on the numeric side: it clears both bounds, disables the
+      operator and value fields, and withdraws the `+ N/A` offer.
+- [x] 3.5 Make the value picker's live counts `NOT`-aware —
+      `|matched ∩ has-value| − |that slice carrying v|` — and cross-check them against
+      `evaluateQuery` for the same single condition.
+
+## 4. EAT reliability filter (#416, `e27c7be8`)
+
+- [x] 4.1 Rewrite `setEatConfidenceThreshold` to upsert `<eat-confidence column> >= x` with an
+      `NA_VALUE` presence chip, replacing `NOT(EAT_confidence < x)`.
+- [x] 4.2 Update the reverse mirror's recognizer to match the new shape (numeric, that exact column,
+      `gte`, un-negated, carries the N/A chip) and scope both directions to one base's column.
+- [x] 4.3 Correct the five stale `NOT(EAT_confidence < x)` requirements in
+      `openspec/changes/add-eat-visualization/specs/eat-annotation-overlay/spec.md`.
+
+## 5. Deduplication pass (#416, `1aedc853` + `082b8b75`)
+
+- [x] 5.1 Extract `query-presence.ts` with `displayFilterValue` and `renderValueChip`, and delete the
+      three copies of the sentinel-display rule and the two copies of the chip markup.
+- [x] 5.2 Keep `ANY_DISPLAY` module-private — nothing imports it, and exporting it fails `knip`.
+- [x] 5.3 Restore the side-effect `import './query-value-picker'` in `query-condition-row.ts`, which
+      had been getting element registration for free via the dropped `ANY_DISPLAY` named import.
+- [x] 5.4 Extract `presenceOf(condition)` returning a frozen shared empty array, so a chip-less
+      condition cannot be given a chip through a stray mutation.
+
+## 6. Preview correctness and cost (#416, `a3b65b2a` + `082b8b75`)
+
+- [x] 6.1 Make `countNumericMatches` walk `protein_ids.length` and normalize a missing slot to null,
+      so a sparse column cannot make the preview undershoot the applied result.
+- [x] 6.2 Memoize the value picker's dataset walk, invalidating on `data`, `annotation`,
+      `matchedIndices` and `logicalOp`, so typing in the search box stops re-scanning ~570K rows per
+      character.
+- [x] 6.3 Fold `anyCount` and `mixedNaCount` into the single count-map walk and delete
+      `_proteinsWithValue`, so the `NOT` preview needs no second scan.
+- [x] 6.4 Precompute an `isRealValue` table per _declared_ value in `proteinsWithAnyValue` instead of
+      calling `toInternalValue` per label per protein.
+
+## 7. Tests and docs (#416)
+
+- [x] 7.1 `query-evaluate.test.ts` — NOT scoping, `NOT (is N/A)` ≡ `is Any value`, group scoping,
+      NOT over unconfigured, missing columns.
+- [x] 7.2 `query-value-picker.test.ts` — AND/OR/NOT count arithmetic, multi-label counted once, and
+      the cross-check against `evaluateQuery`.
+- [x] 7.3 `query-numeric-input.test.ts` / `query-numeric-helpers.test.ts` — presence chips,
+      exclusivity, inclusive operators, sparse-column counting.
+- [x] 7.4 `control-bar.query-apply.test.ts` + Playwright `eat-visualization` — the reliability
+      slider's two-way mirror against the real phosphatase bundle.
+- [x] 7.5 Update `docs/explore/control-bar.md` for the new `NOT`, the presence chips and the
+      inclusive operators.
+
+## 8. Spec wrap-up (this change)
+
+- [x] 8.1 Write `proposal.md`, `design.md` and the `filter-query-semantics` spec delta covering the
+      semantics #416 shipped.
+- [x] 8.2 Record the deliberately-unfixed findings as Non-Goals / Open Questions rather than as
+      requirements: the numeric row's `logicalOp`-blind live count, reliability-condition ownership
+      (#427), `presence` as a 3-state enum, the un-type-checked `<option>` list, and the Kleene
+      refactor that would delete `collectAnnotations` + `proteinsWithAnyValue`.
+- [x] 8.3 `openspec validate --strict` clean.
+- [x] 8.4 Archive so `openspec/specs/filter-query-semantics/` becomes the source of truth, on the
+      branch and before the merge.

--- a/openspec/changes/archive/2026-08-11-add-query-builder-controls/.openspec.yaml
+++ b/openspec/changes/archive/2026-08-11-add-query-builder-controls/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-11

--- a/openspec/changes/archive/2026-08-11-add-query-builder-controls/design.md
+++ b/openspec/changes/archive/2026-08-11-add-query-builder-controls/design.md
@@ -1,0 +1,107 @@
+## Context
+
+`<protspace-annotation-select>` is the app's canonical searchable dropdown: a trigger, a search box,
+a grouped and filtered option list, arrow-key navigation, listbox ARIA. The query builder needed two
+more of these — one to pick the annotation a condition filters on, one to pick its values — and both
+were written by copying the reference's markup and stylesheet without its behaviour. They looked
+right and answered only Escape.
+
+The stylesheet had a subtler version of the same problem. `query-builder.styles.ts` was a bare `css`
+block. It is adopted by four components, and only one of them — the control bar — lives in a shadow
+root whose stylesheet already pulls in the design system's mixins. CSS custom properties inherit
+across a shadow boundary, so the colours and spacing looked right everywhere; component classes do
+not, so `.btn-primary` and friends simply did not exist in the row and picker shadow roots, and each
+one had grown a hand-written mirror of whatever it needed.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Make the query builder's controls indistinguishable from the same controls elsewhere in the app,
+  by reaching the design system rather than restating it.
+- Give both pickers the keyboard and screen-reader behaviour the reference already had.
+- State the listbox contract once, so the three implementations cannot drift apart again.
+- Record the stylesheet-ordering constraint that composing the mixins turned out to depend on.
+
+**Non-Goals:**
+
+- Replacing the native `<select>`s with custom widgets. See Decisions.
+- Extracting a shared picker _component_. The two pickers differ in ownership (one closes itself,
+  one asks its parent to), in what a row means, and in whether entries can be locked out; only the
+  keyboard contract is genuinely common, and that is what got extracted.
+- Focus restoration on close, APG `role="group"` category wrappers, and repositioning the popovers
+  on scroll. All three are real gaps; all three need changes outside these components.
+
+## Decisions
+
+**The native `<select>`s stay native.** Both carry a handful of options and no search. The platform
+gives keyboard support, the mobile picker and screen-reader semantics for free; a custom
+button-and-menu would be code written to lose all of that in exchange for pixel-identical borders.
+They were restyled instead — and the actual user-visible bug, an orange focus ring, was that
+`inputMixin`'s `select:focus` rule had never reached them.
+
+**Reach the mixins through their own hooks, not through mirrors.** `inputMixin` matches
+`select, input[type='text'], input[type='search'], .input-base`. The picker search inputs carried no
+`type` at all, so nothing matched them and the sheet mirrored ~28 declarations instead. Adding
+`type="text"` — what the reference component does — deletes the mirror. `type="search"` would also
+match, but WebKit's search input adds a clear affordance and an Escape-clears-the-field behaviour
+that would fight the dropdown's own Escape handling. The number inputs use `.input-base`, the hook
+the mixin exposes for exactly this; widening the mixin to `input[type='number']` would restyle
+number inputs in the legend, its settings dialog and the publish modal, which is a separate change.
+
+**Extract the keyboard contract, not the component.** `handleListboxKeydown` in `dropdown-helpers`
+takes a thunk for the option list, the current index and a setter, callbacks for select and escape,
+and the selector/attribute pair used to find the hovered row. It sits beside `handleDropdownEscape`
+and `scrollHighlightedIntoView`, which it uses and which the components were already importing. The
+thunk matters: a keystroke that is neither an arrow nor Enter should not pay to re-group the
+annotation list or re-walk the value counts, and every previous copy did.
+
+**Hover does not drive the highlight.** The reference had already learned this and says so in a
+comment — mirroring hover into the highlight index re-rendered every row the pointer crossed, and
+the value picker's list is unvirtualized and as long as the annotation has distinct values. The
+consequence is that the pointer and the keyboard can point at different rows, so `Enter` resolves
+`:hover` first and falls back to the index. Both render identically, so the user cannot tell.
+
+**Clamp the index rather than synchronising it.** The list shrinks under the stored index in three
+different ways, and the value picker's multi-add behaviour makes one of them routine: selecting a
+value removes it from the list while the picker stays open. Rather than resetting the index from
+each of those places, `handleListboxKeydown` and the render both clamp against the current list.
+That is one rule instead of three, and it cannot be forgotten at a fourth call site.
+
+**Sheet order in `controlBarStyles` is load-bearing.** Lit's `finalizeStyles` deduplicates a
+flattened style array in reverse and so keeps each sheet's _last_ position. Turning
+`queryBuilderStyles` into `[tokens, buttonMixin, inputMixin, dropdownMixin, css…]` therefore moved
+those four foundation sheets to wherever `queryBuilderStyles` appears — which was after `iconMixin`
+and `layoutStyles`, the two sheets written to override them. `layoutStyles` and `dropdownMixin` both
+declare `.filter-container, .export-container` at equal specificity, so the control bar's containers
+silently changed from `display: inline-flex` to `display: flex; align-items: center`. Fixed by
+listing `queryBuilderStyles` before them, with the constraint written down where it is depended on.
+
+## Risks / Trade-offs
+
+**A shared keyboard handler can become an options soup.** → Mitigated by keeping it to the contract
+that is genuinely identical and leaving the differences at the call sites: the closed-trigger
+Enter/Space branch, what Escape does, and whether rows can be locked out all stay in the components.
+`Home`/`End` are deliberately absent, matching what all three did before.
+
+**Reusing `.dropdown-item` and `.input-base` couples these components to the mixins.** → That is the
+point, and it is the direction the rest of the control bar already goes. Both option lists keep
+their existing class alongside the shared one, so unit and Playwright selectors are unaffected.
+
+**The popovers still mirror `.dropdown-menu`'s surface.** → They are `position: fixed` at measured
+coordinates so they can escape the condition list's scrolling clip context, which `.dropdown-menu`'s
+absolute positioning cannot do. `info-popover` solves the identical problem the identical way, so
+this is the house mechanism rather than a workaround. After adopting `.dropdown-item` the remaining
+mirror is a handful of token references, which is low-drift; an `.is-anchored-fixed` modifier on the
+mixin would inherit eight declarations and need four overridden, including a `min-width: 100%` that
+resolves against the viewport under `position: fixed`.
+
+## Open Questions
+
+- Should closing a picker return focus to its trigger? It is a WCAG 2.4.3 gap, but fixing it only
+  here would leave the reference component inconsistent, and the value picker's trigger belongs to
+  its parent.
+- Should the grouped option lists adopt APG's `role="group"` wrappers instead of
+  `role="presentation"` headers? The current spelling keeps non-option content inside the listbox.
+- Should the popovers reposition on scroll, as `info-popover` does? They measure once at open, so
+  scrolling the condition list leaves them behind.

--- a/openspec/changes/archive/2026-08-11-add-query-builder-controls/proposal.md
+++ b/openspec/changes/archive/2026-08-11-add-query-builder-controls/proposal.md
@@ -1,0 +1,63 @@
+## Why
+
+The query builder's two dropdowns are hand-rolled clones of `<protspace-annotation-select>` that
+inherited its look and none of its behaviour: no arrow-key navigation, no listbox roles, Escape the
+only key they answered. They also could not reach the design system — `query-builder.styles.ts` was
+a bare `css` block, so it worked in the control bar's shadow root (where the parent pulls the mixins
+in) but the row and picker components have their own, and inherited the custom properties without
+the component classes. The reported symptom: the operator `<select>` had no `:focus` rule and fell
+back to Chrome's UA ring, which on macOS follows the system accent — an orange border in a blue UI.
+
+Composing the mixins is the fix, but it also makes the sheet an array, and Lit dedupes such arrays
+keeping each sheet's _last_ position — silently reordering the control bar's cascade.
+
+Retroactive like `add-filter-presence-semantics`: this shipped as #417, and `openspec/specs/`
+describes none of it.
+
+## What Changes
+
+- The query builder's stylesheet composes the design system (`tokens` + the button, input and
+  dropdown mixins) instead of restating it, so its controls carry the app's focus indicator rather
+  than the browser's.
+- Both pickers gain the full listbox keyboard contract: arrows walk the filtered list clamped
+  without wrapping, Enter commits, Escape closes the dropdown without closing the modal around it.
+- Both pickers are announced as listboxes — `role="listbox"` on the option container (not the
+  popover, which also holds the search input), `role="option"` on entries, `aria-activedescendant`
+  tracking the cursor, `aria-expanded`/`aria-haspopup` on triggers.
+- The keyboard contract is **stated once**, in `dropdown-helpers`, and the three components that
+  implement a searchable listbox all delegate to it.
+- Pointer hover does **not** move the keyboard cursor; `:hover` styling comes from CSS and Enter
+  resolves against the hovered row first.
+- The stored highlight is clamped against the list on every use, because the list can shrink under
+  it (a search, a multi-add selection, a dataset change).
+- **The order of `controlBarStyles` is load-bearing** and must stay so: sheets that override the
+  foundation mixins have to keep their position after them.
+- The operator and logical-operator controls stay native `<select>` elements.
+
+## Capabilities
+
+### New Capabilities
+
+- `query-builder-controls`: how the query builder's controls are styled, focused, navigated by
+  keyboard and announced to assistive technology.
+
+### Modified Capabilities
+
+<!-- `filter-query-semantics` already states the ANY_VALUE exclusivity lock, including that the
+     picker refuses selection "by pointer or keyboard". This change implements the keyboard half
+     but does not alter that requirement, so there is no delta. -->
+
+## Impact
+
+- **Styles:** `packages/core/src/components/control-bar/query-builder.styles.ts` (composes the
+  mixins, drops the mirrors), `control-bar.styles.ts` (sheet order).
+- **Behaviour:** `query-condition-row.ts`, `query-value-picker.ts`, `annotation-select.ts` — all
+  three now delegate to `handleListboxKeydown` in `packages/core/src/utils/dropdown-helpers.ts`.
+- **Markup:** `type="text"` on the two picker search inputs and `.input-base` on the numeric fields,
+  which is what lets `inputMixin` reach them; `.dropdown-item` on both option lists. Existing class
+  names are kept alongside, so every unit and Playwright selector still resolves.
+- **Not included:** returning focus to the trigger when a picker closes (needs the same treatment in
+  `annotation-select` and a parent-side change for the value picker); replacing the
+  `role="presentation"` category headers with APG's `role="group"` wrappers; a `.dropdown-menu`
+  modifier so the fixed-position popovers can stop mirroring its surface; and repositioning the
+  popovers on scroll, which `info-popover` does and these do not.

--- a/openspec/changes/archive/2026-08-11-add-query-builder-controls/specs/query-builder-controls/spec.md
+++ b/openspec/changes/archive/2026-08-11-add-query-builder-controls/specs/query-builder-controls/spec.md
@@ -1,0 +1,185 @@
+## ADDED Requirements
+
+### Requirement: Query builder controls carry the design system's focus indicator
+
+Every interactive control in the query builder SHALL show the design system's focus indicator rather
+than the browser's default. The query builder's stylesheet SHALL compose the design system — the
+token sheet plus the button, input and dropdown mixins — instead of restating their declarations,
+because the row and picker components have their own shadow roots and inherit custom properties but
+not component classes from the control bar around them. Where a mixin's element selectors cannot
+reach a control, the markup SHALL adopt the mixin's provided class hook rather than the sheet
+growing a local mirror of the mixin's rules.
+
+#### Scenario: Focusing the comparison operator
+
+- **WHEN** a user tabs to the numeric comparison operator control
+- **THEN** it shows the design system's focus ring
+- **AND** not the browser's default focus ring, which follows the operating system accent colour and
+  can render as an unrelated colour
+
+#### Scenario: A control the mixin's element selectors miss
+
+- **WHEN** a control is outside a mixin's element selectors, such as a number input
+- **THEN** it carries the mixin's class hook and picks the rules up that way
+- **AND** the stylesheet keeps only the declarations that are genuinely local to that control
+
+#### Scenario: Picker rendered outside the control bar's shadow root
+
+- **WHEN** a picker component renders in its own shadow root
+- **THEN** its controls are styled identically to the same controls elsewhere in the app
+
+### Requirement: The picker option lists are navigable by keyboard
+
+Both query builder pickers SHALL support the same keyboard contract as the app's other searchable
+dropdowns: `ArrowDown` and `ArrowUp` walk the filtered list and SHALL clamp at each end rather than
+wrapping, `Enter` commits the current row, and `Escape` closes the dropdown. `Escape` SHALL NOT also
+close the surrounding modal. Opening a closed picker from its trigger SHALL be possible with `Enter`
+or `Space`. This contract SHALL be stated once and shared by every component that implements a
+searchable listbox, so the keyboard does not behave differently from one dropdown to the next.
+
+#### Scenario: Walking the list
+
+- **WHEN** the picker is open and the user presses ArrowDown repeatedly
+- **THEN** the highlight advances one row at a time through the filtered list
+- **AND** stops on the last row rather than wrapping to the first
+
+#### Scenario: Escape inside a modal
+
+- **WHEN** the user presses Escape with a picker open inside the query builder modal
+- **THEN** the picker closes
+- **AND** the modal stays open
+
+#### Scenario: Opening from the trigger
+
+- **WHEN** the trigger has keyboard focus and the user presses Enter or Space
+- **THEN** the picker opens
+- **AND** does not immediately toggle back shut from the same keypress
+
+#### Scenario: A locked-out list
+
+- **WHEN** every entry is locked out because the exclusive "Any value" sentinel is selected
+- **THEN** the arrows do not move the highlight and Enter commits nothing, matching the pointer
+
+### Requirement: Pointer hover does not move the keyboard cursor
+
+Hovering a row SHALL NOT write the keyboard highlight. Hover feedback SHALL come from CSS, which
+renders it identically to the keyboard highlight, so the two can point at different rows without
+looking different. Because they can differ, `Enter` SHALL commit the hovered row when the pointer is
+over one, and the highlighted row otherwise — including when no arrow key has been pressed and there
+is no highlight at all.
+
+#### Scenario: Dragging the pointer down a long list
+
+- **WHEN** the pointer crosses many rows of an option list
+- **THEN** no component state changes and no re-render is scheduled per row
+- **AND** each row still shows hover feedback
+
+#### Scenario: Pointer and keyboard disagree
+
+- **WHEN** the keyboard cursor is on one row and the pointer rests on another, and Enter is pressed
+- **THEN** the hovered row is committed
+
+#### Scenario: Enter with a pointer but no keyboard cursor
+
+- **WHEN** the user has pressed no arrow key and presses Enter while hovering a row
+- **THEN** that row is committed
+
+### Requirement: The stored highlight is clamped against the list it indexes
+
+The highlight index SHALL be clamped against the current list every time it is used, for both
+navigation and rendering. The list can shrink underneath a stored index — a search narrows it, a
+selection removes the chosen value from a picker that stays open for multi-add, and a dataset change
+replaces it wholesale — and an index past the end SHALL NOT leave `aria-activedescendant` pointing
+at an element that is no longer rendered.
+
+#### Scenario: Selecting the last entry of a multi-add picker
+
+- **WHEN** the user highlights the last value, presses Enter, and the picker stays open with that
+  value now removed from the list
+- **THEN** `aria-activedescendant` does not reference a missing element
+- **AND** the next ArrowUp moves relative to the shortened list rather than skipping a row
+
+#### Scenario: The underlying data changes while a picker is open
+
+- **WHEN** the available annotations are replaced while the picker is open and the highlight sits
+  past the end of the new list
+- **THEN** no row claims to be highlighted and Enter is not silently inert against a stale index
+
+### Requirement: The pickers are announced as listboxes
+
+Each picker SHALL expose its option list as a listbox to assistive technology: `role="listbox"` on
+the element that contains the options, `role="option"` on each entry, and `aria-activedescendant` on
+the focused search input tracking the keyboard cursor. The listbox role SHALL sit on the option
+container rather than the popover, because the popover also contains the search input and a textbox
+is not a valid listbox child. The search input SHALL carry `role="combobox"` with `aria-expanded`
+and `aria-controls`, since `aria-activedescendant` on a bare textbox is poorly announced, and SHALL
+have an accessible name. A trigger that opens a picker SHALL carry `aria-expanded` and
+`aria-haspopup="listbox"`. When nothing is highlighted, `aria-activedescendant` SHALL be absent
+rather than empty.
+
+#### Scenario: Nothing highlighted yet
+
+- **WHEN** a picker has just opened and no arrow key has been pressed
+- **THEN** the search input carries no `aria-activedescendant` attribute at all
+
+#### Scenario: Cursor moves
+
+- **WHEN** the user arrows to a row
+- **THEN** `aria-activedescendant` names that row's id
+- **AND** an element with that id exists and is the row rendered as highlighted
+
+#### Scenario: Trigger state
+
+- **WHEN** a picker is open
+- **THEN** its trigger reports `aria-expanded="true"`, and `false` once closed
+
+### Requirement: Reopening a picker starts from a clean state
+
+Opening or closing a picker SHALL reset both its search query and its highlight. A search left over
+from the previous visit silently hides most of the values the reopened picker exists to offer, with
+nothing on screen explaining why the list is short. This reset SHALL happen before the update that
+renders it, not after one has completed, so it does not schedule a second render.
+
+#### Scenario: Reopening after a search
+
+- **WHEN** a user narrows the list by typing, closes the picker, and reopens it
+- **THEN** the full list is shown again and the search box is empty
+
+#### Scenario: No redundant render on open or close
+
+- **WHEN** a picker opens or closes
+- **THEN** the reset does not trigger a second update pass or a change-in-update warning
+
+### Requirement: Composing a shared stylesheet must not reorder another component's cascade
+
+A stylesheet that is itself an array of sheets SHALL be positioned so that any sheet written to
+override the shared foundation sheets keeps its place after them. The framework deduplicates a
+flattened style array by keeping each sheet's **last** position, so nesting the foundation sheets
+inside a composed stylesheet moves them to wherever that stylesheet is listed. Where sheets collide
+at equal specificity, the ordering constraint SHALL be documented at the point that depends on it.
+
+#### Scenario: A composed sheet is added to a component that already lists the foundations
+
+- **WHEN** a component's style array contains both the foundation sheets and a composed sheet that
+  re-lists them
+- **THEN** the sheets that override the foundations still take effect
+- **AND** rules such as the control bar's container layout keep the values they had before the
+  composed sheet was introduced
+
+### Requirement: The comparison and logical-operator controls remain native selects
+
+The operator and logical-operator controls SHALL remain native `<select>` elements. They present a
+handful of options with no search, and the platform supplies keyboard support, mobile pickers and
+screen-reader semantics for free; replacing them with custom button-and-menu widgets to make the
+pixels match would mean writing code to lose that. They SHALL instead be styled to match the design
+system, with one shared indicator rule rather than a per-control copy.
+
+#### Scenario: Operating the control on a touch device
+
+- **WHEN** a user opens the comparison operator control on a mobile browser
+- **THEN** the platform's native picker appears
+
+#### Scenario: Consistent affordance
+
+- **WHEN** the operator and logical-operator controls render
+- **THEN** their dropdown indicator comes from one shared rule rather than a copy per control

--- a/openspec/changes/archive/2026-08-11-add-query-builder-controls/tasks.md
+++ b/openspec/changes/archive/2026-08-11-add-query-builder-controls/tasks.md
@@ -1,0 +1,74 @@
+> Retroactive change: the presentation and a11y work shipped as #417 before this OpenSpec entry
+> existed, and the `/simplify` and `/code-review` passes that followed are recorded here too.
+
+## 1. Reach the design system (#417)
+
+- [x] 1.1 Compose `queryBuilderStyles` as `[tokens, buttonMixin, inputMixin, dropdownMixin, css…]`
+      so the mixins' component classes reach the row and picker shadow roots, not just their
+      inherited custom properties.
+- [x] 1.2 Fix the reported bug: the operator `<select>` had no `:focus` rule and fell back to the UA
+      ring (macOS accent → orange). `inputMixin`'s `select:focus` now supplies it.
+- [x] 1.3 Write the chevron data URI once for both selects, and let the logical-op select size to
+      its widest option instead of a hardcoded width that could clip.
+- [x] 1.4 Keep both `<select>`s native — record the reasoning rather than converting them.
+
+## 2. Picker keyboard and ARIA (#417)
+
+- [x] 2.1 Arrow-key navigation over the filtered list in both pickers, clamped without wrapping.
+- [x] 2.2 Enter commits; Escape closes via `handleDropdownEscape` so the surrounding modal survives.
+- [x] 2.3 Enter/Space on a closed trigger opens the picker, with `preventDefault` so the native
+      button activation does not toggle it straight back shut.
+- [x] 2.4 `role="listbox"` on the option container rather than the popover — the popover also holds
+      the search input, and a textbox is not a valid listbox child.
+- [x] 2.5 `role="option"` + `aria-selected` on entries, `role="presentation"` on category headers,
+      `aria-expanded` + `aria-haspopup="listbox"` on triggers, accessible names on search inputs.
+- [x] 2.6 `aria-activedescendant` tracks the cursor, and the keyboard honours the `ANY_VALUE`
+      exclusivity lock already specified in `filter-query-semantics`.
+- [x] 2.7 28 keyboard/ARIA tests across the two components.
+
+## 3. Stop mirroring what the design system already provides (`/simplify`)
+
+- [x] 3.1 Replace two hand-rolled scroll-into-view methods with `scrollHighlightedIntoView`, which
+      both files' existing import already reached. The copies had diverged: one had dropped the
+      jsdom guard the helper documents.
+- [x] 3.2 Adopt `.dropdown-item` on both option lists and delete the byte-identical local mirror,
+      keeping the existing class alongside so every selector still resolves.
+- [x] 3.3 Add `type="text"` to the picker search inputs and `.input-base` to the numeric fields so
+      `inputMixin` reaches them; delete ~28 mirrored declarations.
+- [x] 3.4 Delete the `:focus-visible` rule on options that carry no tabindex by design, and a `mark`
+      selector with no matching markup.
+- [x] 3.5 Drop `_navigableValues`, a non-reactive field written from inside `render()` whose stated
+      justification did not hold — the highlight is `@state`, so every arrow key re-renders anyway.
+- [x] 3.6 Stamp each filtered annotation's flat index in the helper instead of threading a mutable
+      counter through a nested `map` in the template.
+- [x] 3.7 Restore the save/delete dance around the `Element.prototype.scrollIntoView` stub, which
+      was assigned with no restore.
+
+## 4. Correctness pass (`/code-review`)
+
+- [x] 4.1 Fix the cascade regression: list `queryBuilderStyles` before `iconMixin`/`layoutStyles`,
+      because Lit keeps each sheet's LAST position when deduplicating a flattened array, and nesting
+      the four foundation sheets had moved them after the sheets that override them. Document the
+      constraint where it is depended on.
+- [x] 4.2 Extract `handleListboxKeydown` into `dropdown-helpers` and delegate all three searchable
+      listboxes to it (~130 duplicated lines → ~45), fixing the truthy hover check that made an
+      empty-string annotation name select the highlighted row instead of the hovered one.
+- [x] 4.3 Clamp the highlight index against the current list on every use, so a multi-add selection
+      cannot leave `aria-activedescendant` pointing at an unrendered id.
+- [x] 4.4 Move the value picker's open/close reset from `updated()` to `willUpdate()` — reactive
+      state assigned after an update completed schedules a second render and trips Lit's
+      change-in-update warning.
+- [x] 4.5 Clear the value picker's search query on open/close; reopening silently re-applied it.
+- [x] 4.6 Give the annotation picker's search input `role="combobox"`/`aria-expanded`/
+      `aria-haspopup`, matching the value picker.
+- [x] 4.7 Make `ListboxKeyboardOptions` module-private — knip fails on an exported type nothing
+      imports.
+
+## 5. Verification
+
+- [x] 5.1 `pnpm test:ci --force`: 1628 core / 371 utils / 165 app.
+- [x] 5.2 `pnpm type-check`, `pnpm knip`, `pnpm lint` (0 errors), `pnpm format:check` clean.
+- [x] 5.3 Playwright `e2e.yml` dispatched against the branch — the assertion that matters for a
+      restyle, since it proves the class changes did not break click targets. #417 is merged, so
+      pushes to the branch trigger no PR CI and the run has to be dispatched explicitly.
+- [x] 5.4 Archive this change before the merge, as the last commit on the branch.

--- a/openspec/specs/filter-query-semantics/spec.md
+++ b/openspec/specs/filter-query-semantics/spec.md
@@ -1,0 +1,271 @@
+# filter-query-semantics Specification
+
+## Purpose
+
+What a filter condition in the query builder matches: the presence sentinels that select proteins by whether they have a value at all, how `AND`/`OR`/`NOT` combine conditions once a missing value is a first-class case, when a condition constrains the result at all, and the live match counts the builder previews before Apply.
+
+## Requirements
+
+### Requirement: NOT is scoped to proteins that carry a value
+
+`NOT` SHALL mean "carries a value for the negated annotation **and** does not match", i.e.
+`difference(proteinsWithAnyValue(annotations), matches)` — NOT a complement of the matched set over
+all protein indices. The scope SHALL be the proteins holding at least one real (non-N/A) label for
+at least one annotation the negated item references; for a group, "at least one" rather than "all"
+keeps the negation as permissive as possible. A protein that is N/A on the negated annotation SHALL
+NOT be returned by a `NOT`.
+
+#### Scenario: Negating a categorical value
+
+- **WHEN** a condition is `NOT (family is Kinase)` and the dataset holds kinases, non-kinases, and
+  proteins with no family annotation
+- **THEN** the non-kinases are returned
+- **AND** the proteins with no family annotation are not returned
+
+#### Scenario: Negating N/A means "has any value"
+
+- **WHEN** a condition is `NOT (family is N/A)`
+- **THEN** exactly the proteins carrying at least one real family label are returned
+- **AND** the result equals the condition `family is Any value`
+
+#### Scenario: The old N/A guard is now redundant
+
+- **WHEN** a query pairs `NOT (family is Kinase)` with the hand-written guard
+  `AND NOT (family is N/A)`
+- **THEN** the result is the same as the first condition alone
+
+#### Scenario: Negating a group
+
+- **WHEN** a group over two annotations is negated
+- **THEN** the scope is the proteins carrying a value for either annotation
+- **AND** only a protein that is N/A across both is dropped by the scoping
+
+#### Scenario: Negating a numeric annotation
+
+- **WHEN** a condition is `NOT (confidence > 0.8)` and some proteins have no confidence value
+- **THEN** the proteins whose confidence is at most `0.8` are returned
+- **AND** the proteins with no confidence value are not returned
+
+#### Scenario: Negating an unconfigured condition
+
+- **WHEN** a `NOT` is applied to a condition that has no selected values and no bounds
+- **THEN** the condition matches every protein, so the negation matches none
+- **AND** Apply remains disabled because no condition is configured
+
+### Requirement: Presence sentinels select proteins by whether a value exists
+
+The system SHALL provide two presence sentinels that are exact complements of each other over a
+given annotation: `NA_VALUE` (`'__NA__'`) selects the proteins missing a value, and `ANY_VALUE`
+(`'__ANY__'`) selects precisely the rest. Categorical conditions SHALL carry them among their
+`values`; numeric conditions SHALL carry them in a separate `presence` field. Both kinds SHALL
+evaluate them identically. `ANY_VALUE` SHALL be offered first in the value picker, ahead of the
+declared values, and SHALL be rendered as "Any value" through the same label path as N/A.
+
+#### Scenario: Any value on a categorical annotation
+
+- **WHEN** a condition is `family is Any value`
+- **THEN** every protein carrying at least one real family label is returned
+- **AND** proteins with no family label are not returned
+
+#### Scenario: Multi-label protein carrying both real labels and nulls
+
+- **WHEN** a protein resolves to a mix of real labels and N/A for the annotation
+- **THEN** it matches `Any value`
+- **AND** it also matches `is N/A`, because it carries that label too
+
+#### Scenario: Any value leads the picker
+
+- **WHEN** the value picker opens for an annotation and `Any value` is not already selected
+- **THEN** `Any value` is the first entry, ahead of the annotation's declared values
+
+#### Scenario: A sentinel reads the same wherever it is shown
+
+- **WHEN** a sentinel is rendered in the value picker, on a categorical value chip, or on a numeric
+  presence chip
+- **THEN** all three show the same label for it, resolved through one shared display function
+- **AND** searching the picker for that label matches the sentinel entry
+
+### Requirement: A presence chip is unioned with the numeric comparison
+
+A numeric condition's presence chips SHALL be unioned with its comparison, not replace it: `>= 0.5`
+carrying an N/A chip SHALL read "at least 0.5, or no value at all". A null (missing) value SHALL be
+matched ONLY by an explicit `NA_VALUE` chip — no comparison operator SHALL ever match a null, since
+a missing value sits outside the numeric domain. An `ANY_VALUE` chip SHALL match every non-null
+value regardless of the comparison.
+
+#### Scenario: Threshold plus N/A
+
+- **WHEN** a condition is `confidence >= 0.5` carrying an N/A chip
+- **THEN** proteins whose confidence is at least `0.5` are returned
+- **AND** proteins with no confidence value are also returned
+- **AND** proteins whose confidence is below `0.5` are not returned
+
+#### Scenario: A comparison alone never keeps a null
+
+- **WHEN** a condition is `confidence < 0.5` with no presence chip
+- **THEN** proteins with no confidence value are not returned
+
+#### Scenario: Any value on a numeric annotation
+
+- **WHEN** a condition carries an `Any value` chip
+- **THEN** every protein with a non-null value for that annotation is returned
+- **AND** proteins with no value are not returned
+
+### Requirement: Any value is exclusive
+
+Selecting `ANY_VALUE` SHALL replace the rest of the selection rather than join it, because "any
+value OR X" is just "any value" and "any value OR N/A" is everything. While it is selected the
+remaining choices SHALL be locked out rather than silently ignored. On the categorical side the
+picker SHALL mark every entry `aria-disabled` and refuse selection by pointer or keyboard. On the
+numeric side adding the chip SHALL clear both bounds and disable the operator and value fields, and
+the N/A chip SHALL no longer be offered.
+
+#### Scenario: Selecting Any value over an existing selection
+
+- **WHEN** a categorical condition already selects `Kinase` and the user picks `Any value`
+- **THEN** the condition's values become exactly `[Any value]`
+
+#### Scenario: The picker locks out while Any value is selected
+
+- **WHEN** `Any value` is selected and the user clicks or presses Enter on another entry
+- **THEN** the selection does not change
+- **AND** every entry reports `aria-disabled="true"`
+
+#### Scenario: Adding the Any value chip to a numeric condition
+
+- **WHEN** a numeric condition is `>= 0.5` and the user adds the `Any value` chip
+- **THEN** its presence becomes exactly `[Any value]` and both bounds are cleared
+- **AND** the operator dropdown and the value fields are disabled
+- **AND** the `+ N/A` chip button is no longer offered
+
+### Requirement: A condition constrains the result only when it is configured
+
+A condition SHALL constrain the result when it is _configured_, and SHALL otherwise be a match-all
+no-op, symmetric across the two kinds. A categorical condition SHALL be configured when it has at
+least one selected value. A numeric condition SHALL be configured when it has every bound its
+operator requires **OR** it carries a presence chip — a presence chip is meaningful on its own. The
+operator → required-bounds table SHALL be stated once (`gt`/`gte` need `min`, `lt`/`lte` need `max`,
+`between` needs both) and readiness SHALL be derived from it. Apply SHALL be gated on at least one
+configured condition existing anywhere in the query — alongside the result being neither empty nor
+the whole dataset — so a query of nothing but no-ops cannot be applied as if it were a real filter.
+
+#### Scenario: A presence chip alone is enough
+
+- **WHEN** a numeric condition has no bounds but carries an N/A chip
+- **THEN** it is configured, it returns the proteins with no value, and Apply is enabled
+
+#### Scenario: A bound-less comparison is a no-op
+
+- **WHEN** a numeric condition is `>` with an empty min field and no presence chip
+- **THEN** it matches every protein
+- **AND** Apply is disabled unless some other condition is configured
+
+#### Scenario: An empty categorical condition is a no-op
+
+- **WHEN** a categorical condition has no selected values
+- **THEN** it matches every protein
+
+#### Scenario: An emptied group is a no-op
+
+- **WHEN** a group's last condition is removed
+- **THEN** the empty group matches every protein rather than intersecting the query down to nothing
+
+#### Scenario: A configured condition on a missing column
+
+- **WHEN** a configured condition names an annotation the dataset does not carry
+- **THEN** it matches no protein
+
+### Requirement: Numeric comparisons offer inclusive and exclusive operators
+
+The numeric operator set SHALL be `gt`, `gte`, `lt`, `lte`, and `between`. `>` and `<` SHALL be
+exclusive at the boundary; `>=`, `<=` and `between` SHALL be inclusive at both ends. Switching
+operator SHALL null out the bound the new operator does not use, so a hidden value cannot linger and
+silently re-constrain the filter on switching back.
+
+#### Scenario: Inclusive versus exclusive at the boundary
+
+- **WHEN** a protein's value is exactly `0.5`
+- **THEN** it matches `>= 0.5` and `<= 0.5` and `between 0.5 and 0.9`
+- **AND** it does not match `> 0.5` or `< 0.5`
+
+#### Scenario: Switching operator drops the unused bound
+
+- **WHEN** a condition is `between 0.2 and 0.8` and the operator changes to `>=`
+- **THEN** `min` is kept and `max` is set to null
+- **AND** switching back to `between` leaves the condition unconfigured until a new max is entered
+
+### Requirement: The EAT reliability filter retains proteins with no confidence score
+
+The legend's reliability slider SHALL drive a single query condition of the form
+`<eat-confidence column> >= x` carrying an `NA_VALUE` presence chip — stating "confidence at least
+x, or no confidence score at all" directly, so curated proteins (which carry no confidence value)
+stay visible. It SHALL NOT be expressed as `NOT (confidence < x)`, which retained nulls only as a
+side effect of the old complement semantics and would now hide every curated protein. A threshold of
+`0` or below SHALL remove the condition. The eat-confidence column SHALL be resolved by runtime
+identity (role plus base annotation) rather than by name suffix, and only the selected base's
+condition SHALL be replaced, leaving other bases' filters and unrelated user conditions untouched.
+
+#### Scenario: Raising the slider above zero
+
+- **WHEN** the reliability slider for a transferred base moves to `0.75`
+- **THEN** the query gains exactly one condition `<base's eat-confidence column> >= 0.75` with an
+  N/A presence chip
+- **AND** predictions below `0.75` are filtered out while curated proteins remain visible
+
+#### Scenario: Returning the slider to zero
+
+- **WHEN** the slider returns to `0`
+- **THEN** that base's reliability condition is removed from the query
+- **AND** if no configured condition remains, the filter is cleared and every protein returns
+
+#### Scenario: Two transferred bases
+
+- **WHEN** one base's slider is tuned while another base already has a reliability condition
+- **THEN** only the tuned base's condition is replaced
+- **AND** the other base's condition and any unrelated user conditions are preserved
+
+#### Scenario: Reading the threshold back out of the query
+
+- **WHEN** the slider needs to reflect the query
+- **THEN** a condition counts as this base's reliability filter only when it is numeric, names that
+  exact column, uses `gte`, is not negated, and carries the N/A presence chip
+- **AND** its `min` is the threshold shown, defaulting to `0` when no such condition exists
+
+### Requirement: Live match previews agree with the applied filter
+
+The counts the builder shows before Apply SHALL be computed the same way the filter itself matches,
+so a preview never disagrees with the result it predicts. The value picker's per-value counts SHALL
+be relative to the query with the current condition excluded, and SHALL account for the row's
+logical operator: `AND` counts the carriers within the already-matched set; `OR` counts the union of
+the matched set with the whole-dataset carriers; `NOT` counts the has-a-value slice of the matched
+set minus the proteins in that slice carrying the value, which equals evaluating the same single
+`NOT` condition. A multi-label protein SHALL be counted once per value, however many of its labels
+miss. The numeric row's count SHALL walk the protein count rather than the value array's length,
+normalizing a missing slot to null, and SHALL be `0` for an unconfigured condition or a missing
+column.
+
+#### Scenario: NOT preview matches the applied result
+
+- **WHEN** a categorical row's operator is `NOT` and the picker lists per-value counts
+- **THEN** each count equals the number of proteins that applying that single `NOT` condition would
+  return
+- **AND** proteins that are N/A on the annotation are not counted
+
+#### Scenario: Multi-label protein counted once
+
+- **WHEN** a protein carries three labels and the `NOT` preview is computed for a value it does not
+  carry
+- **THEN** the protein is removed from the count at most once
+
+#### Scenario: Numeric count over a sparse column
+
+- **WHEN** a numeric column holds fewer entries than the dataset has proteins and the condition
+  carries an N/A chip
+- **THEN** the missing rows count as null and are matched by the chip
+- **AND** the preview equals the number of proteins the applied filter returns
+
+#### Scenario: Typing in the value search does not rescan the dataset
+
+- **WHEN** the user types into the value picker's search box
+- **THEN** the per-value counts are reused rather than recomputed, and are invalidated only when the
+  data, annotation, matched set, or logical operator changes

--- a/openspec/specs/query-builder-controls/spec.md
+++ b/openspec/specs/query-builder-controls/spec.md
@@ -1,0 +1,191 @@
+# query-builder-controls Specification
+
+## Purpose
+
+How the query builder's controls behave as controls rather than as filters: how they reach the design system instead of restating it, how the two searchable pickers are driven from the keyboard and announced to assistive technology, and the stylesheet-ordering constraint that composing a shared sheet imposes on the components that adopt it. What those controls _mean_ — what a condition matches — is `filter-query-semantics`.
+
+## Requirements
+
+### Requirement: Query builder controls carry the design system's focus indicator
+
+Every interactive control in the query builder SHALL show the design system's focus indicator rather
+than the browser's default. The query builder's stylesheet SHALL compose the design system — the
+token sheet plus the button, input and dropdown mixins — instead of restating their declarations,
+because the row and picker components have their own shadow roots and inherit custom properties but
+not component classes from the control bar around them. Where a mixin's element selectors cannot
+reach a control, the markup SHALL adopt the mixin's provided class hook rather than the sheet
+growing a local mirror of the mixin's rules.
+
+#### Scenario: Focusing the comparison operator
+
+- **WHEN** a user tabs to the numeric comparison operator control
+- **THEN** it shows the design system's focus ring
+- **AND** not the browser's default focus ring, which follows the operating system accent colour and
+  can render as an unrelated colour
+
+#### Scenario: A control the mixin's element selectors miss
+
+- **WHEN** a control is outside a mixin's element selectors, such as a number input
+- **THEN** it carries the mixin's class hook and picks the rules up that way
+- **AND** the stylesheet keeps only the declarations that are genuinely local to that control
+
+#### Scenario: Picker rendered outside the control bar's shadow root
+
+- **WHEN** a picker component renders in its own shadow root
+- **THEN** its controls are styled identically to the same controls elsewhere in the app
+
+### Requirement: The picker option lists are navigable by keyboard
+
+Both query builder pickers SHALL support the same keyboard contract as the app's other searchable
+dropdowns: `ArrowDown` and `ArrowUp` walk the filtered list and SHALL clamp at each end rather than
+wrapping, `Enter` commits the current row, and `Escape` closes the dropdown. `Escape` SHALL NOT also
+close the surrounding modal. Opening a closed picker from its trigger SHALL be possible with `Enter`
+or `Space`. This contract SHALL be stated once and shared by every component that implements a
+searchable listbox, so the keyboard does not behave differently from one dropdown to the next.
+
+#### Scenario: Walking the list
+
+- **WHEN** the picker is open and the user presses ArrowDown repeatedly
+- **THEN** the highlight advances one row at a time through the filtered list
+- **AND** stops on the last row rather than wrapping to the first
+
+#### Scenario: Escape inside a modal
+
+- **WHEN** the user presses Escape with a picker open inside the query builder modal
+- **THEN** the picker closes
+- **AND** the modal stays open
+
+#### Scenario: Opening from the trigger
+
+- **WHEN** the trigger has keyboard focus and the user presses Enter or Space
+- **THEN** the picker opens
+- **AND** does not immediately toggle back shut from the same keypress
+
+#### Scenario: A locked-out list
+
+- **WHEN** every entry is locked out because the exclusive "Any value" sentinel is selected
+- **THEN** the arrows do not move the highlight and Enter commits nothing, matching the pointer
+
+### Requirement: Pointer hover does not move the keyboard cursor
+
+Hovering a row SHALL NOT write the keyboard highlight. Hover feedback SHALL come from CSS, which
+renders it identically to the keyboard highlight, so the two can point at different rows without
+looking different. Because they can differ, `Enter` SHALL commit the hovered row when the pointer is
+over one, and the highlighted row otherwise — including when no arrow key has been pressed and there
+is no highlight at all.
+
+#### Scenario: Dragging the pointer down a long list
+
+- **WHEN** the pointer crosses many rows of an option list
+- **THEN** no component state changes and no re-render is scheduled per row
+- **AND** each row still shows hover feedback
+
+#### Scenario: Pointer and keyboard disagree
+
+- **WHEN** the keyboard cursor is on one row and the pointer rests on another, and Enter is pressed
+- **THEN** the hovered row is committed
+
+#### Scenario: Enter with a pointer but no keyboard cursor
+
+- **WHEN** the user has pressed no arrow key and presses Enter while hovering a row
+- **THEN** that row is committed
+
+### Requirement: The stored highlight is clamped against the list it indexes
+
+The highlight index SHALL be clamped against the current list every time it is used, for both
+navigation and rendering. The list can shrink underneath a stored index — a search narrows it, a
+selection removes the chosen value from a picker that stays open for multi-add, and a dataset change
+replaces it wholesale — and an index past the end SHALL NOT leave `aria-activedescendant` pointing
+at an element that is no longer rendered.
+
+#### Scenario: Selecting the last entry of a multi-add picker
+
+- **WHEN** the user highlights the last value, presses Enter, and the picker stays open with that
+  value now removed from the list
+- **THEN** `aria-activedescendant` does not reference a missing element
+- **AND** the next ArrowUp moves relative to the shortened list rather than skipping a row
+
+#### Scenario: The underlying data changes while a picker is open
+
+- **WHEN** the available annotations are replaced while the picker is open and the highlight sits
+  past the end of the new list
+- **THEN** no row claims to be highlighted and Enter is not silently inert against a stale index
+
+### Requirement: The pickers are announced as listboxes
+
+Each picker SHALL expose its option list as a listbox to assistive technology: `role="listbox"` on
+the element that contains the options, `role="option"` on each entry, and `aria-activedescendant` on
+the focused search input tracking the keyboard cursor. The listbox role SHALL sit on the option
+container rather than the popover, because the popover also contains the search input and a textbox
+is not a valid listbox child. The search input SHALL carry `role="combobox"` with `aria-expanded`
+and `aria-controls`, since `aria-activedescendant` on a bare textbox is poorly announced, and SHALL
+have an accessible name. A trigger that opens a picker SHALL carry `aria-expanded` and
+`aria-haspopup="listbox"`. When nothing is highlighted, `aria-activedescendant` SHALL be absent
+rather than empty.
+
+#### Scenario: Nothing highlighted yet
+
+- **WHEN** a picker has just opened and no arrow key has been pressed
+- **THEN** the search input carries no `aria-activedescendant` attribute at all
+
+#### Scenario: Cursor moves
+
+- **WHEN** the user arrows to a row
+- **THEN** `aria-activedescendant` names that row's id
+- **AND** an element with that id exists and is the row rendered as highlighted
+
+#### Scenario: Trigger state
+
+- **WHEN** a picker is open
+- **THEN** its trigger reports `aria-expanded="true"`, and `false` once closed
+
+### Requirement: Reopening a picker starts from a clean state
+
+Opening or closing a picker SHALL reset both its search query and its highlight. A search left over
+from the previous visit silently hides most of the values the reopened picker exists to offer, with
+nothing on screen explaining why the list is short. This reset SHALL happen before the update that
+renders it, not after one has completed, so it does not schedule a second render.
+
+#### Scenario: Reopening after a search
+
+- **WHEN** a user narrows the list by typing, closes the picker, and reopens it
+- **THEN** the full list is shown again and the search box is empty
+
+#### Scenario: No redundant render on open or close
+
+- **WHEN** a picker opens or closes
+- **THEN** the reset does not trigger a second update pass or a change-in-update warning
+
+### Requirement: Composing a shared stylesheet must not reorder another component's cascade
+
+A stylesheet that is itself an array of sheets SHALL be positioned so that any sheet written to
+override the shared foundation sheets keeps its place after them. The framework deduplicates a
+flattened style array by keeping each sheet's **last** position, so nesting the foundation sheets
+inside a composed stylesheet moves them to wherever that stylesheet is listed. Where sheets collide
+at equal specificity, the ordering constraint SHALL be documented at the point that depends on it.
+
+#### Scenario: A composed sheet is added to a component that already lists the foundations
+
+- **WHEN** a component's style array contains both the foundation sheets and a composed sheet that
+  re-lists them
+- **THEN** the sheets that override the foundations still take effect
+- **AND** rules such as the control bar's container layout keep the values they had before the
+  composed sheet was introduced
+
+### Requirement: The comparison and logical-operator controls remain native selects
+
+The operator and logical-operator controls SHALL remain native `<select>` elements. They present a
+handful of options with no search, and the platform supplies keyboard support, mobile pickers and
+screen-reader semantics for free; replacing them with custom button-and-menu widgets to make the
+pixels match would mean writing code to lose that. They SHALL instead be styled to match the design
+system, with one shared indicator rule rather than a per-control copy.
+
+#### Scenario: Operating the control on a touch device
+
+- **WHEN** a user opens the comparison operator control on a mobile browser
+- **THEN** the platform's native picker appears
+
+#### Scenario: Consistent affordance
+
+- **WHEN** the operator and logical-operator controls render
+- **THEN** their dropdown indicator comes from one shared rule rather than a copy per control

--- a/packages/core/src/components/control-bar/annotation-select.ts
+++ b/packages/core/src/components/control-bar/annotation-select.ts
@@ -2,7 +2,7 @@ import { LitElement, html, type PropertyValues } from 'lit';
 import { property, state } from 'lit/decorators.js';
 import { customElement } from '../../utils/safe-custom-element';
 import { annotationSelectStyles } from './annotation-select.styles';
-import { handleDropdownEscape, scrollHighlightedIntoView } from '../../utils/dropdown-helpers';
+import { handleListboxKeydown, scrollHighlightedIntoView } from '../../utils/dropdown-helpers';
 import { groupAnnotations, type GroupedAnnotation } from './annotation-categories';
 import {
   annotationLabel,
@@ -97,42 +97,24 @@ class ProtspaceAnnotationSelect extends LitElement {
       return;
     }
 
-    const filtered = this.getFilteredGroupedAnnotations();
-    const flatAnnotations = this.flattenGroupedAnnotations(filtered);
-
-    if (event.key === 'Escape') {
-      handleDropdownEscape(event, () => {
+    handleListboxKeydown(event, {
+      // Lazy: only the arrow and Enter keys pay for re-filtering the list.
+      getValues: () => this.flattenGroupedAnnotations(this.getFilteredGroupedAnnotations()),
+      highlightIndex: this.highlightIndex,
+      setHighlightIndex: (index) => {
+        this.highlightIndex = index;
+        this.scrollToHighlighted();
+      },
+      onEscape: () => {
         this.open = false;
         this.query = '';
         this.highlightIndex = -1;
-      });
-    } else if (event.key === 'ArrowDown') {
-      event.preventDefault();
-      if (flatAnnotations.length > 0) {
-        this.highlightIndex = Math.min(this.highlightIndex + 1, flatAnnotations.length - 1);
-        this.scrollToHighlighted();
-      }
-    } else if (event.key === 'ArrowUp') {
-      event.preventDefault();
-      if (flatAnnotations.length > 0) {
-        this.highlightIndex = Math.max(this.highlightIndex - 1, 0);
-        this.scrollToHighlighted();
-      }
-    } else if (event.key === 'Enter') {
-      event.preventDefault();
-      // Hover no longer moves highlightIndex (that re-rendered every row the pointer crossed),
-      // so the row under the pointer and the keyboard highlight can differ, and both render
-      // with the same background. The browser's :hover is the source of truth for the pointer,
-      // and it must win, including when no arrow key was ever pressed (highlightIndex −1).
-      const hovered = this.shadowRoot
-        ?.querySelector('.dropdown-item:hover')
-        ?.getAttribute('data-annotation');
-      if (hovered) {
-        this.selectAnnotation(hovered, event);
-      } else if (this.highlightIndex >= 0 && this.highlightIndex < flatAnnotations.length) {
-        this.selectAnnotation(flatAnnotations[this.highlightIndex], event);
-      }
-    }
+      },
+      onSelect: (annotation) => this.selectAnnotation(annotation, event),
+      root: this.shadowRoot,
+      itemSelector: '.dropdown-item',
+      valueAttribute: 'data-annotation',
+    });
   }
 
   private scrollToHighlighted() {

--- a/packages/core/src/components/control-bar/control-bar.styles.ts
+++ b/packages/core/src/components/control-bar/control-bar.styles.ts
@@ -20,16 +20,23 @@ import { responsiveStyles } from './styles/responsive';
 
 /**
  * Export as an array of CSS style sheets.
- * Lit will automatically compose and deduplicate these styles.
+ *
+ * Order is load-bearing: several of these sheets collide at equal specificity
+ * (`layoutStyles` restyles bare `select` and re-declares `.filter-container` /
+ * `.export-container`, both of which `inputMixin` / `dropdownMixin` also own),
+ * so the later sheet wins. `queryBuilderStyles` is itself an array that re-lists
+ * the four foundation sheets, and Lit deduplicates a flattened style array by
+ * keeping each sheet's *last* position — so listing it before `iconMixin` and
+ * `layoutStyles` is what keeps those two after the mixins they override.
  */
 export const controlBarStyles = [
   tokens,
   buttonMixin,
   inputMixin,
   dropdownMixin,
+  queryBuilderStyles,
   iconMixin,
   layoutStyles,
-  queryBuilderStyles,
   exportStyles,
   responsiveStyles,
 ];

--- a/packages/core/src/components/control-bar/query-builder.styles.ts
+++ b/packages/core/src/components/control-bar/query-builder.styles.ts
@@ -288,31 +288,17 @@ export const queryBuilderStyles = [
       box-sizing: border-box;
     }
 
-    /* The search fields carry no type attribute, so inputMixin's
-       input[type='text'] selector never reaches them; this mirrors it. */
+    /* Surface, border and focus ring come from inputMixin via the type="text" the
+       markup carries. Only the layout the mixin has no opinion on stays here.
+       type="text" rather than type="search": WebKit's search input adds its own
+       clear affordance and an Escape-clears-the-field behaviour that would fight
+       handleDropdownEscape. Matches annotation-select's search input. */
     .annotation-picker-input,
     .value-picker-input {
       width: 100%;
-      padding: var(--input-padding-y) var(--input-padding-x);
-      border: var(--border-width) solid var(--border);
-      border-radius: var(--radius);
-      background: var(--surface);
       font-family: inherit;
-      font-size: var(--text-base);
-      color: var(--muted);
-      box-shadow: var(--shadow-sm);
-      transition: var(--transition);
       margin-bottom: var(--spacing-xs);
       box-sizing: border-box;
-    }
-
-    .annotation-picker-input:focus,
-    .value-picker-input:focus {
-      outline: none;
-      border-color: var(--primary);
-      box-shadow:
-        0 0 0 1px var(--primary),
-        0 0 0 3px var(--focus-ring-bg);
     }
 
     /* Shared by both pickers (the annotation picker reuses this list wrapper). */
@@ -324,41 +310,17 @@ export const queryBuilderStyles = [
       scrollbar-width: thin;
     }
 
-    /* Mirrors .dropdown-item from dropdownMixin. .highlighted is the keyboard
-       cursor and must render identically to hover. */
-    .annotation-picker-item,
-    .value-picker-item {
-      padding: var(--spacing-sm) var(--spacing-md);
-      font-size: var(--text-base);
-      color: var(--muted);
-      cursor: pointer;
-      transition: var(--transition-fast);
-      border-left: var(--border-width) solid transparent;
-    }
-
+    /* Both option lists carry .dropdown-item, so padding, colour, cursor and the
+       hover/.highlighted pair come from dropdownMixin. Only the value picker's
+       count-on-the-right layout is local. No :focus-visible rule: the options
+       carry no tabindex by design — both pickers keep DOM focus on the search
+       input and move an aria-activedescendant cursor, so .highlighted IS the
+       focus indicator. */
     .value-picker-item {
       display: flex;
       align-items: center;
       justify-content: space-between;
       gap: var(--spacing-sm);
-    }
-
-    .annotation-picker-item:hover,
-    .annotation-picker-item.highlighted,
-    .value-picker-item:hover,
-    .value-picker-item.highlighted {
-      background: var(--primary-light);
-      border-left-color: var(--primary);
-    }
-
-    .annotation-picker-item:focus-visible,
-    .value-picker-item:focus-visible {
-      outline: none;
-      background: var(--primary-light);
-      border-left-color: var(--primary);
-      box-shadow:
-        0 0 0 1px var(--primary),
-        0 0 0 3px var(--focus-ring-bg);
     }
 
     /* Locked out while the "Any value" sentinel is selected (it subsumes them). */
@@ -372,7 +334,6 @@ export const queryBuilderStyles = [
       color: var(--muted);
     }
 
-    .value-picker-item mark,
     .value-picker-highlight {
       color: var(--primary);
       font-weight: var(--font-medium);
@@ -481,27 +442,15 @@ export const queryBuilderStyles = [
       flex-wrap: wrap;
     }
 
-    /* type="number" is outside inputMixin's reach, so this mirrors it. */
+    /* type="number" is outside inputMixin's element selectors, so the markup wears
+       .input-base — the hook the mixin exposes for exactly this — and only the
+       width stays local. Widening the mixin to input[type='number'] instead would
+       restyle the number inputs in the legend, its settings dialog and the publish
+       modal, which carry their own rules; that sweep is its own change. */
     .numeric-field {
       width: 90px;
-      padding: var(--input-padding-y) var(--input-padding-x);
-      border: var(--border-width) solid var(--border);
-      border-radius: var(--radius);
-      background: var(--surface);
       font-family: inherit;
-      font-size: var(--text-base);
-      color: var(--muted);
-      box-shadow: var(--shadow-sm);
-      transition: var(--transition);
       box-sizing: border-box;
-    }
-
-    .numeric-field:focus {
-      outline: none;
-      border-color: var(--primary);
-      box-shadow:
-        0 0 0 1px var(--primary),
-        0 0 0 3px var(--focus-ring-bg);
     }
 
     .numeric-dash {

--- a/packages/core/src/components/control-bar/query-condition-row.test.ts
+++ b/packages/core/src/components/control-bar/query-condition-row.test.ts
@@ -6,7 +6,7 @@
  * materialized for the legend: it becomes kind:'categorical' but keeps
  * sourceKind:'numeric', and must still be filtered with the numeric range input.
  */
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import './query-condition-row';
 import type { FilterCondition } from './query-types';
 import { ANY_VALUE } from './query-types';
@@ -155,10 +155,22 @@ describe('query-condition-row value chips', () => {
  * whole thing is announced as a listbox.
  */
 describe('query-condition-row annotation picker accessibility', () => {
+  // jsdom has no layout engine, so scrollIntoView is assigned rather than spied on.
+  const hadScrollIntoView = 'scrollIntoView' in Element.prototype;
+  const originalScrollIntoView = Element.prototype.scrollIntoView;
+
   beforeEach(() => {
     document.body.innerHTML = '';
-    // jsdom has no layout engine, so scrollIntoView is undefined on Element.
     Element.prototype.scrollIntoView = vi.fn();
+  });
+
+  afterEach(() => {
+    // Restoring by assignment would leave an own `scrollIntoView: undefined` on
+    // Element.prototype, so `'scrollIntoView' in el` would answer true for the rest
+    // of the file. Delete it instead when jsdom never had one. Same dance as
+    // search.component.test.ts.
+    if (hadScrollIntoView) Element.prototype.scrollIntoView = originalScrollIntoView;
+    else delete (Element.prototype as Partial<Element>).scrollIntoView;
   });
 
   const trigger = (el: ConditionRowEl) =>

--- a/packages/core/src/components/control-bar/query-condition-row.ts
+++ b/packages/core/src/components/control-bar/query-condition-row.ts
@@ -5,7 +5,7 @@ import type { FilterCondition, LogicalOp, NumericCondition } from './query-types
 import { ANY_VALUE, createCondition, createNumericCondition } from './query-types';
 import type { ProtspaceData } from './types';
 import { groupAnnotations } from './annotation-categories';
-import { handleDropdownEscape } from '../../utils/dropdown-helpers';
+import { handleDropdownEscape, scrollHighlightedIntoView } from '../../utils/dropdown-helpers';
 import { isNumericAnnotation } from '@protspace/utils';
 import { queryBuilderStyles } from './query-builder.styles';
 import { renderValueChip } from './query-presence';
@@ -81,26 +81,34 @@ class ProtspaceQueryConditionRow extends LitElement {
 
   // ─── Annotation picker grouping ───────────────────────────────────────────
 
-  private _groupAnnotations() {
-    return groupAnnotations(this.annotations, this.data?.annotations).map((g) => ({
-      category: g.category,
-      items: g.annotations,
-    }));
-  }
-
-  /** The grouped annotations that survive the search box, in render order. */
-  private _filteredAnnotationGroups(): { category: string; items: string[] }[] {
+  /**
+   * The grouped annotations that survive the search box, each item already
+   * carrying its position in the flattened list.
+   *
+   * Stamping the index here rather than counting through the nested render keeps
+   * `aria-activedescendant` and `.highlighted` from depending on the template
+   * arrays being evaluated in document order exactly once — an assumption a
+   * `repeat()` or a memoized sub-render would break silently.
+   */
+  private _filteredAnnotationGroups(): {
+    category: string;
+    items: { name: string; index: number }[];
+  }[] {
     const queryLower = this._annotationSearch.trim().toLowerCase();
-    const groups = this._groupAnnotations();
-    if (!queryLower) return groups;
-    return groups
-      .map((g) => ({ ...g, items: g.items.filter((a) => a.toLowerCase().includes(queryLower)) }))
+    let flatIndex = 0;
+    return groupAnnotations(this.annotations, this.data?.annotations)
+      .map((g) => ({
+        category: g.category,
+        items: g.annotations
+          .filter((a) => !queryLower || a.toLowerCase().includes(queryLower))
+          .map((name) => ({ name, index: flatIndex++ })),
+      }))
       .filter((g) => g.items.length > 0);
   }
 
   /** Flattened filtered list — the sequence keyboard navigation walks. */
   private _flatFilteredAnnotations(): string[] {
-    return this._filteredAnnotationGroups().flatMap((g) => g.items);
+    return this._filteredAnnotationGroups().flatMap((g) => g.items.map(({ name }) => name));
   }
 
   // ─── Event handlers ───────────────────────────────────────────────────────
@@ -112,15 +120,15 @@ class ProtspaceQueryConditionRow extends LitElement {
   }
 
   private _toggleAnnotationPicker(e: Event) {
-    this._showAnnotationPicker = !this._showAnnotationPicker;
-    this._annotationHighlightIndex = -1;
     if (this._showAnnotationPicker) {
-      const btn = e.currentTarget as HTMLElement;
-      const rect = btn.getBoundingClientRect();
-      this._pickerPos = { top: rect.bottom + 4, left: rect.left };
-    } else {
-      this._annotationSearch = '';
+      this._closeAnnotationPicker();
+      return;
     }
+    this._showAnnotationPicker = true;
+    this._annotationHighlightIndex = -1;
+    const btn = e.currentTarget as HTMLElement;
+    const rect = btn.getBoundingClientRect();
+    this._pickerPos = { top: rect.bottom + 4, left: rect.left };
   }
 
   private _handleAnnotationPickerKeydown(e: KeyboardEvent) {
@@ -156,25 +164,32 @@ class ProtspaceQueryConditionRow extends LitElement {
       }
     } else if (e.key === 'Enter') {
       e.preventDefault();
-      if (this._annotationHighlightIndex >= 0 && this._annotationHighlightIndex < items.length) {
+      // Hover does not move the highlight (see _renderAnnotationPicker), so the
+      // row under the pointer and the keyboard cursor can differ and both render
+      // the same. The browser's :hover wins, matching annotation-select —
+      // including when no arrow key was ever pressed and the cursor is still -1.
+      const hovered = this.shadowRoot
+        ?.querySelector('.annotation-picker-item:hover')
+        ?.getAttribute('data-annotation');
+      if (hovered) {
+        this._selectAnnotation(hovered);
+      } else if (
+        this._annotationHighlightIndex >= 0 &&
+        this._annotationHighlightIndex < items.length
+      ) {
         this._selectAnnotation(items[this._annotationHighlightIndex]);
       }
     }
   }
 
   private _scrollToHighlighted() {
-    this.updateComplete.then(() => {
-      const highlighted = this.shadowRoot?.querySelector('.annotation-picker-item.highlighted');
-      if (highlighted) {
-        highlighted.scrollIntoView({ block: 'nearest', behavior: 'smooth' });
-      }
-    });
+    this.updateComplete.then(() =>
+      scrollHighlightedIntoView(this.shadowRoot, '.annotation-picker-item.highlighted'),
+    );
   }
 
   private _selectAnnotation(annotation: string) {
-    this._showAnnotationPicker = false;
-    this._annotationSearch = '';
-    this._annotationHighlightIndex = -1;
+    this._closeAnnotationPicker();
     this._showValuePicker = false;
     // Replace the whole condition object so its kind matches the annotation.
     const base = {
@@ -239,9 +254,6 @@ class ProtspaceQueryConditionRow extends LitElement {
 
   private _renderAnnotationPicker() {
     const filteredGroups = this._filteredAnnotationGroups();
-    // Running index over the flattened filtered list, so it lines up with
-    // `_flatFilteredAnnotations()` and therefore with `_annotationHighlightIndex`.
-    let flatIndex = 0;
 
     return html`
       <div
@@ -251,6 +263,7 @@ class ProtspaceQueryConditionRow extends LitElement {
       >
         <input
           class="annotation-picker-input"
+          type="text"
           placeholder="Search annotations..."
           aria-label="Search annotations"
           aria-controls="annotation-picker-list"
@@ -273,21 +286,20 @@ class ProtspaceQueryConditionRow extends LitElement {
           ${filteredGroups.map(
             (group) => html`
               <div class="annotation-picker-category" role="presentation">${group.category}</div>
-              ${group.items.map((ann) => {
-                const itemIndex = flatIndex++;
-                const isHighlighted = itemIndex === this._annotationHighlightIndex;
+              ${group.items.map(({ name, index }) => {
+                const isHighlighted = index === this._annotationHighlightIndex;
                 return html`
                   <div
-                    id="annotation-picker-option-${itemIndex}"
-                    class="annotation-picker-item ${isHighlighted ? 'highlighted' : ''}"
+                    id="annotation-picker-option-${index}"
+                    class="dropdown-item annotation-picker-item ${isHighlighted
+                      ? 'highlighted'
+                      : ''}"
                     role="option"
-                    aria-selected=${ann === this.condition.annotation}
-                    @click=${() => this._selectAnnotation(ann)}
-                    @mouseenter=${() => {
-                      this._annotationHighlightIndex = itemIndex;
-                    }}
+                    data-annotation=${name}
+                    aria-selected=${name === this.condition.annotation}
+                    @click=${() => this._selectAnnotation(name)}
                   >
-                    ${ann}
+                    ${name}
                   </div>
                 `;
               })}

--- a/packages/core/src/components/control-bar/query-condition-row.ts
+++ b/packages/core/src/components/control-bar/query-condition-row.ts
@@ -5,7 +5,7 @@ import type { FilterCondition, LogicalOp, NumericCondition } from './query-types
 import { ANY_VALUE, createCondition, createNumericCondition } from './query-types';
 import type { ProtspaceData } from './types';
 import { groupAnnotations } from './annotation-categories';
-import { handleDropdownEscape, scrollHighlightedIntoView } from '../../utils/dropdown-helpers';
+import { handleListboxKeydown, scrollHighlightedIntoView } from '../../utils/dropdown-helpers';
 import { isNumericAnnotation } from '@protspace/utils';
 import { queryBuilderStyles } from './query-builder.styles';
 import { renderValueChip } from './query-presence';
@@ -142,44 +142,21 @@ class ProtspaceQueryConditionRow extends LitElement {
       return;
     }
 
-    const items = this._flatFilteredAnnotations();
-
-    if (e.key === 'Escape') {
-      // Stops propagation so the surrounding modal does not also close.
-      handleDropdownEscape(e, () => this._closeAnnotationPicker());
-    } else if (e.key === 'ArrowDown') {
-      e.preventDefault();
-      if (items.length > 0) {
-        this._annotationHighlightIndex = Math.min(
-          this._annotationHighlightIndex + 1,
-          items.length - 1,
-        );
+    handleListboxKeydown(e, {
+      // Lazy: only the arrow and Enter keys pay for re-grouping the annotations.
+      getValues: () => this._flatFilteredAnnotations(),
+      highlightIndex: this._annotationHighlightIndex,
+      setHighlightIndex: (index) => {
+        this._annotationHighlightIndex = index;
         this._scrollToHighlighted();
-      }
-    } else if (e.key === 'ArrowUp') {
-      e.preventDefault();
-      if (items.length > 0) {
-        this._annotationHighlightIndex = Math.max(this._annotationHighlightIndex - 1, 0);
-        this._scrollToHighlighted();
-      }
-    } else if (e.key === 'Enter') {
-      e.preventDefault();
-      // Hover does not move the highlight (see _renderAnnotationPicker), so the
-      // row under the pointer and the keyboard cursor can differ and both render
-      // the same. The browser's :hover wins, matching annotation-select —
-      // including when no arrow key was ever pressed and the cursor is still -1.
-      const hovered = this.shadowRoot
-        ?.querySelector('.annotation-picker-item:hover')
-        ?.getAttribute('data-annotation');
-      if (hovered) {
-        this._selectAnnotation(hovered);
-      } else if (
-        this._annotationHighlightIndex >= 0 &&
-        this._annotationHighlightIndex < items.length
-      ) {
-        this._selectAnnotation(items[this._annotationHighlightIndex]);
-      }
-    }
+      },
+      // Escape stops propagation so the surrounding modal does not also close.
+      onEscape: () => this._closeAnnotationPicker(),
+      onSelect: (annotation) => this._selectAnnotation(annotation),
+      root: this.shadowRoot,
+      itemSelector: '.annotation-picker-item',
+      valueAttribute: 'data-annotation',
+    });
   }
 
   private _scrollToHighlighted() {
@@ -254,6 +231,12 @@ class ProtspaceQueryConditionRow extends LitElement {
 
   private _renderAnnotationPicker() {
     const filteredGroups = this._filteredAnnotationGroups();
+    // Clamped: the list can shrink under a parked highlight (the annotations
+    // change), and an index past the end would leave `aria-activedescendant`
+    // referencing an id that is no longer rendered.
+    const total = filteredGroups.reduce((n, g) => n + g.items.length, 0);
+    const activeIndex =
+      this._annotationHighlightIndex < total ? this._annotationHighlightIndex : -1;
 
     return html`
       <div
@@ -266,9 +249,12 @@ class ProtspaceQueryConditionRow extends LitElement {
           type="text"
           placeholder="Search annotations..."
           aria-label="Search annotations"
+          role="combobox"
+          aria-expanded="true"
+          aria-haspopup="listbox"
           aria-controls="annotation-picker-list"
-          aria-activedescendant=${this._annotationHighlightIndex >= 0
-            ? `annotation-picker-option-${this._annotationHighlightIndex}`
+          aria-activedescendant=${activeIndex >= 0
+            ? `annotation-picker-option-${activeIndex}`
             : nothing}
           .value=${this._annotationSearch}
           @input=${(e: Event) => {
@@ -287,7 +273,7 @@ class ProtspaceQueryConditionRow extends LitElement {
             (group) => html`
               <div class="annotation-picker-category" role="presentation">${group.category}</div>
               ${group.items.map(({ name, index }) => {
-                const isHighlighted = index === this._annotationHighlightIndex;
+                const isHighlighted = index === activeIndex;
                 return html`
                   <div
                     id="annotation-picker-option-${index}"

--- a/packages/core/src/components/control-bar/query-numeric-input.ts
+++ b/packages/core/src/components/control-bar/query-numeric-input.ts
@@ -200,7 +200,7 @@ class ProtspaceQueryNumericInput extends LitElement {
 
         ${fields.min
           ? html`<input
-              class="numeric-field"
+              class="numeric-field input-base"
               type="number"
               aria-label="Minimum value"
               placeholder="min"
@@ -212,7 +212,7 @@ class ProtspaceQueryNumericInput extends LitElement {
         ${fields.min && fields.max ? html`<span class="numeric-dash">–</span>` : nothing}
         ${fields.max
           ? html`<input
-              class="numeric-field"
+              class="numeric-field input-base"
               type="number"
               aria-label="Maximum value"
               placeholder="max"

--- a/packages/core/src/components/control-bar/query-value-picker.test.ts
+++ b/packages/core/src/components/control-bar/query-value-picker.test.ts
@@ -674,7 +674,10 @@ describe('query-value-picker', () => {
     it('points aria-activedescendant at the highlighted option', async () => {
       const el = await mount();
       const input = el.shadowRoot!.querySelector('.value-picker-input')!;
-      expect(input.getAttribute('aria-activedescendant')).toBe('');
+      // Absent rather than empty while nothing is highlighted: an empty
+      // aria-activedescendant is an a11y-lint finding, and it matches how the
+      // annotation picker spells the same idle state.
+      expect(input.getAttribute('aria-activedescendant')).toBeNull();
 
       const keydown = new KeyboardEvent('keydown', { key: 'ArrowDown', bubbles: true });
       input.dispatchEvent(keydown);

--- a/packages/core/src/components/control-bar/query-value-picker.ts
+++ b/packages/core/src/components/control-bar/query-value-picker.ts
@@ -9,7 +9,7 @@ import { resolveAnnotationInternalValues } from './query-evaluate';
 import { isNAValue } from '@protspace/utils';
 import { displayFilterValue } from './query-presence';
 import { queryBuilderStyles } from './query-builder.styles';
-import { handleDropdownEscape } from '../../utils/dropdown-helpers';
+import { handleDropdownEscape, scrollHighlightedIntoView } from '../../utils/dropdown-helpers';
 
 /**
  * One dataset walk's worth of tallies: the per-value counts plus the two
@@ -44,13 +44,6 @@ class ProtspaceQueryValuePicker extends LitElement {
   @state() private _searchQuery: string = '';
   /** Index into the *currently filtered* list, or -1 for "nothing highlighted". */
   @state() private _highlightIndex: number = -1;
-
-  /**
-   * The filtered values as last rendered, in render order — the list keyboard
-   * navigation walks. Captured during render so arrow keys never have to redo
-   * the (dataset-sized) count arithmetic just to know what is on screen.
-   */
-  private _navigableValues: string[] = [];
 
   @litQuery('.value-picker-input') private _inputEl?: HTMLInputElement;
 
@@ -286,7 +279,7 @@ class ProtspaceQueryValuePicker extends LitElement {
   }
 
   private _handleKeydown(e: KeyboardEvent) {
-    const values = this._navigableValues;
+    const values = this._computeValues().filteredValues;
 
     if (e.key === 'Escape') {
       // Via the shared helper so the enclosing modal does not also close.
@@ -310,18 +303,25 @@ class ProtspaceQueryValuePicker extends LitElement {
       e.preventDefault();
       // Refuses disabled items exactly as the click handler does.
       if (this._lockedByAnyValue) return;
-      if (this._highlightIndex >= 0 && this._highlightIndex < values.length) {
-        this._selectValue(values[this._highlightIndex]);
+      // Hover does not move the highlight (see render), so the row under the
+      // pointer and the keyboard cursor can differ and both render the same.
+      // The browser's :hover wins, matching annotation-select — including when
+      // no arrow key was ever pressed and the cursor is still -1.
+      const hovered = this.shadowRoot
+        ?.querySelector('.value-picker-item:hover')
+        ?.getAttribute('data-value');
+      if (hovered !== null && hovered !== undefined) {
+        this._selectValue(hovered);
+      } else if (this._highlightIndex >= 0 && this._highlightIndex < values.length) {
+        this._selectValue(values[this._highlightIndex].value);
       }
     }
   }
 
   private _scrollToHighlighted() {
-    this.updateComplete.then(() => {
-      const highlighted = this.shadowRoot?.querySelector('.value-picker-item.highlighted');
-      // Optional call: jsdom has no scrollIntoView.
-      highlighted?.scrollIntoView?.({ block: 'nearest', behavior: 'smooth' });
-    });
+    this.updateComplete.then(() =>
+      scrollHighlightedIntoView(this.shadowRoot, '.value-picker-item.highlighted'),
+    );
   }
 
   private _selectValue(value: string) {
@@ -339,32 +339,29 @@ class ProtspaceQueryValuePicker extends LitElement {
 
   render() {
     if (!this.open) {
-      this._navigableValues = [];
       return nothing;
     }
 
     const { allValues, filteredValues } = this._computeValues();
-    this._navigableValues = filteredValues.map(({ value }) => value);
     // "Any value" subsumes every other entry — OR-ing it with a real value is
     // just "any value", and OR-ing it with N/A is everything — so while it is
     // selected the rest of the list is locked out rather than silently ignored.
     const lockedByAnyValue = this._lockedByAnyValue;
-    const activeId =
-      this._highlightIndex >= 0 && this._highlightIndex < filteredValues.length
-        ? `value-picker-option-${this._highlightIndex}`
-        : '';
 
     return html`
       <div class="value-picker" style="top:${this.triggerTop}px;left:${this.triggerLeft}px">
         <input
           class="value-picker-input"
+          type="text"
           placeholder="Search values..."
           aria-label="Search values"
           role="combobox"
           aria-expanded="true"
           aria-haspopup="listbox"
           aria-controls="value-picker-list"
-          aria-activedescendant=${activeId}
+          aria-activedescendant=${this._highlightIndex >= 0
+            ? `value-picker-option-${this._highlightIndex}`
+            : nothing}
           .value=${this._searchQuery}
           @input=${this._handleSearch}
           @keydown=${this._handleKeydown}
@@ -375,17 +372,15 @@ class ProtspaceQueryValuePicker extends LitElement {
             return html`
               <div
                 id="value-picker-option-${index}"
-                class="value-picker-item ${lockedByAnyValue ? 'is-disabled' : ''} ${isHighlighted
-                  ? 'highlighted'
-                  : ''}"
+                class="dropdown-item value-picker-item ${lockedByAnyValue
+                  ? 'is-disabled'
+                  : ''} ${isHighlighted ? 'highlighted' : ''}"
                 role="option"
+                data-value=${value}
                 aria-disabled=${lockedByAnyValue ? 'true' : 'false'}
                 aria-selected=${isHighlighted ? 'true' : 'false'}
                 @click=${() => {
                   if (!lockedByAnyValue) this._selectValue(value);
-                }}
-                @mouseenter=${() => {
-                  if (!lockedByAnyValue) this._highlightIndex = index;
                 }}
               >
                 <span>${this._highlightMatch(displayFilterValue(value))}</span>

--- a/packages/core/src/components/control-bar/query-value-picker.ts
+++ b/packages/core/src/components/control-bar/query-value-picker.ts
@@ -9,7 +9,7 @@ import { resolveAnnotationInternalValues } from './query-evaluate';
 import { isNAValue } from '@protspace/utils';
 import { displayFilterValue } from './query-presence';
 import { queryBuilderStyles } from './query-builder.styles';
-import { handleDropdownEscape, scrollHighlightedIntoView } from '../../utils/dropdown-helpers';
+import { handleListboxKeydown, scrollHighlightedIntoView } from '../../utils/dropdown-helpers';
 
 /**
  * One dataset walk's worth of tallies: the per-value counts plus the two
@@ -70,6 +70,16 @@ class ProtspaceQueryValuePicker extends LitElement {
     ) {
       this._countCache = null;
     }
+    // Opening and closing both start the next visit from a clean slate: a stale
+    // highlight indexes into the previous list, and a stale search silently
+    // hides most of the values the reopened picker is supposed to offer.
+    // Reset here rather than in `updated()` — setting reactive state after an
+    // update has completed schedules a second render and trips Lit's
+    // `change-in-update` dev warning.
+    if (changed.has('open')) {
+      this._highlightIndex = -1;
+      this._searchQuery = '';
+    }
   }
 
   // ─── Click-outside detection ──────────────────────────────────────────────
@@ -93,14 +103,10 @@ class ProtspaceQueryValuePicker extends LitElement {
   // ─── Auto-focus on open ───────────────────────────────────────────────────
 
   updated(changedProperties: Map<string, unknown>) {
-    if (changedProperties.has('open')) {
-      // Opening and closing both start the next visit from a clean highlight.
-      this._highlightIndex = -1;
-      if (this.open) {
-        this.updateComplete.then(() => {
-          this._inputEl?.focus();
-        });
-      }
+    if (changedProperties.has('open') && this.open) {
+      this.updateComplete.then(() => {
+        this._inputEl?.focus();
+      });
     }
   }
 
@@ -279,43 +285,26 @@ class ProtspaceQueryValuePicker extends LitElement {
   }
 
   private _handleKeydown(e: KeyboardEvent) {
-    const values = this._computeValues().filteredValues;
-
-    if (e.key === 'Escape') {
-      // Via the shared helper so the enclosing modal does not also close.
-      handleDropdownEscape(e, () => {
-        this.dispatchEvent(new CustomEvent('picker-close', { bubbles: true, composed: true }));
-      });
-    } else if (e.key === 'ArrowDown') {
-      e.preventDefault();
-      // Nothing is selectable while the lock is on, so the highlight stays put.
-      if (values.length > 0 && !this._lockedByAnyValue) {
-        this._highlightIndex = Math.min(this._highlightIndex + 1, values.length - 1);
+    handleListboxKeydown(e, {
+      // Lazy: only the arrow and Enter keys pay for the walk over the values.
+      getValues: () => this._computeValues().filteredValues.map(({ value }) => value),
+      highlightIndex: this._highlightIndex,
+      setHighlightIndex: (index) => {
+        this._highlightIndex = index;
         this._scrollToHighlighted();
-      }
-    } else if (e.key === 'ArrowUp') {
-      e.preventDefault();
-      if (values.length > 0 && !this._lockedByAnyValue) {
-        this._highlightIndex = Math.max(this._highlightIndex - 1, 0);
-        this._scrollToHighlighted();
-      }
-    } else if (e.key === 'Enter') {
-      e.preventDefault();
-      // Refuses disabled items exactly as the click handler does.
-      if (this._lockedByAnyValue) return;
-      // Hover does not move the highlight (see render), so the row under the
-      // pointer and the keyboard cursor can differ and both render the same.
-      // The browser's :hover wins, matching annotation-select — including when
-      // no arrow key was ever pressed and the cursor is still -1.
-      const hovered = this.shadowRoot
-        ?.querySelector('.value-picker-item:hover')
-        ?.getAttribute('data-value');
-      if (hovered !== null && hovered !== undefined) {
-        this._selectValue(hovered);
-      } else if (this._highlightIndex >= 0 && this._highlightIndex < values.length) {
-        this._selectValue(values[this._highlightIndex].value);
-      }
-    }
+      },
+      // Escape goes through the shared helper so the enclosing modal does not
+      // also close.
+      onEscape: () =>
+        this.dispatchEvent(new CustomEvent('picker-close', { bubbles: true, composed: true })),
+      onSelect: (value) => this._selectValue(value),
+      root: this.shadowRoot,
+      itemSelector: '.value-picker-item',
+      valueAttribute: 'data-value',
+      // Nothing is selectable while the lock is on, so the highlight stays put
+      // and Enter refuses — exactly as the click handler does.
+      disabled: this._lockedByAnyValue,
+    });
   }
 
   private _scrollToHighlighted() {
@@ -347,6 +336,10 @@ class ProtspaceQueryValuePicker extends LitElement {
     // just "any value", and OR-ing it with N/A is everything — so while it is
     // selected the rest of the list is locked out rather than silently ignored.
     const lockedByAnyValue = this._lockedByAnyValue;
+    // Clamped: selecting a value drops it from the list, so a highlight parked
+    // on the last entry would otherwise point past the end and leave
+    // `aria-activedescendant` referencing an id that is no longer rendered.
+    const activeIndex = this._highlightIndex < filteredValues.length ? this._highlightIndex : -1;
 
     return html`
       <div class="value-picker" style="top:${this.triggerTop}px;left:${this.triggerLeft}px">
@@ -359,16 +352,14 @@ class ProtspaceQueryValuePicker extends LitElement {
           aria-expanded="true"
           aria-haspopup="listbox"
           aria-controls="value-picker-list"
-          aria-activedescendant=${this._highlightIndex >= 0
-            ? `value-picker-option-${this._highlightIndex}`
-            : nothing}
+          aria-activedescendant=${activeIndex >= 0 ? `value-picker-option-${activeIndex}` : nothing}
           .value=${this._searchQuery}
           @input=${this._handleSearch}
           @keydown=${this._handleKeydown}
         />
         <div class="value-picker-list" id="value-picker-list" role="listbox" aria-label="Values">
           ${filteredValues.map(({ value, count }, index) => {
-            const isHighlighted = index === this._highlightIndex;
+            const isHighlighted = index === activeIndex;
             return html`
               <div
                 id="value-picker-option-${index}"

--- a/packages/core/src/utils/dropdown-helpers.ts
+++ b/packages/core/src/utils/dropdown-helpers.ts
@@ -30,6 +30,89 @@ export function isAnyDropdownOpen(dropdownStates: Record<string, boolean>): bool
 }
 
 /**
+ * Everything `handleListboxKeydown` needs to drive one dropdown's option list.
+ *
+ * Module-private: callers pass an object literal to `handleListboxKeydown` and
+ * infer the type from it, so nothing imports the name — and knip fails on an
+ * exported type with no importer.
+ */
+interface ListboxKeyboardOptions {
+  /**
+   * The values the highlight walks, in render order — a thunk rather than an
+   * array so a keystroke that is neither an arrow nor Enter costs nothing.
+   */
+  getValues: () => readonly string[];
+  /** The current highlight, or -1 for "nothing highlighted". */
+  highlightIndex: number;
+  /** Store a new highlight index. */
+  setHighlightIndex: (index: number) => void;
+  /** Close the dropdown (Escape). */
+  onEscape: () => void;
+  /** Commit a value (Enter). */
+  onSelect: (value: string) => void;
+  /** Shadow root holding the option rows. */
+  root: ShadowRoot | null | undefined;
+  /** Row selector, e.g. `.value-picker-item`. */
+  itemSelector: string;
+  /** Attribute on a row carrying its value, e.g. `data-value`. */
+  valueAttribute: string;
+  /** When true every row is locked out, so arrows and Enter are inert. */
+  disabled?: boolean;
+}
+
+/**
+ * The keyboard contract shared by every searchable dropdown in the app: arrows
+ * walk the *filtered* list (clamped, never wrapping), Enter commits, Escape
+ * closes without also closing whatever surrounds the dropdown.
+ *
+ * Stated once because three components implement the same listbox — the
+ * annotation select, the query builder's annotation picker and its value picker
+ * — and a divergence between them is a bug the user feels as "the keyboard
+ * works differently over here".
+ *
+ * The stored index is clamped against the list on every use: it indexes into a
+ * list that the search box, a new selection or a data change can shrink under
+ * it, and an index past the end would otherwise leave `.highlighted` on nothing
+ * while `aria-activedescendant` pointed at an id that no longer exists.
+ *
+ * Hover does not move the highlight (mirroring it re-rendered every row the
+ * pointer crossed), so the row under the pointer and the keyboard cursor can
+ * differ and both render the same. The browser's `:hover` is the source of
+ * truth for the pointer and wins, including when no arrow key was ever pressed.
+ */
+export function handleListboxKeydown(event: KeyboardEvent, options: ListboxKeyboardOptions): void {
+  const { key } = event;
+  if (key === 'Escape') {
+    handleDropdownEscape(event, options.onEscape);
+    return;
+  }
+  if (key !== 'ArrowDown' && key !== 'ArrowUp' && key !== 'Enter') return;
+  event.preventDefault();
+  if (options.disabled) return;
+
+  const values = options.getValues();
+  // Clamp before use — see the note above.
+  const current = options.highlightIndex < values.length ? options.highlightIndex : -1;
+
+  if (key === 'ArrowDown' || key === 'ArrowUp') {
+    if (values.length === 0) return;
+    options.setHighlightIndex(
+      key === 'ArrowDown' ? Math.min(current + 1, values.length - 1) : Math.max(current - 1, 0),
+    );
+    return;
+  }
+
+  const hovered = options.root
+    ?.querySelector(`${options.itemSelector}:hover`)
+    ?.getAttribute(options.valueAttribute);
+  if (hovered !== null && hovered !== undefined) {
+    options.onSelect(hovered);
+  } else if (current >= 0) {
+    options.onSelect(values[current]);
+  }
+}
+
+/**
  * Scrolls the currently highlighted row of a scrolling dropdown into view.
  *
  * Keyboard navigation moves the highlight without scrolling anything, so past the height


### PR DESCRIPTION
Re-lands #417 after #436 reverted it from `main`, with the review it never got and the OpenSpec entry it never had.

## Why this is a new PR

#417 was merged before review. #436 backed it out (tree byte-for-byte `81ad450b`), and this branch continues from there. Reverting a merge does not un-merge a branch — git still counts `dbc64cc7` as an ancestor of `main` — so this branch merges `main` and reverts the revert; the merge commit's tree for the touched paths is verified byte-identical to the pre-merge branch.

## What #417 did

`query-builder.styles.ts` was a bare `css` block. It is adopted by four components, but only the control bar lives in a shadow root whose stylesheet already pulls in the design system. Custom properties inherit across a shadow boundary; **component classes do not** — so the row and picker components had the right colours and none of the classes, and each had grown a hand-written mirror.

The user-visible symptom: the operator `<select>` had no `:focus` rule and fell back to Chrome's UA ring, which on macOS follows the system accent — an orange border in a blue UI. `inputMixin` supplies `select:focus`; it had simply never reached it.

The two pickers were also hand-rolled clones of `<protspace-annotation-select>` that inherited its look and none of its behaviour: no arrow keys, no listbox roles, Escape the only key they answered. Both now carry the full contract.

**The `<select>`s stay native.** Three and five options, no search — the platform gives keyboard, mobile and screen-reader support for free, and a custom widget would be code written to lose it.

## What review added

**A regression #417 introduced without meaning to.** Lit's `finalizeStyles` deduplicates a flattened style array *"in reverse order to preserve the last items"* (its own comment). #417 turned `queryBuilderStyles` into an array re-listing `[tokens, buttonMixin, inputMixin, dropdownMixin]`, and `controlBarStyles` listed it **after** `iconMixin` and `layoutStyles` — moving the four foundation sheets after the very sheets written to override them. `layoutStyles` and `dropdownMixin` both declare `.filter-container, .export-container` at equal specificity, so the control bar's containers silently changed from `display: inline-flex` to `display: flex; align-items: center`. Fixed by ordering, with the constraint documented where it's depended on.

**Stopped mirroring what the design system already provides.** `scrollHighlightedIntoView` (already exported from the module both files imported from — the two hand-rolled copies had already diverged on the jsdom guard); `.dropdown-item` in place of a byte-identical local mirror; `type="text"` and `.input-base` so `inputMixin` can actually reach the inputs, retiring two of #417's own listed follow-ups.

**The listbox keyboard contract is now stated once**, in `dropdown-helpers`, and all three searchable dropdowns delegate to it — ~130 duplicated lines to ~45. That fixed real drift: a truthy hover check meant an empty-string annotation name selected the *highlighted* row instead of the hovered one.

**Hover no longer writes the keyboard cursor.** `annotation-select` had already removed exactly this, with a comment that it "re-rendered every row the pointer crossed"; the value picker's list is unvirtualized and as long as the annotation has distinct values. Enter resolves `:hover` first, so pointer users are unaffected.

**The highlight index is clamped against the list on every use.** The value picker stays open for multi-add, so selecting the last entry shrank the list under the stored index — the highlight vanished and `aria-activedescendant` pointed at an id that was no longer rendered.

Also: open/close reset moved to `willUpdate` (no more `change-in-update` warning or double render), the search query cleared on reopen, and `role="combobox"` on the annotation picker's input.

## OpenSpec

Two changes, both archived so `openspec/specs/` is true:

- `filter-query-semantics` — the debt #416 left: the redefined `NOT`, presence sentinels, inclusive operators, the EAT reliability filter. (Was #435, folded in here.)
- `query-builder-controls` — this branch's own: the focus indicator, the listbox keyboard and ARIA contract, hover not driving the cursor, the clamped highlight, and the `controlBarStyles` ordering constraint.

Findings deliberately left unfixed are recorded as Non-Goals / Open Questions rather than requirements — focus restoration on close (WCAG 2.4.3), APG `role="group"` category wrappers, repositioning the fixed popovers on scroll, and the `logicalOp`-blind numeric preview.

## Verification

- **1628** core / **371** utils / **165** app — `pnpm test:ci --force`
- `type-check`, `knip`, `lint` (0 errors), `format:check` clean
- `openspec validate --all --strict` — 17 passed, 0 failed
- **E2E Playwright: success** ([run](https://github.com/tsenoner/protspace/actions/runs/31523203691)) — dispatched explicitly, since with #417 merged this branch got no PR CI at all. For a restyle this is the assertion that matters: it proves the class changes didn't break click targets. Both option lists keep their original class alongside `.dropdown-item`, so every selector still resolves.

**Merge, do not squash.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HGVhbzHK79uUDaJPhTDu9c
