### PR TITLE
fix(stats): the faithfulness hard ceiling suppressed results no more expensive than the ones it returned

### DIFF
--- a/apps/protspace/src/protspace/stats/metrics/faithfulness.py
+++ b/apps/protspace/src/protspace/stats/metrics/faithfulness.py
@@ -38,7 +38,14 @@ from protspace.stats._sampling import id_seed, sorted_subsample
 from protspace.stats.base import DEFAULT_SAMPLE_THRESHOLD, StatContext, StatRow
 
 DEFAULT_K = 15
-DEFAULT_HARD_CEILING = 20000
+# No size ceiling by default. Every metric below runs on the deterministic
+# ``DEFAULT_SAMPLE_THRESHOLD`` subsample, so the O(n^2) work is bounded by the
+# SUBSAMPLE size and not by n -- a dataset of 573k rows and one of 20k rows are
+# both scored on 5,000 points and cost the same. The previous default of 20000
+# gated the bounded work on the unbounded number, which only ever suppressed
+# results that were cheap to produce. Set ``hard_ceiling`` explicitly to restore
+# a bail-out; ``None`` means "no ceiling".
+DEFAULT_HARD_CEILING = None
 DEFAULT_N_TRIPLETS_PER_POINT = 5
 
 
@@ -200,7 +207,8 @@ class FaithfulnessStatistic:
         if n < 3:
             return []
 
-        hard_ceiling = int(ctx.params.get("hard_ceiling", DEFAULT_HARD_CEILING))
+        ceiling_param = ctx.params.get("hard_ceiling", DEFAULT_HARD_CEILING)
+        hard_ceiling = None if ceiling_param is None else int(ceiling_param)
         base = {
             "space_kind": ctx.space_kind,
             "space_name": ctx.space_name,
@@ -213,9 +221,10 @@ class FaithfulnessStatistic:
             "destination": "projection_metadata",
         }
 
-        # Bail before the canonical sort/copy below: past the ceiling every metric
-        # is skipped anyway, so sorting and copying emb/coords would be pure waste.
-        if n > hard_ceiling:
+        # An explicit ceiling still bails before any copy. It is opt-in now
+        # (DEFAULT_HARD_CEILING is None) because the subsample below already bounds
+        # every metric's cost independently of n.
+        if hard_ceiling is not None and n > hard_ceiling:
             return [
                 StatRow(
                     metric="knn_overlap",
@@ -230,15 +239,15 @@ class FaithfulnessStatistic:
                 )
             ]
 
-        # Past the guards: upcast to float64 (now bounded by hard_ceiling rows) and
-        # resolve the embedding-aligned projection coords + ids.
-        emb = np.asarray(emb_raw, dtype=float)
-        # Use the projection coordinates ALIGNED to the embedding (id-intersection
+        # Resolve the embedding-aligned projection coords + ids, WITHOUT upcasting:
+        # the subsample below decides which rows are actually needed, and a full
+        # float64 copy of a 570k x 1024 embedding is ~4.7 GB spent to discard 99%
+        # of it. Use the coordinates ALIGNED to the embedding (id-intersection
         # join), falling back to full coords only when no aligned view was built.
         coords_src = (
             ctx.embedding_coords if ctx.embedding_coords is not None else ctx.coords
         )
-        coords = np.asarray(coords_src, dtype=float)
+        coords_raw = np.asarray(coords_src)
         ids = ctx.embedding_ids if ctx.embedding_ids is not None else ctx.ids
 
         # Canonicalise row order by id up front so EVERY metric depends only on the
@@ -247,8 +256,6 @@ class FaithfulnessStatistic:
         # sorting here (matching the id-derived subsample seed) makes random_triplet
         # reproducible across differently-ordered inputs too.
         canonical = np.argsort(np.asarray(ids), kind="stable")
-        emb = emb[canonical]
-        coords = coords[canonical]
         ids = [ids[int(i)] for i in canonical]
 
         k = int(ctx.params.get("k", DEFAULT_K))
