### PR TITLE
feat(prep): hold the retention config to the published privacy bound

### DIFF
--- a/apps/prep/src/protspace_prep/config.py
+++ b/apps/prep/src/protspace_prep/config.py
@@ -10,6 +10,7 @@ class Settings:
     job_root: Path
     max_concurrent_jobs: int
     max_pending_jobs: int
+    # Retention. See `retention_worst_case_seconds` and the bound below.
     bundle_ttl_seconds: int
     upload_max_bytes: int
     sequence_max_count: int
@@ -26,13 +27,44 @@ class Settings:
     cors_allowed_origins: tuple[str, ...]
     rate_limit: str
 
+    @property
+    def retention_worst_case_seconds(self) -> int:
+        """Longest an upload and its bundle can exist on disk, measured from upload.
+
+        Three settings stack up. A job is deleted once its directory is older
+        than the TTL, but the sweeper only runs every `sweep_interval_seconds`,
+        so becoming eligible is not the same as being removed. And the
+        directory's mtime tracks the last pipeline write rather than the
+        upload, so the clock effectively starts up to a full
+        `pipeline_timeout_seconds` late.
+        """
+        return (
+            self.pipeline_timeout_seconds
+            + self.bundle_ttl_seconds
+            + self.sweep_interval_seconds
+        )
+
+
+# The retention bound published to users, in `apps/web/src/pages/Privacy.tsx`
+# ("Your Data": deleted "in any case within two hours").
+#
+# This is a promise, not a readout: the page states a figure a human chose, and
+# this constant is what holds the configuration to it. `load_settings` refuses
+# to start the service when the configured worst case exceeds it, so a TTL
+# raised here or via PREP_* in deploy-protspace-backend cannot silently make a
+# published privacy commitment false. Going under it is fine — the page is then
+# merely conservative.
+#
+# To change the promise, edit the page and this constant together.
+PUBLISHED_RETENTION_BOUND_SECONDS = 7200
+
 
 def _parse_origins(raw: str) -> tuple[str, ...]:
     return tuple(o.strip() for o in raw.split(",") if o.strip())
 
 
 def load_settings() -> Settings:
