### PR TITLE
docs(protspace): correct the ESM-C licensing note in the agent doc

### DIFF
--- a/apps/protspace/CLAUDE.md
+++ b/apps/protspace/CLAUDE.md
@@ -106,10 +106,12 @@ protspace bundle -p project_dir -a annotations.parquet -s statistics.parquet --s
 | `ankh_base` | ElnaggarLab/ankh-base | 768 | CC-BY-NC-SA-4.0 |
 | `ankh_large` | ElnaggarLab/ankh-large | 1536 | CC-BY-NC-SA-4.0 |
 | `ankh3_large` | ElnaggarLab/ankh3-large | 1536 | CC-BY-NC-SA-4.0 |
-| `esmc_300m` | Synthyra/ESMplusplus_small | 960 | Cambrian Open |
-| `esmc_600m` | Synthyra/ESMplusplus_large | 1152 | Cambrian Non-Commercial |
+| `esmc_300m` | Synthyra/ESMplusplus_small | 960 | MIT |
+| `esmc_600m` | Synthyra/ESMplusplus_large | 1152 | MIT |
 
-Ankh models, ankh3_large, and esmc_600m are non-commercial only. ESMC models use Synthyra's HuggingFace-compatible reimplementation of EvolutionaryScale's ESM-C (near-identical embeddings, MSE ~7.74e-10).
+Only the Ankh models (`ankh_base`, `ankh_large`, `ankh3_large`) are non-commercial. ESM-C was relicensed under MIT in May 2026, retroactively, when it moved to the Chan Zuckerberg Biohub — it is no longer Cambrian Non-Commercial, so do not re-add that warning. ESMC models use Synthyra's HuggingFace-compatible reimplementation of EvolutionaryScale's ESM-C (near-identical embeddings, MSE ~7.74e-10).
+
+The user-facing copy of this licensing note lives in `docs/guide/python-cli.md` and the `prepare`/`embed` CLI help; keep the three in step.
 
 Model shortcuts are defined in `MODEL_SHORT_KEYS` (CommonEmbedder models) and `EXTRA_SHORT_KEYS` (additional HuggingFace models) in `src/protspace/data/embedding/biocentral.py`. Display names are in `src/protspace/data/loaders/embedding_set.py`.
 


### PR DESCRIPTION
Follow-up to #390, which corrected the stale ESM-C licensing claim in the `prepare`/`embed` CLI help and `docs/guide/python-cli.md` but missed a fourth copy in `apps/protspace/CLAUDE.md`.

## What was wrong

The embedder table listed `esmc_300m` as "Cambrian Open" and `esmc_600m` as "Cambrian Non-Commercial". ESM-C was relicensed under **MIT in May 2026, retroactively**, when it moved to the Chan Zuckerberg Biohub. Only the Ankh models remain non-commercial.

## Why it was missed

Worth recording, because it will bite again. The sandboxed `grep` in this environment is a shell function wrapping `ugrep` with `--ignore-files`. Run from the repo root it skipped this file, while still returning *other* files under `apps/protspace/` — so the sweep looked complete. `command grep -rn` and `git grep` both find it.

**Use `git grep` for exhaustive sweeps in this repo.**

## Note on scope

`apps/protspace/docs/superpowers/specs/2026-04-30-toxprot-demo-regeneration-design.md` still contains the old claim and is deliberately left alone — it is a dated design record from before the relicense, so editing it would falsify the historical record.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SpfFuds7VayF5JkQHrt3mX