@@ -258,15 +265,23 @@ class FaithfulnessStatistic:
         hi_metric = ctx.high_dim_metric or "euclidean"
 
         sampled = False
-        # Rows are already in canonical id order, so a positional draw is itself
-        # id-canonical and thus row-order invariant.
+        # Seeded from the FULL canonical id list, exactly as before, so the drawn
+        # subsample — and therefore every number this function returns — is
+        # unchanged by the reordering above.
         rng = np.random.default_rng(id_seed(ctx.rng_seed, ids))
         idx = sorted_subsample(n, sample_threshold, rng)
         if idx is not None:
-            emb = emb[idx]
-            coords = coords[idx]
+            # Gather straight from the source rows in one pass: canonical[idx] maps
+            # canonical positions back to original row positions, so this is the
+            # same rows the old emb[canonical][idx] produced.
+            take = canonical[idx]
             n = len(idx)
             sampled = True
+        else:
+            take = canonical
+
+        emb = np.asarray(emb_raw[take], dtype=float)
+        coords = np.asarray(coords_raw[take], dtype=float)
 
         # sklearn.manifold.trustworthiness requires n_neighbors < n / 2 (strict),
         # else it raises. Clamp accordingly so trustworthiness/continuity are not


### PR DESCRIPTION
## The ceiling was protecting nothing

`DEFAULT_HARD_CEILING = 20000` refused to compute faithfulness for any dataset above 20,000 points.

The bail at `faithfulness.py:218` sits **46 lines before** `sorted_subsample(n, sample_threshold, rng)` at line 264, which caps the scored set at `DEFAULT_SAMPLE_THRESHOLD = 5000` regardless of `n`. Every dataset above 5,000 points is therefore scored on exactly 5,000 points, and the O(n²) neighbourhood work is bounded by the **subsample**, not by `n`.

A 573,649-point dataset and a 20,000-point one cost the same to score. The ceiling only ever decided whether that identical, bounded work happened at all.

Measured with the ceiling lifted: **exact** (not approximate) neighbourhood computation at n = 113,015 and n = 573,606, in **17 s of metric time** each, bitwise deterministic across processes, `sample_size: 5000` in every run.

## Two changes

1. **`DEFAULT_HARD_CEILING` is now `None`.** An explicit `hard_ceiling` param still bails exactly as before, so the behaviour is opt-in rather than removed.

2. **The subsample now runs before the float64 upcast.** The old order allocated a full-`n` float64 copy of the embedding *and* the coords, then discarded 99% of it — measured at **+16.68 GB transient** on a 573k × 1024 input against **0.041 GB** of data actually scored. Gathering `emb_raw[canonical[idx]]` in one pass makes the allocation O(subsample · d).

## Determinism is preserved by construction

The RNG is still seeded from `id_seed(ctx.rng_seed, ids)` over the **full** canonical id list, and `canonical[idx]` selects the same rows the previous `emb[canonical][idx]` did. `ids` is not read after the subsample, so the reordering is safe.

## Why it matters beyond one constant

The ProtSpace manuscript had promoted this default to a **stated limitation of the method**, in four places, including:

> lifting that ceiling requires approximate neighborhood computation

That is false, and it is refuted by the first half of its own sentence — which notes the metric already runs on a 5,000-point subsample from 5,000 to 20,000. The cost above 20,000 is identical.

`git log -S DEFAULT_HARD_CEILING --all` returns exactly one authoring commit, `a627a18d`, whose entire justification is the parenthetical *"large-n sampling guard"*. It was never tuned or revisited.

## There is a real wall, but not here

Exact-path memory scales as ~24·m², giving 0.6 GB at m = 5,000, 9.6 GB at 20,000 and ~60 GB at 50,000. That wall is on `DEFAULT_SAMPLE_THRESHOLD`, and the code never approaches it.

## Follow-up not addressed here

`hard_ceiling` has no CLI flag — `stats.py:317` hard-codes `params`, so an explicit ceiling is only settable programmatically. That is now the less common case, but worth a flag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MvGHi1QKs9TGYEd3pNzdJH