-    return Settings(
+    settings = Settings(
         job_root=Path(os.getenv("PREP_JOB_ROOT", "/var/lib/protspace-prep/jobs")),
         max_concurrent_jobs=int(os.getenv("PREP_MAX_CONCURRENT_JOBS", "5")),
         max_pending_jobs=int(os.getenv("PREP_MAX_PENDING_JOBS", "50")),
@@ -56,3 +88,21 @@ def load_settings() -> Settings:
         cors_allowed_origins=_parse_origins(os.getenv("CORS_ALLOWED_ORIGIN", "")),
         rate_limit=(os.getenv("PREP_RATE_LIMIT", "").strip() or "5/15minutes"),
     )
+
+    # Fail fast rather than serve while contradicting the published policy: a
+    # service that is down is a visible problem someone fixes, whereas one that
+    # quietly retains uploads for longer than users were told is not.
+    worst_case = settings.retention_worst_case_seconds
+    if worst_case > PUBLISHED_RETENTION_BOUND_SECONDS:
+        raise ValueError(
+            f"Retention worst case is {worst_case}s "
+            f"(PREP_PIPELINE_TIMEOUT_SECONDS={settings.pipeline_timeout_seconds} "
+            f"+ PREP_BUNDLE_TTL_SECONDS={settings.bundle_ttl_seconds} "
+            f"+ PREP_SWEEP_INTERVAL_SECONDS={settings.sweep_interval_seconds}), "
+            f"which exceeds the {PUBLISHED_RETENTION_BOUND_SECONDS}s bound "
+            "published in apps/web/src/pages/Privacy.tsx. Lower one of those "
+            "settings, or change the published promise and "
+            "PUBLISHED_RETENTION_BOUND_SECONDS together."
+        )
+
+    return settings

--- a/apps/prep/tests/test_config.py
+++ b/apps/prep/tests/test_config.py
@@ -1,4 +1,9 @@
-from protspace_prep.config import load_settings
+import pytest
+
+from protspace_prep.config import (
+    PUBLISHED_RETENTION_BOUND_SECONDS,
+    load_settings,
+)
 
 
 def test_cors_origins_parsed_from_env(monkeypatch):
@@ -32,3 +37,52 @@ def test_cors_origins_trailing_comma(monkeypatch):
 def test_rate_limit_blank_falls_back_to_default(monkeypatch):
     monkeypatch.setenv("PREP_RATE_LIMIT", "   ")
     assert load_settings().rate_limit == "5/15minutes"
+
+
+def test_retention_worst_case_sums_the_three_contributing_settings(monkeypatch):
+    monkeypatch.setenv("PREP_PIPELINE_TIMEOUT_SECONDS", "100")
+    monkeypatch.setenv("PREP_BUNDLE_TTL_SECONDS", "200")
+    monkeypatch.setenv("PREP_SWEEP_INTERVAL_SECONDS", "30")
+    assert load_settings().retention_worst_case_seconds == 330
+
+
+def test_shipped_defaults_stay_within_the_published_retention_bound(monkeypatch):
+    for name in (
+        "PREP_PIPELINE_TIMEOUT_SECONDS",
+        "PREP_BUNDLE_TTL_SECONDS",
+        "PREP_SWEEP_INTERVAL_SECONDS",
+    ):
+        monkeypatch.delenv(name, raising=False)
+    assert (
+        load_settings().retention_worst_case_seconds
+        <= PUBLISHED_RETENTION_BOUND_SECONDS
+    )
+
+
+def test_ttl_beyond_the_published_bound_refuses_to_start(monkeypatch):
+    # The failure mode this guards: someone raises the TTL for an unrelated
+    # reason and silently makes the published privacy page a false statement.
+    monkeypatch.setenv(
+        "PREP_BUNDLE_TTL_SECONDS", str(PUBLISHED_RETENTION_BOUND_SECONDS)
+    )
+    with pytest.raises(ValueError, match="exceeds"):
+        load_settings()
+
+
+def test_violation_message_names_the_page_and_the_settings(monkeypatch):
+    monkeypatch.setenv("PREP_BUNDLE_TTL_SECONDS", "999999")
+    with pytest.raises(ValueError) as excinfo:
+        load_settings()
+    message = str(excinfo.value)
+    assert "Privacy.tsx" in message
+    assert "PREP_BUNDLE_TTL_SECONDS=999999" in message
+
+
+def test_bound_is_not_breached_by_the_other_two_settings(monkeypatch):
+    # The TTL is the obvious dial, but the sweep interval and pipeline timeout
+    # count toward the same promise and must be guarded too.
+    monkeypatch.setenv(
+        "PREP_SWEEP_INTERVAL_SECONDS", str(PUBLISHED_RETENTION_BOUND_SECONDS)
+    )
+    with pytest.raises(ValueError, match="exceeds"):
+        load_settings()


### PR DESCRIPTION
Supersedes the comment-only approach this branch started with. Answers "can we make the privacy page and the configured value always in sync?"

## Why not derive the page from the config

- **A privacy policy is a commitment, not a readout.** If someone raises the TTL to a day, a human should decide to tell users that — not have the page quietly begin claiming it.
- **The fallback reintroduces drift.** The page must state a period even when a fetch fails (service down, CORS, offline). That fallback is a hardcoded number.
- **Build-time injection would be wrong anyway.** The authoritative value is `PREP_BUNDLE_TTL_SECONDS` in `deploy-protspace-backend`, applied at container start — a build-time constant captures the default, not the deployed value.

## What this does instead

Inverts the dependency: the configuration is held to the promise.

`PUBLISHED_RETENTION_BOUND_SECONDS` records what the page says, and `load_settings` refuses to start when the configured worst case exceeds it.

**The check runs at startup against the real environment**, which is what makes it worth more than a comment — it is the only place that sees the values `deploy-protspace-backend` actually sets. No static check or CI lint in this repo can reach those.

Failing fast is deliberate: a service that will not boot is a visible problem someone fixes; one that quietly retains uploads longer than users were told is not. Going *under* the bound stays fine — the page is then merely conservative.

## Why the bound is a sum

`retention_worst_case_seconds` documents this:

| Setting | Default | Contribution |
| --- | --- | --- |
| `pipeline_timeout_seconds` | 420 | the job dir's mtime tracks the last pipeline write, not the upload |
| `bundle_ttl_seconds` | 3600 | the age at which a job becomes eligible |
| `sweep_interval_seconds` | 300 | the sweeper runs periodically, so eligible ≠ deleted |

~72 min worst case, against a published bound of two hours.

## Tests

Five new cases in `test_config.py`, covering the sum, that shipped defaults stay within the bound, that an over-bound TTL refuses to start, that the message names the page and the offending setting, and that the *other two* settings are guarded too — not just the obvious TTL dial.

Full `apps/prep` suite passes (86 tests).

> **Note:** running `uv run pytest` from the repo root shows 47 failures in `apps/prep` — **pre-existing and unrelated**, confirmed identical with these changes stashed. The suite is designed to run from `apps/prep` (`testpaths = ["tests"]`), which is what `prep-ci.yml` does via `working-directory`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SpfFuds7VayF5JkQHrt3mX